### PR TITLE
Fix slow trajectory playback with wall-clock timing

### DIFF
--- a/src/mj_manipulator/executor.py
+++ b/src/mj_manipulator/executor.py
@@ -75,6 +75,7 @@ class KinematicExecutor:
                 f"joint count {len(self.joint_qpos_indices)}"
             )
 
+        t_start = time.time()
         for i in range(trajectory.num_waypoints):
             if self._abort_fn is not None and self._abort_fn():
                 logger.info("Trajectory aborted at waypoint %d/%d", i, trajectory.num_waypoints)
@@ -95,7 +96,10 @@ class KinematicExecutor:
                     self.viewer.sync()
                     self._last_viewer_sync = now
 
-            time.sleep(self.control_dt)
+            t_target = t_start + (i + 1) * self.control_dt
+            t_remaining = t_target - time.time()
+            if t_remaining > 0:
+                time.sleep(t_remaining)
 
         # Final state with zero velocity
         for joint_idx, qpos_idx in enumerate(self.joint_qpos_indices):

--- a/src/mj_manipulator/physics_controller.py
+++ b/src/mj_manipulator/physics_controller.py
@@ -326,8 +326,9 @@ class PhysicsController:
                 f"arm joint count {len(state.joint_qpos_indices)}"
             )
 
-        # Follow trajectory
-        sleep_dt = self.control_dt if self.viewer is not None else 0.0
+        # Follow trajectory at real-time rate
+        realtime = self.viewer is not None
+        t_start = time.time() if realtime else 0.0
         for i in range(trajectory.num_waypoints):
             if self._abort_fn is not None and self._abort_fn():
                 logger.info("Trajectory aborted at waypoint %d/%d", i, trajectory.num_waypoints)
@@ -337,8 +338,11 @@ class PhysicsController:
             state.target_position = trajectory.positions[i]
             state.target_velocity = trajectory.velocities[i]
             self.step()
-            if sleep_dt > 0:
-                time.sleep(sleep_dt)
+            if realtime:
+                t_target = t_start + (i + 1) * self.control_dt
+                t_remaining = t_target - time.time()
+                if t_remaining > 0:
+                    time.sleep(t_remaining)
 
         # Hold final position (zero velocity)
         state.target_position = trajectory.positions[-1].copy()
@@ -551,7 +555,8 @@ class PhysicsController:
                 f"entity joint count {len(state.joint_qpos_indices)}"
             )
 
-        sleep_dt = self.control_dt if self.viewer is not None else 0.0
+        realtime = self.viewer is not None
+        t_start = time.time() if realtime else 0.0
         for i in range(trajectory.num_waypoints):
             if self._abort_fn is not None and self._abort_fn():
                 logger.info("Entity trajectory aborted at waypoint %d/%d", i, trajectory.num_waypoints)
@@ -559,8 +564,11 @@ class PhysicsController:
             state.target_position = trajectory.positions[i]
             state.target_velocity = trajectory.velocities[i]
             self.step()
-            if sleep_dt > 0:
-                time.sleep(sleep_dt)
+            if realtime:
+                t_target = t_start + (i + 1) * self.control_dt
+                t_remaining = t_target - time.time()
+                if t_remaining > 0:
+                    time.sleep(t_remaining)
 
         state.target_position = trajectory.positions[-1].copy()
         state.target_velocity = np.zeros(len(state.actuator_ids))


### PR DESCRIPTION
## Summary
- KinematicExecutor, PhysicsController.execute(), and execute_entity() were sleeping a fixed `control_dt` per waypoint on top of physics/render time
- Now tracks wall-clock start time and sleeps only the remainder: `sleep(t_start + (i+1)*dt - now)`
- Trajectories play back at real-time rate regardless of render overhead

## Test plan
- [x] 239 tests pass
- [ ] Manual: trajectory motion in Viser viewer looks real-time speed