### PR TITLE
refactor: structural cleanups (iter_contacts, required kinematic_limits, _NoIKSolver, bilateral warning)

### DIFF
--- a/src/mj_manipulator/arm.py
+++ b/src/mj_manipulator/arm.py
@@ -570,4 +570,4 @@ class _NoIKSolver:
     def solve_valid(
         self, pose: np.ndarray, q_init: np.ndarray | None = None
     ) -> list[np.ndarray]:
-        return []
+        return self.solve(pose, q_init)

--- a/src/mj_manipulator/cartesian.py
+++ b/src/mj_manipulator/cartesian.py
@@ -22,6 +22,8 @@ import mujoco
 import numpy as np
 from scipy.linalg import cho_factor, cho_solve
 
+from mj_manipulator.contacts import iter_contacts
+
 logger = logging.getLogger(__name__)
 
 
@@ -341,19 +343,11 @@ def check_gripper_contact(
         if body_id != -1:
             gripper_body_ids.add(body_id)
 
-    for i in range(data.ncon):
-        contact = data.contact[i]
-        geom1_body = model.geom_bodyid[contact.geom1]
-        geom2_body = model.geom_bodyid[contact.geom2]
-
-        if geom1_body in gripper_body_ids:
-            return mujoco.mj_id2name(
-                model, mujoco.mjtObj.mjOBJ_GEOM, contact.geom2
-            )
-        if geom2_body in gripper_body_ids:
-            return mujoco.mj_id2name(
-                model, mujoco.mjtObj.mjOBJ_GEOM, contact.geom1
-            )
+    for b1, b2, contact in iter_contacts(model, data):
+        if b1 in gripper_body_ids:
+            return mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, contact.geom2)
+        if b2 in gripper_body_ids:
+            return mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, contact.geom1)
 
     return None
 
@@ -410,25 +404,17 @@ def check_arm_contact(
     Returns:
         Name of contacted geom, or None if no contact.
     """
-    for i in range(data.ncon):
-        contact = data.contact[i]
-        geom1_body = model.geom_bodyid[contact.geom1]
-        geom2_body = model.geom_bodyid[contact.geom2]
+    for b1, b2, contact in iter_contacts(model, data):
+        b1_is_arm = b1 in arm_body_ids
+        b2_is_arm = b2 in arm_body_ids
 
-        geom1_is_arm = geom1_body in arm_body_ids
-        geom2_is_arm = geom2_body in arm_body_ids
-
-        if exclude_self_collision and geom1_is_arm and geom2_is_arm:
+        if exclude_self_collision and b1_is_arm and b2_is_arm:
             continue
 
-        if geom1_is_arm and not geom2_is_arm:
-            return mujoco.mj_id2name(
-                model, mujoco.mjtObj.mjOBJ_GEOM, contact.geom2
-            )
-        if geom2_is_arm and not geom1_is_arm:
-            return mujoco.mj_id2name(
-                model, mujoco.mjtObj.mjOBJ_GEOM, contact.geom1
-            )
+        if b1_is_arm and not b2_is_arm:
+            return mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, contact.geom2)
+        if b2_is_arm and not b1_is_arm:
+            return mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_GEOM, contact.geom1)
 
     return None
 

--- a/src/mj_manipulator/collision.py
+++ b/src/mj_manipulator/collision.py
@@ -16,6 +16,7 @@ import logging
 import mujoco
 import numpy as np
 
+from mj_manipulator.contacts import iter_contacts
 from mj_manipulator.grasp_manager import GraspManager
 
 logger = logging.getLogger(__name__)
@@ -148,11 +149,7 @@ class CollisionChecker:
         else:
             data = self._live_data if self._live_data is not None else self.data
 
-        for i in range(data.ncon):
-            contact = data.contact[i]
-            body1 = self.model.geom_bodyid[contact.geom1]
-            body2 = self.model.geom_bodyid[contact.geom2]
-
+        for body1, body2, contact in iter_contacts(self.model, data):
             body1_name = mujoco.mj_id2name(self.model, mujoco.mjtObj.mjOBJ_BODY, body1)
             body2_name = mujoco.mj_id2name(self.model, mujoco.mjtObj.mjOBJ_BODY, body2)
 
@@ -275,11 +272,7 @@ class CollisionChecker:
         """
         invalid_count = 0
 
-        for i in range(data.ncon):
-            contact = data.contact[i]
-            body1 = self.model.geom_bodyid[contact.geom1]
-            body2 = self.model.geom_bodyid[contact.geom2]
-
+        for body1, body2, _ in iter_contacts(self.model, data):
             body1_name = mujoco.mj_id2name(self.model, mujoco.mjtObj.mjOBJ_BODY, body1)
             body2_name = mujoco.mj_id2name(self.model, mujoco.mjtObj.mjOBJ_BODY, body2)
 

--- a/src/mj_manipulator/config.py
+++ b/src/mj_manipulator/config.py
@@ -67,11 +67,7 @@ class ArmConfig(EntityConfig):
     datasheet values (e.g., KinematicLimits for UR5e, Franka, Xarm).
     """
 
-    kinematic_limits: KinematicLimits = field(
-        default_factory=lambda: KinematicLimits(
-            velocity=np.ones(1), acceleration=np.ones(1)
-        )
-    )
+    kinematic_limits: KinematicLimits  # required: robot-specific velocity/acceleration limits
     ee_site: str = ""  # MuJoCo site name for Jacobian / FK
     tcp_offset: np.ndarray | None = None  # 4x4 SE3 from ee_site to tool center point
     planning_defaults: PlanningDefaults = field(default_factory=PlanningDefaults)

--- a/src/mj_manipulator/contacts.py
+++ b/src/mj_manipulator/contacts.py
@@ -1,0 +1,29 @@
+"""Shared contact iteration utility for MuJoCo.
+
+Not part of the public API.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import mujoco
+
+
+def iter_contacts(
+    model: mujoco.MjModel, data: mujoco.MjData
+) -> Iterator[tuple[int, int, Any]]:
+    """Iterate over active MuJoCo contacts.
+
+    Yields:
+        (body_id_1, body_id_2, contact) for each active contact, where
+        body_id_1 and body_id_2 are the body IDs of the two geoms in contact.
+    """
+    for i in range(data.ncon):
+        contact = data.contact[i]
+        yield (
+            model.geom_bodyid[contact.geom1],
+            model.geom_bodyid[contact.geom2],
+            contact,
+        )

--- a/src/mj_manipulator/grasp_manager.py
+++ b/src/mj_manipulator/grasp_manager.py
@@ -10,6 +10,8 @@ import logging
 import mujoco
 import numpy as np
 
+from mj_manipulator.contacts import iter_contacts
+
 logger = logging.getLogger(__name__)
 
 
@@ -229,11 +231,7 @@ def detect_grasped_object(
     # Track contacts per object: body_id -> {group_name: bool, ..., "count": int}
     object_contacts: dict[int, dict] = {}
 
-    for i in range(data.ncon):
-        contact = data.contact[i]
-        body1 = model.geom_bodyid[contact.geom1]
-        body2 = model.geom_bodyid[contact.geom2]
-
+    for body1, body2, _ in iter_contacts(model, data):
         gripper_body = None
         other_body = None
         if body1 in all_gripper_body_ids:
@@ -265,6 +263,13 @@ def detect_grasped_object(
 
     # Filter by bilateral contact requirement
     non_empty_groups = [g for g, ids in group_body_ids.items() if ids]
+    if require_bilateral and len(non_empty_groups) < 2:
+        logger.warning(
+            "require_bilateral=True but only %d non-empty finger group(s) found "
+            "(body names may not match '/left_' or '/right_' convention); "
+            "falling back to any-contact detection",
+            len(non_empty_groups),
+        )
     if require_bilateral and len(non_empty_groups) >= 2:
         bilateral = {
             bid: info

--- a/src/mj_manipulator/grippers/_base.py
+++ b/src/mj_manipulator/grippers/_base.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING
 import mujoco
 import numpy as np
 
+from mj_manipulator.contacts import iter_contacts
+
 if TYPE_CHECKING:
     from mj_manipulator.grasp_manager import GraspManager
 
@@ -178,11 +180,7 @@ class _BaseGripper:
         candidate_body: str | None = None
         first_external: str | None = None
 
-        for i in range(self._data.ncon):
-            contact = self._data.contact[i]
-            b1 = self._model.geom_bodyid[contact.geom1]
-            b2 = self._model.geom_bodyid[contact.geom2]
-
+        for b1, b2, _ in iter_contacts(self._model, self._data):
             b1_gripper = b1 in self._gripper_body_ids
             b2_gripper = b2 in self._gripper_body_ids
 


### PR DESCRIPTION
## Summary

Four independent structural improvements identified during full codebase review:

- **`contacts.py`**: New `iter_contacts(model, data)` generator eliminates 6 identical `for i in range(data.ncon)` boilerplate loops across `cartesian.py` (×2), `collision.py` (×2), `grasp_manager.py`, and `grippers/_base.py`. Yields `(body_id_1, body_id_2, contact)`.
- **`config.py`**: `kinematic_limits` is now a required field on `ArmConfig`. The previous `default_factory` silently created a 1-DOF placeholder that would break TOPP-RA for any real arm (6-DOF, 7-DOF). All existing callers already pass it.
- **`arm.py`**: `_NoIKSolver.solve_valid()` delegates to `solve()` instead of duplicating `return []`.
- **`grasp_manager.py`**: `detect_grasped_object` now logs a warning when `require_bilateral=True` but fewer than 2 non-empty finger groups are found (previously silently fell back to any-contact detection).

## Test plan

- [x] 230 tests pass (`uv run pytest tests/ -x -q`)
- [x] No behavior changes — contacts, collision checking, grasp detection logic unchanged