### PR TITLE
Per-arm teleop deactivation for bimanual control

### DIFF
--- a/src/mj_manipulator/event_loop.py
+++ b/src/mj_manipulator/event_loop.py
@@ -62,6 +62,7 @@ class PhysicsEventLoop:
         self._teleop_lock = threading.Lock()  # protects _teleop_entries
         self._idle_step_fn: Callable[[], None] | None = None
         self._viewer_sync_fn: Callable[[], None] | None = None
+        self._executing_entity: str | None = None  # arm currently in execute()
 
     # -- Public API (any thread) ---------------------------------------------
 
@@ -100,19 +101,42 @@ class PhysicsEventLoop:
         with self._teleop_lock:
             self._teleop_entries = [(c, p) for c, p in self._teleop_entries if c is not controller]
 
-    def _deactivate_all_teleop(self) -> None:
-        """Deactivate all teleop controllers and reset their panels."""
+    def is_executing(self, entity: str | None = None) -> bool:
+        """Check if an entity is currently executing a trajectory.
+
+        Args:
+            entity: Arm name to check, or None to check if anything is executing.
+        """
+        if entity is None:
+            return self._executing_entity is not None
+        return self._executing_entity == entity
+
+    def deactivate_teleop(self, entity: str | None = None) -> None:
+        """Deactivate teleop controllers and reset their panels.
+
+        Args:
+            entity: Arm/entity name to deactivate (e.g. "left", "right").
+                If None, deactivates all controllers.
+        """
         with self._teleop_lock:
-            entries = list(self._teleop_entries)
-            self._teleop_entries.clear()
-        for controller, panel in entries:
+            if entity is None:
+                to_deactivate = list(self._teleop_entries)
+                self._teleop_entries.clear()
+            else:
+                to_deactivate = [
+                    (c, p) for c, p in self._teleop_entries if c._arm.config.name == entity
+                ]
+                self._teleop_entries = [
+                    (c, p) for c, p in self._teleop_entries if c._arm.config.name != entity
+                ]
+        for controller, panel in to_deactivate:
             try:
                 controller.deactivate()
             except Exception:
                 pass
             if panel is not None:
                 try:
-                    panel._on_teleop_error()  # resets gizmo/button/status
+                    panel._on_teleop_error()
                 except Exception:
                     pass
 
@@ -136,7 +160,7 @@ class PhysicsEventLoop:
         else:
             # Deactivate all teleop controllers before running a command —
             # the command (trajectory, grasp, etc.) needs exclusive control.
-            self._deactivate_all_teleop()
+            self.deactivate_teleop()
             try:
                 result = cmd.fn()
                 cmd.future.set_result(result)

--- a/src/mj_manipulator/sim_context.py
+++ b/src/mj_manipulator/sim_context.py
@@ -297,7 +297,16 @@ class SimContext:
             True if execution completed successfully.
         """
         if self._event_loop is not None:
-            self._event_loop._deactivate_all_teleop()
+            # Deactivate teleop only on the arms this execution will use.
+            from mj_manipulator.planning import PlanResult
+            from mj_manipulator.trajectory import Trajectory
+
+            if isinstance(item, PlanResult):
+                for traj in item.trajectories:
+                    if traj.entity is not None:
+                        self._event_loop.deactivate_teleop(traj.entity)
+            elif isinstance(item, Trajectory) and item.entity is not None:
+                self._event_loop.deactivate_teleop(item.entity)
             return self._event_loop.run_on_physics_thread(lambda: self._execute_impl(item))
         return self._execute_impl(item)
 
@@ -310,11 +319,23 @@ class SimContext:
             for traj in item.trajectories:
                 if self._abort_fn is not None and self._abort_fn():
                     return False
+                if self._event_loop is not None and traj.entity is not None:
+                    self._event_loop._executing_entity = traj.entity
                 if not self._execute_trajectory(traj):
+                    if self._event_loop is not None:
+                        self._event_loop._executing_entity = None
                     return False
+            if self._event_loop is not None:
+                self._event_loop._executing_entity = None
             return True
         elif isinstance(item, Trajectory):
-            return self._execute_trajectory(item)
+            if self._event_loop is not None and item.entity is not None:
+                self._event_loop._executing_entity = item.entity
+            try:
+                return self._execute_trajectory(item)
+            finally:
+                if self._event_loop is not None:
+                    self._event_loop._executing_entity = None
         else:
             raise TypeError(f"Cannot execute {type(item)}")
 


### PR DESCRIPTION
## Summary
Teleop deactivation is now per-arm, not global. You can teleop one arm while the other executes a trajectory.

## Changes
- `deactivate_teleop(entity)` replaces `_deactivate_all_teleop()` — only deactivates controllers for the specified arm
- `execute()` passes `trajectory.entity` so only the executing arm's teleop is deactivated
- `_executing_entity` tracks which arm is currently in execute() — TeleopPanel checks this to decide whether to abort
- `is_executing(entity)` public method for TeleopPanel to query

## Testing
- [x] 262 tests pass
- [ ] Manual: teleop right arm while left arm picks up an object

## Related
Refinement of #51 (already closed). Merge before mj_viser companion PR.