### PR TITLE
Surface planning failure reasons in BT nodes

### DIFF
--- a/src/mj_manipulator/bt/nodes.py
+++ b/src/mj_manipulator/bt/nodes.py
@@ -62,9 +62,12 @@ class PlanToTSRs(_ManipulationNode):
         timeout = self.bb.get(self._key("timeout"))
         try:
             result = arm.plan_to_tsrs(tsrs, timeout=timeout, return_details=True)
-        except Exception:
-            result = None
+        except Exception as e:
+            self.feedback_message = str(e)
+            return Status.FAILURE
         if result is None or not result.success:
+            reason = getattr(result, "failure_reason", None) if result else None
+            self.feedback_message = reason or "Planning failed"
             return Status.FAILURE
         self.bb.set(self._key("path"), result.path)
         self.bb.set(self._key("goal_tsr_index"), result.goal_index)
@@ -91,9 +94,11 @@ class PlanToConfig(_ManipulationNode):
         timeout = self.bb.get(self._key("timeout"))
         try:
             path = arm.plan_to_configuration(goal, timeout=timeout)
-        except Exception:
-            path = None
+        except Exception as e:
+            self.feedback_message = str(e)
+            return Status.FAILURE
         if path is None:
+            self.feedback_message = "Planning to configuration failed"
             return Status.FAILURE
         self.bb.set(self._key("path"), path)
         return Status.SUCCESS


### PR DESCRIPTION
## Summary

PlanToTSRs and PlanToConfig were silently swallowing exceptions with `except Exception: result = None`. Now they set `feedback_message` with the actual error, which the LLM sees via geodude's log capture system.

Examples of what the LLM now sees:
- `"All 100 goal configuration(s) invalid: 100 IK unreachable"`
- `"All 15 goal configuration(s) in collision: 15 in collision"`
- `"Timeout after 10.0s, 5000 iterations. Trees: start=2400 nodes, goal=1800 nodes. Trees could not connect."`

Depends on personalrobotics/pycbirrt#11 for `PlanResult.failure_reason`.

## Test plan

- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)