### PR TITLE
Add check_collisions() for interactive collision diagnosis

### DIFF
--- a/src/mj_manipulator/arm.py
+++ b/src/mj_manipulator/arm.py
@@ -383,6 +383,36 @@ class Arm:
     # Planning
     # -----------------------------------------------------------------
 
+    def check_collisions(self) -> list[tuple[str, str, float]]:
+        """Check current configuration for collisions.
+
+        Uses the same collision checker as the planner, including
+        grasp-aware filtering (gripper-to-held-object contacts are OK).
+
+        Returns:
+            List of (arm_body, other_body, penetration_mm) tuples.
+            Empty list if collision-free. Prints a summary.
+
+        Example::
+
+            robot.right.check_collisions()
+            # Right arm: 2 contacts
+            #   forearm_link <-> sugar_box_0: 2.3mm
+            #   gripper/pad <-> table: 0.8mm
+        """
+        planner = self.create_planner()
+        contacts = planner.collision.get_contacts(self.get_joint_positions())
+        if contacts:
+            print(f"{self.config.name} arm: {len(contacts)} contact(s)")
+            for arm_body, other, depth in contacts:
+                # Shorten body names for readability
+                arm_short = arm_body.split("/", 1)[-1] if "/" in arm_body else arm_body
+                other_short = other.split("/", 1)[-1] if "/" in other else other
+                print(f"  {arm_short} <-> {other_short}: {depth:.1f}mm")
+        else:
+            print(f"{self.config.name} arm: collision-free")
+        return contacts
+
     def create_planner(
         self,
         config: CBiRRTConfig | None = None,

--- a/src/mj_manipulator/collision.py
+++ b/src/mj_manipulator/collision.py
@@ -119,6 +119,51 @@ class CollisionChecker:
 
         return self._count_invalid_contacts(data) == 0
 
+    def get_contacts(self, q: np.ndarray) -> list[tuple[str, str, float]]:
+        """Return all invalid contacts for a configuration.
+
+        Args:
+            q: Joint configuration (only the controlled joints).
+
+        Returns:
+            List of (arm_body_name, other_body_name, penetration_mm) tuples
+            for each invalid contact. Empty if collision-free.
+        """
+        data = self._prepare_data(q)
+        self._update_attached_poses(data)
+        mujoco.mj_forward(self.model, data)
+
+        contacts = []
+        for body1, body2, contact in iter_contacts(self.model, data):
+            body1_name = mujoco.mj_id2name(self.model, mujoco.mjtObj.mjOBJ_BODY, body1) or str(body1)
+            body2_name = mujoco.mj_id2name(self.model, mujoco.mjtObj.mjOBJ_BODY, body2) or str(body2)
+
+            body1_is_arm = body1 in self._arm_body_ids
+            body2_is_arm = body2 in self._arm_body_ids
+            body1_is_grasped = body1_name is not None and self._is_grasped(body1_name)
+            body2_is_grasped = body2_name is not None and self._is_grasped(body2_name)
+
+            body1_is_robot = body1_is_arm or body1_is_grasped
+            body2_is_robot = body2_is_arm or body2_is_grasped
+
+            if not body1_is_robot and not body2_is_robot:
+                continue
+
+            if body1_is_robot and body2_is_robot:
+                if self._is_gripper_object_contact(
+                    body1, body1_name, body1_is_arm, body1_is_grasped,
+                    body2, body2_name, body2_is_arm, body2_is_grasped,
+                ):
+                    continue
+                contacts.append((body1_name, body2_name, -contact.dist * 1000))
+                continue
+
+            arm_name = body1_name if body1_is_robot else body2_name
+            env_name = body2_name if body1_is_robot else body1_name
+            contacts.append((arm_name, env_name, -contact.dist * 1000))
+
+        return contacts
+
     def is_valid_batch(self, qs: np.ndarray) -> np.ndarray:
         """Check multiple configurations for collisions."""
         results = np.zeros(len(qs), dtype=bool)


### PR DESCRIPTION
## Summary
- `CollisionChecker.get_contacts(q)` — returns `[(arm_body, other_body, penetration_mm)]` for all invalid contacts
- `Arm.check_collisions()` — convenience method, prints human-readable summary

```python
robot.right.check_collisions()
# right arm: 2 contact(s)
#   forearm_link <-> sugar_box_0: 2.3mm
#   gripper/pad <-> table: 0.8mm
```

Uses the same collision checker as the planner (grasp-aware: gripper-to-held-object contacts filtered).

## Test plan
- [x] 239 tests pass
- [ ] Manual: call from IPython console during debugging