### PR TITLE
Add pickup and place manipulation primitives

### DIFF
--- a/src/mj_manipulator/__init__.py
+++ b/src/mj_manipulator/__init__.py
@@ -45,6 +45,7 @@ from mj_manipulator.executor import KinematicExecutor, PhysicsExecutor
 from mj_manipulator.grasp_manager import GraspManager, detect_grasped_object
 from mj_manipulator.grippers import FrankaGripper, RobotiqGripper
 from mj_manipulator.physics_controller import ArmPhysicsExecutor, PhysicsController
+from mj_manipulator.primitives import pickup, place
 from mj_manipulator.sim_context import SimArmController, SimContext
 from mj_manipulator.trajectory import Trajectory, create_linear_trajectory
 
@@ -78,6 +79,9 @@ __all__ = [
     # Physics controller (simulation)
     "PhysicsController",
     "ArmPhysicsExecutor",
+    # Primitives
+    "pickup",
+    "place",
     # Simulation context
     "SimContext",
     "SimArmController",

--- a/src/mj_manipulator/primitives.py
+++ b/src/mj_manipulator/primitives.py
@@ -1,0 +1,156 @@
+"""High-level manipulation primitives.
+
+Simple reference implementations of pickup and place that compose
+the lower-level planning, execution, and grasping APIs. These work
+with any arm, gripper, and execution context (sim or hardware).
+
+For more complex strategies (multi-arm fallback, base repositioning,
+contact-based approach), build custom logic using the same APIs.
+
+Usage::
+
+    from tsr import load_package_template
+
+    template = load_package_template("grasps", "mug_handle_grasp.yaml")
+    grasp_tsrs = [template.instantiate(mug_pose)]
+
+    success = pickup(ctx, arm, "mug", grasp_tsrs)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from mj_manipulator.arm import Arm
+    from mj_manipulator.protocols import ExecutionContext
+
+logger = logging.getLogger(__name__)
+
+
+def pickup(
+    ctx: ExecutionContext,
+    arm: Arm,
+    object_name: str,
+    grasp_tsrs: list,
+    *,
+    constraint_tsrs: list | None = None,
+    lift_height: float = 0.05,
+    timeout: float = 30.0,
+) -> bool:
+    """Pick up an object using TSR-defined grasps.
+
+    Plans a path to the grasp region, executes the approach trajectory,
+    closes the gripper, and lifts the object.
+
+    Args:
+        ctx: Execution context (sim or hardware).
+        arm: Arm to use for grasping.
+        object_name: Name of the object to grasp.
+        grasp_tsrs: TSR goals defining valid grasp poses.
+        constraint_tsrs: Optional path constraints (e.g., keep upright).
+        lift_height: Height to lift after grasping (meters).
+        timeout: Planning timeout in seconds.
+
+    Returns:
+        True if the object was successfully grasped.
+    """
+    # 1. Plan approach to grasp region
+    path = arm.plan_to_tsrs(
+        grasp_tsrs,
+        constraint_tsrs=constraint_tsrs,
+        timeout=timeout,
+    )
+    if path is None:
+        logger.warning("pickup: planning failed for '%s'", object_name)
+        return False
+
+    # 2. Execute approach trajectory
+    traj = arm.retime(path)
+    if not ctx.execute(traj):
+        logger.warning("pickup: execution failed for '%s'", object_name)
+        return False
+
+    # 3. Grasp
+    arm_name = arm.config.name
+    grasped = ctx.arm(arm_name).grasp(object_name)
+    if not grasped:
+        logger.warning("pickup: grasp failed for '%s'", object_name)
+        return False
+
+    # 4. Lift (best-effort — grasp already succeeded)
+    if lift_height > 0:
+        _lift(ctx, arm, lift_height)
+
+    return True
+
+
+def place(
+    ctx: ExecutionContext,
+    arm: Arm,
+    place_tsrs: list,
+    *,
+    object_name: str | None = None,
+    constraint_tsrs: list | None = None,
+    retract_height: float = 0.05,
+    timeout: float = 30.0,
+) -> bool:
+    """Place a held object at a TSR-defined destination.
+
+    Plans a path to the placement region, executes the trajectory,
+    releases the object, and retracts upward.
+
+    Args:
+        ctx: Execution context (sim or hardware).
+        arm: Arm holding the object.
+        place_tsrs: TSR goals defining valid placement poses.
+        object_name: Object to release (None releases whatever is held).
+        constraint_tsrs: Optional path constraints (e.g., keep upright).
+        retract_height: Height to retract after releasing (meters).
+        timeout: Planning timeout in seconds.
+
+    Returns:
+        True if placement succeeded.
+    """
+    # 1. Plan approach to placement region
+    path = arm.plan_to_tsrs(
+        place_tsrs,
+        constraint_tsrs=constraint_tsrs,
+        timeout=timeout,
+    )
+    if path is None:
+        logger.warning("place: planning failed")
+        return False
+
+    # 2. Execute placement trajectory
+    traj = arm.retime(path)
+    if not ctx.execute(traj):
+        logger.warning("place: execution failed")
+        return False
+
+    # 3. Release
+    arm_name = arm.config.name
+    ctx.arm(arm_name).release(object_name)
+
+    # 4. Retract (best-effort — release already succeeded)
+    if retract_height > 0:
+        _lift(ctx, arm, retract_height)
+
+    return True
+
+
+def _lift(ctx: ExecutionContext, arm: Arm, height: float) -> bool:
+    """Lift end-effector by *height* meters in world Z. Best-effort."""
+    ee_pose = arm.get_ee_pose()
+    lift_pose = ee_pose.copy()
+    lift_pose[2, 3] += height
+
+    lift_path = arm.plan_to_pose(lift_pose, timeout=5.0)
+    if lift_path is None:
+        logger.info("_lift: planning failed, skipping")
+        return False
+
+    return ctx.execute(arm.retime(lift_path))

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -1,0 +1,286 @@
+"""Tests for manipulation primitives (pickup, place).
+
+Uses mocks to test orchestration logic without MuJoCo or real planning.
+"""
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from mj_manipulator.primitives import pickup, place
+from mj_manipulator.trajectory import Trajectory
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers
+# ---------------------------------------------------------------------------
+
+
+_UNSET = object()
+
+
+@dataclass
+class _MockConfig:
+    name: str
+
+
+def _make_trajectory() -> Trajectory:
+    """Minimal 2-waypoint trajectory for mock returns."""
+    return Trajectory(
+        timestamps=np.array([0.0, 1.0]),
+        positions=np.zeros((2, 2)),
+        velocities=np.zeros((2, 2)),
+        accelerations=np.zeros((2, 2)),
+        joint_names=["j1", "j2"],
+        entity="test_arm",
+    )
+
+
+def _make_arm(
+    *,
+    plan_tsrs_result=_UNSET,
+    plan_pose_result=_UNSET,
+) -> MagicMock:
+    """Create a mock Arm with configurable planning results."""
+    arm = MagicMock()
+    arm.config = _MockConfig(name="test_arm")
+
+    # Default: return a geometric path (list of arrays)
+    if plan_tsrs_result is _UNSET:
+        plan_tsrs_result = [np.zeros(2), np.ones(2)]
+    arm.plan_to_tsrs.return_value = plan_tsrs_result
+
+    if plan_pose_result is _UNSET:
+        plan_pose_result = [np.zeros(2), np.ones(2)]
+    arm.plan_to_pose.return_value = plan_pose_result
+
+    arm.retime.return_value = _make_trajectory()
+    arm.get_ee_pose.return_value = np.eye(4)
+
+    return arm
+
+
+def _make_context(*, execute_ok: bool = True, grasp_result="mug") -> MagicMock:
+    """Create a mock ExecutionContext."""
+    ctx = MagicMock()
+    ctx.execute.return_value = execute_ok
+
+    arm_ctrl = MagicMock()
+    arm_ctrl.grasp.return_value = grasp_result
+    ctx.arm.return_value = arm_ctrl
+
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# pickup tests
+# ---------------------------------------------------------------------------
+
+
+class TestPickup:
+    """Tests for the pickup primitive."""
+
+    def test_success(self):
+        arm = _make_arm()
+        ctx = _make_context(grasp_result="mug")
+        tsrs = [MagicMock()]
+
+        result = pickup(ctx, arm, "mug", tsrs)
+
+        assert result is True
+        arm.plan_to_tsrs.assert_called_once_with(
+            tsrs, constraint_tsrs=None, timeout=30.0,
+        )
+        ctx.arm("test_arm").grasp.assert_called_once_with("mug")
+
+    def test_planning_fails(self):
+        arm = _make_arm(plan_tsrs_result=None)
+        ctx = _make_context()
+        tsrs = [MagicMock()]
+
+        result = pickup(ctx, arm, "mug", tsrs)
+
+        assert result is False
+        ctx.execute.assert_not_called()
+
+    def test_execution_fails(self):
+        arm = _make_arm()
+        ctx = _make_context(execute_ok=False)
+        tsrs = [MagicMock()]
+
+        result = pickup(ctx, arm, "mug", tsrs)
+
+        assert result is False
+        # grasp should not be attempted after execution failure
+        ctx.arm("test_arm").grasp.assert_not_called()
+
+    def test_grasp_fails(self):
+        arm = _make_arm()
+        ctx = _make_context(grasp_result=None)
+        tsrs = [MagicMock()]
+
+        result = pickup(ctx, arm, "mug", tsrs)
+
+        assert result is False
+
+    def test_lift_planning_fails_still_succeeds(self):
+        """Grasp succeeded but lift planning fails — should still return True."""
+        arm = _make_arm(plan_pose_result=None)
+        ctx = _make_context(grasp_result="mug")
+        tsrs = [MagicMock()]
+
+        result = pickup(ctx, arm, "mug", tsrs)
+
+        assert result is True
+
+    def test_constraint_tsrs_passed_through(self):
+        arm = _make_arm()
+        ctx = _make_context(grasp_result="mug")
+        goal_tsrs = [MagicMock()]
+        constraint = [MagicMock()]
+
+        pickup(ctx, arm, "mug", goal_tsrs, constraint_tsrs=constraint)
+
+        arm.plan_to_tsrs.assert_called_once_with(
+            goal_tsrs, constraint_tsrs=constraint, timeout=30.0,
+        )
+
+    def test_custom_timeout(self):
+        arm = _make_arm()
+        ctx = _make_context(grasp_result="mug")
+        tsrs = [MagicMock()]
+
+        pickup(ctx, arm, "mug", tsrs, timeout=60.0)
+
+        arm.plan_to_tsrs.assert_called_once_with(
+            tsrs, constraint_tsrs=None, timeout=60.0,
+        )
+
+    def test_no_lift_when_zero_height(self):
+        arm = _make_arm()
+        ctx = _make_context(grasp_result="mug")
+        tsrs = [MagicMock()]
+
+        pickup(ctx, arm, "mug", tsrs, lift_height=0.0)
+
+        # plan_to_pose should not be called (no lift)
+        arm.plan_to_pose.assert_not_called()
+
+    def test_lift_pose_is_above_current(self):
+        """Lift target should be current EE pose + lift_height in Z."""
+        ee_pose = np.eye(4)
+        ee_pose[:3, 3] = [0.5, 0.1, 0.3]
+
+        arm = _make_arm()
+        arm.get_ee_pose.return_value = ee_pose
+        ctx = _make_context(grasp_result="mug")
+        tsrs = [MagicMock()]
+
+        pickup(ctx, arm, "mug", tsrs, lift_height=0.10)
+
+        call_args = arm.plan_to_pose.call_args
+        target_pose = call_args[0][0]
+        assert target_pose[2, 3] == pytest.approx(0.4)  # 0.3 + 0.10
+        assert target_pose[0, 3] == pytest.approx(0.5)  # X unchanged
+        assert target_pose[1, 3] == pytest.approx(0.1)  # Y unchanged
+
+
+# ---------------------------------------------------------------------------
+# place tests
+# ---------------------------------------------------------------------------
+
+
+class TestPlace:
+    """Tests for the place primitive."""
+
+    def test_success(self):
+        arm = _make_arm()
+        ctx = _make_context()
+        tsrs = [MagicMock()]
+
+        result = place(ctx, arm, tsrs, object_name="mug")
+
+        assert result is True
+        arm.plan_to_tsrs.assert_called_once_with(
+            tsrs, constraint_tsrs=None, timeout=30.0,
+        )
+        ctx.arm("test_arm").release.assert_called_once_with("mug")
+
+    def test_planning_fails(self):
+        arm = _make_arm(plan_tsrs_result=None)
+        ctx = _make_context()
+        tsrs = [MagicMock()]
+
+        result = place(ctx, arm, tsrs)
+
+        assert result is False
+        ctx.execute.assert_not_called()
+
+    def test_execution_fails(self):
+        arm = _make_arm()
+        ctx = _make_context(execute_ok=False)
+        tsrs = [MagicMock()]
+
+        result = place(ctx, arm, tsrs)
+
+        assert result is False
+        # release should not be attempted after execution failure
+        ctx.arm("test_arm").release.assert_not_called()
+
+    def test_release_with_none_object(self):
+        """object_name=None should pass None to release."""
+        arm = _make_arm()
+        ctx = _make_context()
+        tsrs = [MagicMock()]
+
+        place(ctx, arm, tsrs, object_name=None)
+
+        ctx.arm("test_arm").release.assert_called_once_with(None)
+
+    def test_retract_planning_fails_still_succeeds(self):
+        """Release succeeded but retract planning fails — still True."""
+        arm = _make_arm(plan_pose_result=None)
+        ctx = _make_context()
+        tsrs = [MagicMock()]
+
+        result = place(ctx, arm, tsrs)
+
+        assert result is True
+
+    def test_no_retract_when_zero_height(self):
+        arm = _make_arm()
+        ctx = _make_context()
+        tsrs = [MagicMock()]
+
+        place(ctx, arm, tsrs, retract_height=0.0)
+
+        arm.plan_to_pose.assert_not_called()
+
+    def test_constraint_tsrs_passed_through(self):
+        arm = _make_arm()
+        ctx = _make_context()
+        goal_tsrs = [MagicMock()]
+        constraint = [MagicMock()]
+
+        place(ctx, arm, goal_tsrs, constraint_tsrs=constraint)
+
+        arm.plan_to_tsrs.assert_called_once_with(
+            goal_tsrs, constraint_tsrs=constraint, timeout=30.0,
+        )
+
+    def test_retract_pose_is_above_current(self):
+        ee_pose = np.eye(4)
+        ee_pose[:3, 3] = [0.4, -0.2, 0.8]
+
+        arm = _make_arm()
+        arm.get_ee_pose.return_value = ee_pose
+        ctx = _make_context()
+        tsrs = [MagicMock()]
+
+        place(ctx, arm, tsrs, retract_height=0.07)
+
+        call_args = arm.plan_to_pose.call_args
+        target_pose = call_args[0][0]
+        assert target_pose[2, 3] == pytest.approx(0.87)  # 0.8 + 0.07


### PR DESCRIPTION
## Summary
- Adds `pickup()` and `place()` as generic manipulation primitives in `primitives.py`
- Both take TSR goals directly as arguments — no affordance registry, caller resolves which templates to use
- Compose existing APIs: `Arm.plan_to_tsrs` → `ctx.execute` → `ctx.arm().grasp/release` → best-effort lift/retract
- 17 unit tests with mocks covering all orchestration paths (planning/execution/grasp failure, best-effort lift/retract)

## Test plan
- [x] `uv run pytest tests/ -v` — 247/247 pass (230 existing + 17 new)
- [x] Both functions importable from `mj_manipulator`
- [x] Existing tests unaffected