### PR TITLE
BT demo: pick any reachable can using goal_tsr_index

### DIFF
--- a/demos/bt_recycle.py
+++ b/demos/bt_recycle.py
@@ -227,6 +227,7 @@ def run(robot_type, *, physics=False, headless=False, cycles=3):
         bb = py_trees.blackboard.Client(name="demo")
         for key in ["/context", f"{ns}/arm", f"{ns}/arm_name",
                      f"{ns}/grasp_tsrs", f"{ns}/place_tsrs", f"{ns}/grasped",
+                     f"{ns}/goal_tsr_index", f"{ns}/tsr_to_object",
                      f"{ns}/timeout", f"{ns}/object_name", f"{ns}/goal_config",
                      f"{ns}/step_fn"]:
             bb.register_key(key=key, access=Access.WRITE)
@@ -241,27 +242,46 @@ def run(robot_type, *, physics=False, headless=False, cycles=3):
         # Set place TSRs once (same for all cycles)
         bb.set(f"{ns}/place_tsrs", make_place_tsrs())
 
-        for cycle, body_name in enumerate(CAN_BODY_NAMES[:cycles], 1):
-            if not ctx.is_running():
+        # Track which TSRs belong to which can (for goal_tsr_index lookup)
+        remaining_cans = list(CAN_BODY_NAMES[:cycles])
+
+        for cycle in range(1, cycles + 1):
+            if not ctx.is_running() or not remaining_cans:
                 break
 
-            print(f"\n--- Cycle {cycle}: {body_name} ---")
-            T_center = env.get_body_pose(body_name)
-            print(f"  Can at: {T_center[:3, 3].round(3)}")
+            print(f"\n--- Cycle {cycle}: {len(remaining_cans)} cans remaining ---")
 
-            # Set per-cycle blackboard values
-            bb.set(f"{ns}/grasp_tsrs", make_grasp_tsrs(T_center, robot_type))
-            bb.set(f"{ns}/object_name", body_name)
+            # Combine grasp TSRs from ALL remaining cans
+            all_grasp_tsrs = []
+            tsr_to_can = []  # maps TSR index → can body name
+            for body_name in remaining_cans:
+                T_center = env.get_body_pose(body_name)
+                tsrs = make_grasp_tsrs(T_center, robot_type)
+                for _ in tsrs:
+                    tsr_to_can.append(body_name)
+                all_grasp_tsrs.extend(tsrs)
 
-            # Reset tree and tick (synchronous — runs full pickup+place in one tick)
+            print(f"  {len(all_grasp_tsrs)} TSRs from {len(remaining_cans)} cans")
+
+            bb.set(f"{ns}/grasp_tsrs", all_grasp_tsrs)
+            bb.set(f"{ns}/tsr_to_object", tsr_to_can)
+            bb.set(f"{ns}/object_name", remaining_cans[0])  # fallback
+
+            # Reset tree and tick
             for node in root.iterate():
                 node.status = Status.INVALID
             tree.tick()
 
             if root.status == Status.SUCCESS:
-                print(f"  Picked up and placed {body_name}")
+                # Determine which can was actually grasped via goal_tsr_index
+                goal_idx = bb.get(f"{ns}/goal_tsr_index")
+                grasped_can = tsr_to_can[goal_idx] if goal_idx < len(tsr_to_can) else remaining_cans[0]
+                print(f"  Picked up and placed {grasped_can} (TSR index {goal_idx})")
+
                 if not physics:
-                    env.hide_freebody(body_name)
+                    env.hide_freebody(grasped_can)
+                remaining_cans.remove(grasped_can)
+
                 # Return home
                 try:
                     home_path = arm.plan_to_configuration(home, timeout=10.0)

--- a/src/mj_manipulator/arm.py
+++ b/src/mj_manipulator/arm.py
@@ -425,6 +425,7 @@ class Arm:
         timeout: float | None = None,
         seed: int | None = None,
         planner_config: CBiRRTConfig | None = None,
+        return_details: bool = False,
     ) -> list[np.ndarray] | None:
         """Plan to a TSR-defined goal region.
 
@@ -437,9 +438,12 @@ class Arm:
             timeout: Planning timeout in seconds (default from planning_defaults).
             seed: RNG seed for reproducibility.
             planner_config: Override planner configuration.
+            return_details: If True, return pycbirrt PlanResult with indices
+                and stats instead of just the path.
 
         Returns:
             Path to a goal satisfying the TSRs, or None if failed.
+            If return_details=True, returns pycbirrt.PlanResult instead.
         """
         if self.ik_solver is None:
             raise RuntimeError(
@@ -453,6 +457,7 @@ class Arm:
             goal_tsrs=goal_tsrs,
             constraint_tsrs=constraint_tsrs,
             seed=seed,
+            return_details=return_details,
         )
 
     def plan_to_pose(

--- a/src/mj_manipulator/bt/nodes.py
+++ b/src/mj_manipulator/bt/nodes.py
@@ -44,8 +44,8 @@ class _ManipulationNode(py_trees.behaviour.Behaviour):
 class PlanToTSRs(_ManipulationNode):
     """Plan a collision-free path to a set of TSR goals.
 
-    Reads: ``{ns}/arm``, ``{ns}/tsrs``, ``{ns}/timeout``
-    Writes: ``{ns}/path``
+    Reads: ``{ns}/arm``, ``{ns}/{tsrs_key}``, ``{ns}/timeout``
+    Writes: ``{ns}/path``, ``{ns}/goal_tsr_index``
     """
 
     def __init__(self, ns: str = "", tsrs_key: str = "tsrs", name: str = "PlanToTSRs"):
@@ -55,18 +55,20 @@ class PlanToTSRs(_ManipulationNode):
         self.bb.register_key(key=self._key(tsrs_key), access=Access.READ)
         self.bb.register_key(key=self._key("timeout"), access=Access.READ)
         self.bb.register_key(key=self._key("path"), access=Access.WRITE)
+        self.bb.register_key(key=self._key("goal_tsr_index"), access=Access.WRITE)
 
     def update(self) -> Status:
         arm = self.bb.get(self._key("arm"))
         tsrs = self.bb.get(self._key(self._tsrs_key))
         timeout = self.bb.get(self._key("timeout"))
         try:
-            path = arm.plan_to_tsrs(tsrs, timeout=timeout)
+            result = arm.plan_to_tsrs(tsrs, timeout=timeout, return_details=True)
         except Exception:
-            path = None
-        if path is None:
+            result = None
+        if result is None or not result.success:
             return Status.FAILURE
-        self.bb.set(self._key("path"), path)
+        self.bb.set(self._key("path"), result.path)
+        self.bb.set(self._key("goal_tsr_index"), result.goal_index)
         return Status.SUCCESS
 
 
@@ -142,6 +144,10 @@ class Grasp(_ManipulationNode):
 
     Reads: ``/context``, ``{ns}/arm_name``, ``{ns}/object_name``
     Writes: ``{ns}/grasped``
+
+    If ``{ns}/tsr_to_object`` (list mapping TSR index → object name) and
+    ``{ns}/goal_tsr_index`` are set, resolves the actual object name from
+    the planner's goal index. This enables "pick any object" workflows.
     """
 
     def __init__(self, ns: str = "", name: str = "Grasp"):
@@ -150,11 +156,23 @@ class Grasp(_ManipulationNode):
         self.bb.register_key(key=self._key("arm_name"), access=Access.READ)
         self.bb.register_key(key=self._key("object_name"), access=Access.READ)
         self.bb.register_key(key=self._key("grasped"), access=Access.WRITE)
+        self.bb.register_key(key=self._key("goal_tsr_index"), access=Access.READ)
+        self.bb.register_key(key=self._key("tsr_to_object"), access=Access.READ)
 
     def update(self) -> Status:
         ctx = self.bb.get("/context")
         arm_name = self.bb.get(self._key("arm_name"))
         obj = self.bb.get(self._key("object_name"))
+
+        # Resolve actual object from planner's goal index if available
+        try:
+            tsr_to_obj = self.bb.get(self._key("tsr_to_object"))
+            goal_idx = self.bb.get(self._key("goal_tsr_index"))
+            if tsr_to_obj is not None and goal_idx is not None and goal_idx < len(tsr_to_obj):
+                obj = tsr_to_obj[goal_idx]
+        except KeyError:
+            pass
+
         grasped = ctx.arm(arm_name).grasp(obj)
         self.bb.set(self._key("grasped"), grasped)
         return Status.SUCCESS if grasped else Status.FAILURE


### PR DESCRIPTION
## Summary

- Combine TSRs from ALL remaining cans and send to planner
- Planner picks whichever is easiest to reach
- `goal_tsr_index` from pycbirrt PlanResult identifies which can
- Grasp node resolves actual object name from `tsr_to_object` mapping
- Remaining cans tracked per cycle — picked cans are removed

## Changes

- `PlanToTSRs` node: uses `return_details=True`, writes `goal_tsr_index`
- `Grasp` node: resolves `object_name` from `tsr_to_object[goal_tsr_index]`
- `Arm.plan_to_tsrs`: accepts `return_details` passthrough
- `bt_recycle.py`: combines all cans' TSRs per cycle

## Test plan

- [x] 239 mj_manipulator tests passing
- [x] `bt_recycle.py --headless --cycles 3` picks correct cans

Closes #20