### PR TITLE
Add INFO logging and feedback_message for critical operations

### DIFF
--- a/src/mj_manipulator/arm.py
+++ b/src/mj_manipulator/arm.py
@@ -448,12 +448,17 @@ class Arm:
         """
         config = self._make_planner_config(timeout, planner_config)
         planner = self.create_planner(config)
-        return planner.plan(
+        path = planner.plan(
             start=self.get_joint_positions(),
             goal=q_goal,
             constraint_tsrs=constraint_tsrs,
             seed=seed,
         )
+        if path is not None:
+            logger.info("Plan to configuration succeeded: %d waypoints", len(path))
+        else:
+            logger.info("Plan to configuration failed")
+        return path
 
     def plan_to_configurations(
         self,
@@ -520,13 +525,26 @@ class Arm:
             )
         config = self._make_planner_config(timeout, planner_config)
         planner = self.create_planner(config)
-        return planner.plan(
+        result = planner.plan(
             start=self.get_joint_positions(),
             goal_tsrs=goal_tsrs,
             constraint_tsrs=constraint_tsrs,
             seed=seed,
             return_details=return_details,
         )
+        if return_details:
+            if result is not None and result.success:
+                logger.info(
+                    "Plan to TSRs succeeded: %d waypoints in %.1fs",
+                    len(result.path), result.planning_time,
+                )
+            elif result is not None:
+                logger.info("Plan to TSRs failed: %s", result.failure_reason or "unknown")
+            else:
+                logger.info("Plan to TSRs failed: no result")
+        elif result is None:
+            logger.info("Plan to TSRs failed")
+        return result
 
     def plan_to_pose(
         self,

--- a/src/mj_manipulator/bt/nodes.py
+++ b/src/mj_manipulator/bt/nodes.py
@@ -140,6 +140,8 @@ class Execute(_ManipulationNode):
         ctx = self.bb.get("/context")
         traj = self.bb.get(self._key("trajectory"))
         ok = ctx.execute(traj)
+        if not ok:
+            self.feedback_message = "Trajectory execution failed"
         return Status.SUCCESS if ok else Status.FAILURE
 
 
@@ -181,6 +183,8 @@ class Grasp(_ManipulationNode):
         self.bb.set(self._key("object_name"), obj)
         grasped = ctx.arm(arm_name).grasp(obj)
         self.bb.set(self._key("grasped"), grasped)
+        if not grasped:
+            self.feedback_message = f"Grasp failed: no contact with {obj or 'any object'}"
         return Status.SUCCESS if grasped else Status.FAILURE
 
 

--- a/src/mj_manipulator/sim_context.py
+++ b/src/mj_manipulator/sim_context.py
@@ -104,6 +104,12 @@ class SimArmController:
             self._arm.grasp_manager.attach_object(
                 grasped, gripper.attachment_body,
             )
+            logger.info("Grasped %s with %s arm", grasped, arm_name)
+        elif not grasped:
+            logger.info(
+                "Grasp failed: no object detected%s",
+                f" (target was {object_name})" if object_name else "",
+            )
 
         self._context.sync()
         return grasped


### PR DESCRIPTION
## Summary

Address HIGH-severity error reporting gaps from audit:

- `Arm.plan_to_tsrs()`: logs success (waypoints + time) and failure (reason from PlanResult)
- `Arm.plan_to_configuration()`: logs success/failure
- `SimContext.grasp()`: logs successful grasp (object + arm) and failure (with target)
- BT `Grasp` node: sets `feedback_message` on failure ("no contact with can_0")
- BT `Execute` node: sets `feedback_message` on failure

All at INFO level, captured by geodude's `_LogCapture` for LLM diagnostics.

## Test plan

- [x] Existing tests pass
- [ ] Manual: pickup failure shows diagnostics in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)