### PR TITLE
Show 'Aborted' feedback in PlanToConfig

### DIFF
--- a/src/mj_manipulator/bt/nodes.py
+++ b/src/mj_manipulator/bt/nodes.py
@@ -119,7 +119,10 @@ class PlanToConfig(_ManipulationNode):
             self.feedback_message = str(e)
             return Status.FAILURE
         if path is None:
-            self.feedback_message = "Planning to configuration failed"
+            if abort_fn is not None and abort_fn():
+                self.feedback_message = "Aborted"
+            else:
+                self.feedback_message = "Planning to configuration failed"
             return Status.FAILURE
         self.bb.set(self._key("path"), path)
         return Status.SUCCESS


### PR DESCRIPTION
## Summary
- PlanToConfig BT node now sets feedback_message to "Aborted" when abort_fn caused the failure, instead of generic "Planning to configuration failed"

## Test plan
- [x] 239 tests pass