### PR TITLE
docs: add find_locked_joint_index + Adding a New Arm guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Pre-built arm factories in `mj_manipulator.arms`:
 - **UR5e** (6-DOF) — `create_ur5e_arm(env)`
 - **Franka Emika Panda** (7-DOF) — `create_franka_arm(env)`
 
-Adding a new arm is straightforward — see `mj_manipulator/arms/__init__.py` for the recipe.
+See [Adding a New Arm](#adding-a-new-arm) below.
 
 ## Installation
 
@@ -96,6 +96,93 @@ mj_environment  →  mj_manipulator  →  geodude (UR5e + Robotiq)
 ```
 
 Robot-specific code (joint names, limits, IK config) lives in `arms/<robot>.py`. The generic layer (`Arm`, protocols, executors) knows nothing about specific robots.
+
+## Adding a New Arm
+
+`arms/ur5e.py` (6-DOF) and `arms/franka.py` (7-DOF) are the complete references. The steps:
+
+**1. Create `arms/<robot>.py`**
+
+```python
+import numpy as np
+from mj_manipulator.arm import Arm
+from mj_manipulator.arms.eaik_solver import MuJoCoEAIKSolver
+from mj_manipulator.config import ArmConfig, KinematicLimits
+
+MY_ROBOT_JOINT_NAMES = ["joint1", "joint2", ...]   # from your XML
+MY_ROBOT_HOME        = np.array([0.0, 0.0, ...])
+MY_ROBOT_VEL_LIMITS  = np.array([...]) * 0.5       # datasheet values, halved
+MY_ROBOT_ACC_LIMITS  = np.array([...]) * 0.5
+
+def create_my_robot_arm(env, *, ee_site="grasp_site", with_ik=True, ...):
+    config = ArmConfig(
+        name="my_robot", entity_type="arm",
+        joint_names=list(MY_ROBOT_JOINT_NAMES),
+        kinematic_limits=KinematicLimits(
+            velocity=MY_ROBOT_VEL_LIMITS.copy(),
+            acceleration=MY_ROBOT_ACC_LIMITS.copy(),
+        ),
+        ee_site=ee_site,
+    )
+    if not with_ik:
+        return Arm(env, config)
+    arm = Arm(env, config)
+    first_joint_body = env.model.jnt_bodyid[arm.joint_ids[0]]
+    base_body_id = env.model.body_parentid[first_joint_body]
+    ik_solver = MuJoCoEAIKSolver(
+        model=env.model, data=env.data,
+        joint_ids=list(arm.joint_ids),
+        joint_qpos_indices=arm.joint_qpos_indices,
+        ee_site_id=arm.ee_site_id,
+        base_body_id=base_body_id,
+        joint_limits=arm.get_joint_limits(),
+        # fixed_joint_index=MY_ROBOT_LOCKED_JOINT,  # 7-DOF only — see step 2
+    )
+    return Arm(env, config, ik_solver=ik_solver)
+```
+
+**2. Find the locked joint (7-DOF only)**
+
+Run this once as a one-off script to discover which joint to lock:
+
+```python
+from mj_manipulator.arms import find_locked_joint_index
+from mj_manipulator.arms.eaik_solver import _extract_hp
+
+arm = Arm(env, config)  # create without IK first
+first_joint_body = env.model.jnt_bodyid[arm.joint_ids[0]]
+base_body_id     = env.model.body_parentid[first_joint_body]
+H, P, _          = _extract_hp(env.model, env.data, list(arm.joint_ids),
+                                arm.joint_qpos_indices, arm.ee_site_id, base_body_id)
+print(find_locked_joint_index(H, P))  # → hardcode this as MY_ROBOT_LOCKED_JOINT
+```
+
+Then pass `fixed_joint_index=MY_ROBOT_LOCKED_JOINT` to `MuJoCoEAIKSolver`.
+
+**3. Add an EE site if the model doesn't have one**
+
+Use `MjSpec` to add the site before creating the `Environment`:
+
+```python
+spec = mujoco.MjSpec.from_file("path/to/scene.xml")
+hand = spec.worldbody.find_child("hand")  # adjust to your link name
+site = hand.add_site()
+site.name = "grasp_site"
+site.pos = [0, 0, 0.1]   # at palm/flange; z = approach direction
+model = spec.compile()
+env = Environment.from_model(model)
+```
+
+See `add_franka_ee_site()` in `arms/franka.py` for the pattern.
+
+**4. Add tests** — copy `TestUR5eFactory` / `TestUR5eIK` from `tests/test_arms.py`:
+factory creates valid Arm, FK-IK round-trip, all solutions within joint limits.
+
+**5. Re-export** — add to `arms/__init__.py`:
+```python
+from mj_manipulator.arms.my_robot import create_my_robot_arm
+__all__ = [..., "create_my_robot_arm"]
+```
 
 ## Demos
 

--- a/src/mj_manipulator/arms/__init__.py
+++ b/src/mj_manipulator/arms/__init__.py
@@ -18,22 +18,26 @@ Usage:
 Adding a new arm:
     1. Create ``arms/<robot>.py`` with:
        - Joint names, home config, velocity/acceleration limits as constants
+         (limits from datasheet, halved for conservative planning)
        - ``create_<robot>_arm(env, ...) -> Arm`` factory function
-    2. In the factory, build an ``ArmConfig`` with your constants and create
-       a ``MuJoCoEAIKSolver`` for IK. The solver extracts kinematics (H/P
-       vectors) directly from the MuJoCo model — no DH parameters needed.
-       - 6-DOF arms: pass joint_ids and ee_site_id directly
-       - 7-DOF arms: set ``fixed_joint_index`` to the joint whose locking
-         gives a known EAIK decomposition (test with ``hasKnownDecomposition()``)
-    3. If the menagerie model lacks an EE site, provide an ``add_<robot>_ee_site(spec)``
-       helper (see ``franka.py`` for the pattern).
+    2. Build ``ArmConfig`` with your constants and ``MuJoCoEAIKSolver`` for IK.
+       The solver extracts kinematics (H/P vectors) from the MuJoCo model —
+       no DH parameters needed.
+       - 6-DOF arms: pass joint_ids and ee_site_id directly (see ``ur5e.py``)
+       - 7-DOF arms: call ``find_locked_joint_index(H, P)`` once to discover
+         which joint to lock for EAIK. Hardcode the result as a module constant
+         (see ``franka.py`` and ``_FRANKA_LOCKED_JOINT_INDEX``).
+    3. If the model lacks an EE site, provide ``add_<robot>_ee_site(spec)``
+       (see ``franka.py``). Place the site at the palm/flange; z-axis = approach.
     4. Add tests in ``tests/test_arms.py``: factory creates valid Arm, FK-IK
-       round-trip at home and offset configs.
+       round-trip at home config, solutions within joint limits.
     5. Re-export the factory from this ``__init__.py``.
 
-    See ``ur5e.py`` (6-DOF) and ``franka.py`` (7-DOF) as references.
+    See ``ur5e.py`` (6-DOF) and ``franka.py`` (7-DOF) as complete references.
+    See ``README.md`` for a code skeleton.
 """
 
+from mj_manipulator.arms.eaik_solver import find_locked_joint_index
 from mj_manipulator.arms.franka import add_franka_ee_site, create_franka_arm
 from mj_manipulator.arms.ur5e import create_ur5e_arm
 
@@ -41,4 +45,5 @@ __all__ = [
     "create_ur5e_arm",
     "create_franka_arm",
     "add_franka_ee_site",
+    "find_locked_joint_index",
 ]

--- a/src/mj_manipulator/arms/eaik_solver.py
+++ b/src/mj_manipulator/arms/eaik_solver.py
@@ -101,6 +101,40 @@ def _extract_hp(
     return H_base, P_offsets, ee_rot_base
 
 
+def find_locked_joint_index(H: np.ndarray, P: np.ndarray) -> int | None:
+    """Find which joint to lock for EAIK 7-DOF arm support.
+
+    Iterates over all joints and returns the first index that yields a known
+    EAIK decomposition when locked. Call this once (e.g. in a one-off script)
+    after extracting H/P from your model to determine ``fixed_joint_index``
+    for ``MuJoCoEAIKSolver``.
+
+    Example::
+
+        from mj_manipulator.arms.eaik_solver import _extract_hp, find_locked_joint_index
+
+        # After creating your Arm (arm) and extracting joint/site IDs:
+        H, P, _ = _extract_hp(model, data, joint_ids, qpos_indices, ee_site_id, base_id)
+        idx = find_locked_joint_index(H, P)
+        # → e.g. 4 for Franka. Hardcode this as YOUR_ROBOT_LOCKED_JOINT_INDEX.
+
+    Args:
+        H: Joint axes (n_joints, 3) from ``_extract_hp``.
+        P: Position offsets (n_joints+1, 3) from ``_extract_hp``.
+
+    Returns:
+        Joint index to pass as ``fixed_joint_index``, or None if no joint works
+        (the arm may not be supported by EAIK).
+    """
+    from eaik.IK_HP import HPRobot
+
+    for i in range(len(H)):
+        robot = HPRobot(H, P, fixed_axes=[(i, 0.0)])
+        if robot.hasKnownDecomposition():
+            return i
+    return None
+
+
 class MuJoCoEAIKSolver:
     """EAIK IK solver that extracts kinematics directly from a MuJoCo model.
 

--- a/src/mj_manipulator/arms/franka.py
+++ b/src/mj_manipulator/arms/franka.py
@@ -51,8 +51,10 @@ FRANKA_ACCELERATION_LIMITS = (
     np.array([15.0, 7.5, 10.0, 12.5, 15.0, 20.0, 20.0]) * 0.5
 )
 
-# Joint 5 (index 4) is the only joint whose locking yields an EAIK
-# decomposition with exact analytical solutions (SPHERICAL_SECOND_TWO_PARALLEL).
+# Joint 5 (index 4) is the only joint whose locking yields a known EAIK
+# decomposition (SPHERICAL_SECOND_TWO_PARALLEL). Determined via:
+#   find_locked_joint_index(H, P)  →  4
+# For a new arm, call find_locked_joint_index() to discover the right index.
 _FRANKA_LOCKED_JOINT_INDEX = 4
 
 


### PR DESCRIPTION
## Summary

- **`eaik_solver.py`**: New `find_locked_joint_index(H, P)` utility — iterates over joints to find which one yields a known EAIK decomposition when locked. This was the missing piece for 7-DOF onboarding: previously users had no programmatic way to discover `fixed_joint_index` and had to reverse-engineer it from the Franka example.
- **`franka.py`**: Comment on `_FRANKA_LOCKED_JOINT_INDEX = 4` now says it was found via this utility.
- **`arms/__init__.py`**: Exports `find_locked_joint_index`; step 2 of the recipe references it explicitly.
- **`README.md`**: Replaces the one-liner "see __init__.py for the recipe" with a full **Adding a New Arm** section: complete code skeleton, 7-DOF locked-joint discovery snippet, EE site pattern, test guidance, and re-export step.

## Test plan

- [x] 230 tests pass (`uv run pytest tests/ -x -q`)
- [x] No behavioral changes — `find_locked_joint_index` is a new pure utility