### PR TITLE
Fix: CartesianController routes through context instead of bypassing physics

### DIFF
--- a/demos/bt_recycle.py
+++ b/demos/bt_recycle.py
@@ -221,15 +221,12 @@ def run(robot_type, *, physics=False, headless=False, cycles=3):
                 env.data.ctrl[arm.gripper.actuator_id] = arm.gripper.ctrl_open
             ctx.sync()
 
-        step_fn = ctx.step if ctx._controller is not None else None
-
         # Set up blackboard
         bb = py_trees.blackboard.Client(name="demo")
         for key in ["/context", f"{ns}/arm", f"{ns}/arm_name",
                      f"{ns}/grasp_tsrs", f"{ns}/place_tsrs", f"{ns}/grasped",
                      f"{ns}/goal_tsr_index", f"{ns}/tsr_to_object",
-                     f"{ns}/timeout", f"{ns}/object_name", f"{ns}/goal_config",
-                     f"{ns}/step_fn"]:
+                     f"{ns}/timeout", f"{ns}/object_name", f"{ns}/goal_config"]:
             bb.register_key(key=key, access=Access.WRITE)
 
         bb.set("/context", ctx)
@@ -237,7 +234,6 @@ def run(robot_type, *, physics=False, headless=False, cycles=3):
         bb.set(f"{ns}/arm_name", arm.config.name)
         bb.set(f"{ns}/timeout", 10.0)
         bb.set(f"{ns}/goal_config", home)
-        bb.set(f"{ns}/step_fn", step_fn)
 
         # Set place TSRs once (same for all cycles)
         bb.set(f"{ns}/place_tsrs", make_place_tsrs())

--- a/demos/cartesian_control.py
+++ b/demos/cartesian_control.py
@@ -45,7 +45,7 @@ def demo_teleop(arm, label):
     print_header(f"{label} — Teleop (step, 125 Hz × 2 s)")
 
     controller = CartesianController.from_arm(arm)
-    model, data = arm.env.model, arm.env.data
+    data = arm.env.data
     ee_id = arm.ee_site_id
 
     dt = 0.008        # 125 Hz
@@ -57,7 +57,6 @@ def demo_teleop(arm, label):
 
     for _ in range(n_steps):
         result = controller.step(twist, dt)
-        mujoco.mj_forward(model, data)
         fractions.append(result.achieved_fraction)
 
     ee_end = data.site_xpos[ee_id].copy()
@@ -79,13 +78,11 @@ def demo_move(arm, label):
     print_header(f"{label} — Scripted Move (move, 3 cm -Z)")
 
     controller = CartesianController.from_arm(arm)
-    model, data = arm.env.model, arm.env.data
 
     result = controller.move(
         twist=np.array([0, 0, -0.05, 0, 0, 0]),
         dt=0.008,
         max_distance=0.03,
-        step_fn=lambda: mujoco.mj_forward(model, data),
     )
 
     print(f"\n  Terminated: {result.terminated_by}")
@@ -116,7 +113,6 @@ def demo_move_to(arm, label):
         speed=0.05,
         position_tol=0.002,
         rotation_tol=0.05,
-        step_fn=lambda: mujoco.mj_forward(model, data),
     )
 
     pos_err = np.linalg.norm(target[:3, 3] - data.site_xpos[ee_id])

--- a/demos/recycling.py
+++ b/demos/recycling.py
@@ -313,9 +313,10 @@ def setup_franka():
 
 def cartesian_lift(ctx: SimContext, arm: Arm, height: float = 0.05) -> None:
     """Lift the EE straight up using Jacobian-based cartesian control."""
-    # In physics mode, pass ctx.step so mj_step runs (friction holds object).
-    step_fn = ctx.step if ctx._controller is not None else None
-    ctrl = CartesianController.from_arm(arm, step_fn=step_fn)
+    arm_name = arm.config.name
+    ctrl = CartesianController.from_arm(
+        arm, step_fn=lambda q, qd: ctx.step_cartesian(arm_name, q, qd),
+    )
     ctrl.move(
         np.array([0.0, 0.0, 0.10, 0.0, 0.0, 0.0]),  # 10 cm/s upward
         dt=0.004,
@@ -436,12 +437,15 @@ def run_recycling(
                 env.data.ctrl[arm.gripper.actuator_id] = arm.gripper.ctrl_open
             ctx.sync()
 
+        arm_name = arm.config.name
+        _step_fn = lambda q, qd: ctx.step_cartesian(arm_name, q, qd)
+
         def recover():
             """Release any held object, retract up, return home."""
             # Release anything held
-            ctx.arm(arm.config.name).release()
+            ctx.arm(arm_name).release()
             # Cartesian retract upward to clear collisions
-            ctrl = CartesianController.from_arm(arm, step_fn=step_fn)
+            ctrl = CartesianController.from_arm(arm, step_fn=_step_fn)
             ctrl.move(np.array([0., 0., 0.10, 0., 0., 0.]), dt=0.004, max_distance=0.10)
             # Plan home
             try:
@@ -451,8 +455,6 @@ def run_recycling(
             if home_path is not None:
                 ctx.execute(arm.retime(home_path))
             ctx.sync()
-
-        step_fn = ctx.step if ctx._controller is not None else None
 
         remaining = list(CAN_BODY_NAMES[:cycles])
 

--- a/src/mj_manipulator/bt/nodes.py
+++ b/src/mj_manipulator/bt/nodes.py
@@ -207,17 +207,23 @@ class CartesianMove(_ManipulationNode):
     def __init__(self, ns: str = "", name: str = "CartesianMove"):
         super().__init__(name, ns)
         self.bb.register_key(key=self._key("arm"), access=Access.READ)
+        self.bb.register_key(key=self._key("arm_name"), access=Access.READ)
         self.bb.register_key(key=self._key("twist"), access=Access.READ)
         self.bb.register_key(key=self._key("distance"), access=Access.READ)
-        self.bb.register_key(key=self._key("step_fn"), access=Access.READ)
+        self.bb.register_key(key="/context", access=Access.READ)
 
     def update(self) -> Status:
         from mj_manipulator.cartesian import CartesianController
 
         arm = self.bb.get(self._key("arm"))
+        arm_name = self.bb.get(self._key("arm_name"))
         twist = self.bb.get(self._key("twist"))
         distance = self.bb.get(self._key("distance"))
-        step_fn = self.bb.get(self._key("step_fn"))
+        ctx = self.bb.get("/context")
+
+        def step_fn(q, qd):
+            ctx.step_cartesian(arm_name, q, qd)
+
         ctrl = CartesianController.from_arm(arm, step_fn=step_fn)
         ctrl.move(twist, dt=0.004, max_distance=distance)
         return Status.SUCCESS

--- a/src/mj_manipulator/cartesian.py
+++ b/src/mj_manipulator/cartesian.py
@@ -478,7 +478,7 @@ class CartesianController:
         qd_max: np.ndarray,
         config: CartesianControlConfig | None = None,
         grasp_manager: "GraspManager | None" = None,
-        step_fn: "Callable[[], None] | None" = None,
+        step_fn: "Callable[[np.ndarray, np.ndarray], None] | None" = None,
     ):
         """
         Args:
@@ -495,8 +495,10 @@ class CartesianController:
                 poses during motion. If provided, attached objects follow the
                 gripper automatically during step/move/move_to.
             step_fn: Function to advance the simulation after each control step.
-                In physics mode, this should call mj_step (via ctx.step()) so
-                dynamics are simulated. Defaults to mj_forward (kinematic).
+                Called with ``(q_new, qd_new)`` — joint positions and velocities
+                computed by the Cartesian solver. In physics mode, this should
+                route through ``ctx.step_cartesian(arm_name, q, qd)``. Defaults
+                to writing qpos directly + ``mj_forward`` (kinematic).
         """
         self.model = model
         self.data = data
@@ -516,7 +518,7 @@ class CartesianController:
         cls,
         arm: "Arm",
         config: CartesianControlConfig | None = None,
-        step_fn: "Callable[[], None] | None" = None,
+        step_fn: "Callable[[np.ndarray, np.ndarray], None] | None" = None,
     ) -> "CartesianController":
         """Create a CartesianController from an Arm instance."""
         q_min, q_max = arm.get_joint_limits()
@@ -576,10 +578,19 @@ class CartesianController:
             q_dot_prev=self._q_dot_prev,
         )
         self._q_dot_prev = result.joint_velocities
-        for i, idx in enumerate(self.joint_qpos_indices):
-            self.data.qpos[idx] = q_new[i]
-        if self.grasp_manager is not None:
-            self.grasp_manager.update_attached_poses(self.data)
+
+        # Route through step function (ctx.step_cartesian in physics mode,
+        # direct qpos write + mj_forward in kinematic mode)
+        step_fn = self._default_step_fn
+        if step_fn is not None:
+            step_fn(q_new, result.joint_velocities)
+        else:
+            for i, idx in enumerate(self.joint_qpos_indices):
+                self.data.qpos[idx] = q_new[i]
+            mujoco.mj_forward(self.model, self.data)
+            if self.grasp_manager is not None:
+                self.grasp_manager.update_attached_poses(self.data)
+
         return result
 
     def move(
@@ -590,7 +601,6 @@ class CartesianController:
         max_duration: float = 5.0,
         max_distance: float | None = None,
         stop_condition: Callable[[], bool] | None = None,
-        step_fn: Callable[[], None] | None = None,
     ) -> TwistExecutionResult:
         """Execute a constant twist until a stop condition is met.
 
@@ -606,18 +616,10 @@ class CartesianController:
             max_duration: Stop after this many seconds.
             max_distance: Stop after EE moves this far (meters).
             stop_condition: Callable returning True to stop early.
-            step_fn: Advance simulation after each step. Defaults to
-                ``mj_forward`` for kinematic simulation.
 
         Returns:
             TwistExecutionResult describing why motion terminated.
         """
-        if step_fn is None:
-            step_fn = self._default_step_fn
-        if step_fn is None:
-            def step_fn():
-                mujoco.mj_forward(self.model, self.data)
-
         self.reset()
 
         t = 0.0
@@ -631,7 +633,6 @@ class CartesianController:
                 break
 
             result = self.step(twist, dt)
-            step_fn()
 
             current_pos = self.data.site_xpos[self.ee_site_id].copy()
             distance += float(np.linalg.norm(current_pos - last_pos))
@@ -662,7 +663,6 @@ class CartesianController:
         speed: float = 0.05,
         position_tol: float = 0.005,
         rotation_tol: float = 0.05,
-        step_fn: Callable[[], None] | None = None,
     ) -> TwistExecutionResult:
         """Move end-effector to a target pose.
 
@@ -677,19 +677,11 @@ class CartesianController:
                 proportionally at ``speed / config.length_scale`` (rad/s).
             position_tol: Convergence threshold for position (meters).
             rotation_tol: Convergence threshold for rotation (radians).
-            step_fn: Advance simulation after each step. Defaults to
-                ``mj_forward`` for kinematic simulation.
 
         Returns:
             TwistExecutionResult. ``terminated_by == "condition"`` means
             the target was reached within tolerance.
         """
-        if step_fn is None:
-            step_fn = self._default_step_fn
-        if step_fn is None:
-            def step_fn():
-                mujoco.mj_forward(self.model, self.data)
-
         self.reset()
 
         t = 0.0
@@ -717,7 +709,6 @@ class CartesianController:
             twist = np.concatenate([v, w])
 
             result = self.step(twist, dt)
-            step_fn()
 
             current_pos = self.data.site_xpos[self.ee_site_id].copy()
             distance += float(np.linalg.norm(current_pos - last_pos))
@@ -742,7 +733,6 @@ class CartesianController:
         gripper_body_names: list[str],
         *,
         max_distance: float = 0.2,
-        step_fn: Callable[[], None] | None = None,
     ) -> MoveUntilTouchResult:
         """Move along a twist until gripper contact is detected.
 
@@ -755,18 +745,10 @@ class CartesianController:
             dt: Control timestep (seconds).
             gripper_body_names: Body names of gripper parts to monitor.
             max_distance: Stop after EE moves this far without contact (meters).
-            step_fn: Advance simulation after each step. Defaults to
-                ``mj_forward`` for kinematic simulation.
 
         Returns:
             MoveUntilTouchResult. ``success=True`` if contact was detected.
         """
-        if step_fn is None:
-            step_fn = self._default_step_fn
-        if step_fn is None:
-            def step_fn():
-                mujoco.mj_forward(self.model, self.data)
-
         self.reset()
 
         distance = 0.0
@@ -781,7 +763,6 @@ class CartesianController:
                 break
 
             result = self.step(twist, dt)
-            step_fn()
 
             current_pos = self.data.site_xpos[self.ee_site_id].copy()
             distance += float(np.linalg.norm(current_pos - last_pos))


### PR DESCRIPTION
## Summary

- `CartesianController.step()` now calls `step_fn(q_new, qd_new)` instead of writing `data.qpos` directly
- Default (no step_fn) = kinematic mode: writes qpos + `mj_forward`
- Physics mode: callers pass `ctx.step_cartesian(arm_name, q, qd)` which coordinates all actuators
- Removed per-call `step_fn` from `move()`, `move_to()`, `move_until_contact()` — step function is construction-time only

## Bug

CartesianController bypassed SimContext — physics froze during Cartesian moves (retracts, teleop, move_until_touch). Same class of bug as the Vention base bypass fixed in #24.

## Principle

**Nothing that moves the robot during active execution should call `mj_forward` or write `data.qpos` directly — everything goes through `ctx.step()` or `ctx.execute()`.**

## Test plan

- [x] `uv run pytest tests/ -v` — 239 passed
- [x] `uv run python demos/cartesian_control.py` — all demos pass
- [x] Geodude recycling demo works in both kinematic and physics modes

Fixes #25