### PR TITLE
Working demos: PrlAssetsGraspSource + CLI with objects

### DIFF
--- a/src/mj_manipulator/__init__.py
+++ b/src/mj_manipulator/__init__.py
@@ -46,7 +46,7 @@ from mj_manipulator.protocols import (
     Gripper,
     IKSolver,
 )
-from mj_manipulator.robot import ManipulationRobot
+from mj_manipulator.robot import ManipulationRobot, RobotBase
 from mj_manipulator.sim_context import SimArmController, SimContext
 from mj_manipulator.trajectory import Trajectory, create_linear_trajectory
 
@@ -80,8 +80,9 @@ __all__ = [
     # Physics controller (simulation)
     "PhysicsController",
     "ArmPhysicsExecutor",
-    # Robot protocol
+    # Robot protocol and base class
     "ManipulationRobot",
+    "RobotBase",
     # Simulation context
     "SimContext",
     "SimArmController",

--- a/src/mj_manipulator/bt/nodes.py
+++ b/src/mj_manipulator/bt/nodes.py
@@ -269,7 +269,7 @@ class CartesianMove(_ManipulationNode):
             ctx.step_cartesian(arm_name, q, qd)
 
         ctrl = CartesianController.from_arm(arm, step_fn=step_fn)
-        ctrl.move(twist, dt=0.004, max_distance=distance, stop_condition=abort_fn)
+        ctrl.move(twist, dt=ctx.control_dt, max_distance=distance, stop_condition=abort_fn)
         return Status.SUCCESS
 
 

--- a/src/mj_manipulator/bt/subtrees.py
+++ b/src/mj_manipulator/bt/subtrees.py
@@ -69,7 +69,7 @@ def pickup(ns: str) -> py_trees.composites.Sequence:
     set_distance = py_trees.behaviours.SetBlackboardVariable(
         name="set_lift_distance",
         variable_name=f"{ns}/distance",
-        variable_value=0.05,
+        variable_value=0.15,
         overwrite=True,
     )
 

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -286,7 +286,7 @@ def _scatter_objects(env, objects: dict):
         geo = gp.get("type")
         if geo in ("open_box", "tote"):
             # Place container to the side
-            env.registry.activate(obj_type, pos=[-0.3, 0.0, 0.12])
+            env.registry.activate(obj_type, pos=[-0.5, 0.0, 0.0])
             mujoco.mj_forward(env.model, env.data)
             continue
 

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -149,16 +149,20 @@ def _setup_franka(objects):
     if objects:
         from prl_assets import OBJECTS_DIR
 
-        # Add a table for objects to sit on
-        table = spec.worldbody.add_body()
-        table.name = "table"
-        table.pos = [0.45, 0.0, 0.23]
-        g = table.add_geom()
+        # Flat plate on the ground in front of the robot for objects
+        plate = spec.worldbody.add_body()
+        plate.name = "plate"
+        plate.pos = [0.5, 0.0, 0.005]
+        g = plate.add_geom()
         g.type = mujoco.mjtGeom.mjGEOM_BOX
-        g.size = [0.15, 0.15, 0.23]
-        g.rgba = [0.4, 0.3, 0.2, 1.0]
+        g.size = [0.15, 0.15, 0.005]
+        g.rgba = [0.6, 0.6, 0.6, 1.0]
 
-        env = Environment.from_spec(spec, objects_dir=str(OBJECTS_DIR), scene_config=objects)
+        # Add yellow_tote to the scene config for recycling
+        scene_config = dict(objects)
+        scene_config["yellow_tote"] = 1
+
+        env = Environment.from_spec(spec, objects_dir=str(OBJECTS_DIR), scene_config=scene_config)
     else:
         model = spec.compile()
         env = Environment.from_model(model)
@@ -183,7 +187,7 @@ def _setup_franka(objects):
 
 
 def _scatter_objects(env, objects: dict):
-    """Activate objects and place them on a table in front of the robot."""
+    """Activate and scatter objects on the plate, position tote to the side."""
     import mujoco
     import numpy as np
     from asset_manager import AssetManager
@@ -192,21 +196,33 @@ def _scatter_objects(env, objects: dict):
 
     assets = AssetManager(str(OBJECTS_DIR))
 
-    # Table: 30x30cm, 46cm tall, centered at (0.45, 0, 0.46)
-    table_surface = np.eye(4)
-    table_surface[:3, 3] = [0.45, 0.0, 0.46]
+    # Plate surface: ground level in front of robot
+    plate_surface = np.eye(4)
+    plate_surface[:3, 3] = [0.5, 0.0, 0.01]
     placer = StablePlacer(0.12, 0.12)
 
     placed_positions = []
     for obj_type, count in objects.items():
-        if isinstance(count, dict):
+        if isinstance(count, int):
+            pass
+        elif isinstance(count, dict):
             count = count.get("count", 1)
+        else:
+            continue
+
+        # Position tote to the side, not on the plate
         try:
             gp = assets.get(obj_type)["geometric_properties"]
         except (KeyError, TypeError):
             continue
 
         geo = gp.get("type")
+        if geo in ("open_box", "tote"):
+            # Place container to the side
+            env.registry.activate(obj_type, pos=[0.3, -0.5, 0.0])
+            mujoco.mj_forward(env.model, env.data)
+            continue
+
         if geo == "cylinder":
             templates = placer.place_cylinder(gp["radius"], gp["height"])
         elif geo == "box":
@@ -218,19 +234,16 @@ def _scatter_objects(env, objects: dict):
             continue
 
         for _ in range(count):
-            tsr = templates[0].instantiate(table_surface)
-            # Sample a non-colliding position
+            tsr = templates[0].instantiate(plate_surface)
             for _attempt in range(50):
                 T = tsr.sample()
                 pos = T[:3, 3]
-                min_sep = 0.06
-                if all(np.linalg.norm(pos[:2] - np.array(p[:2])) > min_sep for p in placed_positions):
+                if all(np.linalg.norm(pos[:2] - np.array(p[:2])) > 0.06 for p in placed_positions):
                     break
 
             name = env.registry.activate(obj_type, pos=list(pos))
             placed_positions.append(list(pos))
 
-            # Apply full pose (includes randomized yaw)
             body_id = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_BODY, name)
             jnt_id = env.model.body_jntadr[body_id]
             qpos_adr = env.model.jnt_qposadr[jnt_id]

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -47,6 +47,34 @@ def main() -> None:
 
     robot = _setup_robot(args.robot, objects)
 
+    def commands():
+        """Print available commands."""
+        print(
+            """
+Quick Reference
+===============
+
+Actions:
+  pickup()                — pick up nearest reachable object
+  pickup("can_0")         — pick up specific object
+  place("yellow_tote")    — place in recycling bin
+  place("worktop")        — place on table surface
+  go_home()               — return arm to ready
+
+Arm:
+  robot.arms["ur5e"].get_ee_pose()   — end-effector 4x4 pose
+  robot.arms["ur5e"].get_joint_positions()
+
+Teleop:
+  Click "Activate" in the viser viewer
+
+IPython:
+  robot.<tab>             — tab completion
+  ?pickup                 — docstring
+  commands()              — this help
+"""
+        )
+
     from mj_manipulator.console import start_console
 
     start_console(
@@ -54,6 +82,7 @@ def main() -> None:
         physics=args.physics,
         viser=not args.no_viser,
         robot_name=args.robot.upper(),
+        extra_ns={"commands": commands},
     )
 
 
@@ -272,11 +301,11 @@ def _setup_franka(scene_path, objects):
 
 
 def _attach_prl_objects(spec, objects: dict):
-    """Attach prl_assets objects to the scene."""
+    """Attach prl_assets objects + table + recycling bin to the scene."""
     import mujoco
     from prl_assets import OBJECTS_DIR
 
-    # Simple table
+    # Table
     table = spec.worldbody.add_body()
     table.name = "table"
     table.pos = [0.45, -0.20, 0.23]
@@ -285,11 +314,30 @@ def _attach_prl_objects(spec, objects: dict):
     g.size = [0.15, 0.15, 0.23]
     g.rgba = [0.4, 0.3, 0.2, 1.0]
 
+    # Worktop site on the table surface (for surface placement)
+    s = table.add_site()
+    s.name = "worktop"
+    s.pos = [0, 0, 0.23]  # top of the table
+    s.size = [0.12, 0.12, 0.001]
+    s.type = mujoco.mjtGeom.mjGEOM_BOX
+    s.rgba = [0, 0, 0, 0]  # invisible
+
+    # Recycling bin on the floor
+    from asset_manager import AssetManager
+
+    assets = AssetManager(str(OBJECTS_DIR))
+    try:
+        bin_xml = assets.get_path("yellow_tote", "mujoco")
+        bin_spec = mujoco.MjSpec.from_file(bin_xml)
+        f = spec.worldbody.add_frame()
+        f.pos = [0.25, -0.70, 0.0]
+        f.attach_body(bin_spec.worldbody.first_body(), prefix="yellow_tote_0/")
+    except (KeyError, TypeError):
+        pass  # no tote model available
+
+    # Attach objects on the table
     idx = 0
     for obj_type, count in objects.items():
-        from asset_manager import AssetManager
-
-        assets = AssetManager(str(OBJECTS_DIR))
         try:
             xml_path = assets.get_path(obj_type, "mujoco")
         except (KeyError, TypeError):
@@ -297,7 +345,6 @@ def _attach_prl_objects(spec, objects: dict):
         for i in range(count):
             obj_spec = mujoco.MjSpec.from_file(xml_path)
             f = spec.worldbody.add_frame()
-            # Spread objects on the table
             x = 0.40 + (idx % 3) * 0.05
             y = -0.25 + (idx // 3) * 0.05
             f.pos = [x, y, 0.46 + 0.05]

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -155,7 +155,7 @@ def _setup_franka(objects):
         plate.pos = [0.5, 0.0, 0.005]
         g = plate.add_geom()
         g.type = mujoco.mjtGeom.mjGEOM_BOX
-        g.size = [0.15, 0.15, 0.005]
+        g.size = [0.30, 0.30, 0.005]
         g.rgba = [0.6, 0.6, 0.6, 1.0]
 
         # Add yellow_tote to the scene config for recycling
@@ -199,7 +199,7 @@ def _scatter_objects(env, objects: dict):
     # Plate surface: ground level in front of robot
     plate_surface = np.eye(4)
     plate_surface[:3, 3] = [0.5, 0.0, 0.01]
-    placer = StablePlacer(0.12, 0.12)
+    placer = StablePlacer(0.25, 0.25)
 
     placed_positions = []
     for obj_type, count in objects.items():
@@ -219,7 +219,7 @@ def _scatter_objects(env, objects: dict):
         geo = gp.get("type")
         if geo in ("open_box", "tote"):
             # Place container to the side
-            env.registry.activate(obj_type, pos=[0.3, -0.5, 0.0])
+            env.registry.activate(obj_type, pos=[-0.3, 0.0, 0.0])
             mujoco.mj_forward(env.model, env.data)
             continue
 

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import argparse
 import sys
 
+from mj_manipulator.robot import RobotBase
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(
@@ -119,29 +121,26 @@ def _setup_robot(robot_type: str, objects: dict):
     return robot
 
 
-class _SimpleRobot:
-    """Minimal ManipulationRobot for single-arm use with the generic console.
+class _SimpleRobot(RobotBase):
+    """Minimal robot for the CLI demo. Inherits all convenience methods
+    from RobotBase (pickup, place, go_home, find_objects, etc.).
 
-    This is the reference implementation showing how little code is needed
-    to bring up a new robot with the full console experience.
+    This is the reference implementation — ~20 LOC on top of RobotBase.
     """
 
     def __init__(self, env, arm, home_config, has_objects=False):
-        import threading
-
-        self.model = env.model
-        self.data = env.data
-        self._env = env
-        self._arm = arm
-        self.arms = {arm.config.name: arm}
         from mj_manipulator.grasp_manager import GraspManager as _GM
 
-        self.grasp_manager = arm.grasp_manager or _GM(self.model, self.data)
-        self.named_poses = {"ready": {arm.config.name: list(home_config)}}
+        gm = arm.grasp_manager or _GM(env.model, env.data)
+        super().__init__(
+            model=env.model,
+            data=env.data,
+            arms={arm.config.name: arm},
+            grasp_manager=gm,
+            named_poses={"ready": {arm.config.name: list(home_config)}},
+        )
+        self._env = env
         self._has_objects = has_objects
-        self._grasp_source = None
-        self._context = None
-        self._abort_event = threading.Event()
 
     @property
     def grasp_source(self):
@@ -157,122 +156,7 @@ class _SimpleRobot:
                     self.arms,
                     registry=registry,
                 )
-            else:
-                self._grasp_source = _NullGraspSource()
-        return self._grasp_source
-
-    def pickup(self, target=None, **kwargs):
-        """Pick up an object."""
-        from mj_manipulator.primitives import pickup
-
-        return pickup(self, target, **kwargs)
-
-    def place(self, destination=None, **kwargs):
-        """Place the held object."""
-        from mj_manipulator.primitives import place
-
-        return place(self, destination, **kwargs)
-
-    def go_home(self, **kwargs):
-        """Return to ready configuration."""
-        from mj_manipulator.primitives import go_home
-
-        return go_home(self, **kwargs)
-
-    def find_objects(self, target=None):
-        """List graspable objects in the scene."""
-        if target:
-            return [o for o in self.grasp_source.get_graspable_objects() if target in o]
-        return self.grasp_source.get_graspable_objects()
-
-    def holding(self):
-        """Get (arm_name, object_name) if holding, else None."""
-        for arm_name, arm in self.arms.items():
-            if arm.gripper and arm.gripper.is_holding and arm.gripper.held_object:
-                return (arm_name, arm.gripper.held_object)
-        return None
-
-    def get_object_pose(self, body_name):
-        """Get 4x4 world-frame pose of a body."""
-        import mujoco as mj
-        import numpy as np
-
-        bid = mj.mj_name2id(self.model, mj.mjtObj.mjOBJ_BODY, body_name)
-        if bid < 0:
-            raise ValueError(f"Body not found: {body_name}")
-        pose = np.eye(4)
-        pose[:3, :3] = self.data.xmat[bid].reshape(3, 3)
-        pose[:3, 3] = self.data.xpos[bid]
-        return pose
-
-    @property
-    def _active_context(self):
-        return self._context
-
-    @_active_context.setter
-    def _active_context(self, ctx):
-        self._context = ctx
-
-    def sim(self, *, physics=True, headless=False, viewer=None, event_loop=None):
-        from mj_manipulator.sim_context import SimContext
-
-        inner = SimContext(
-            self.model,
-            self.data,
-            self.arms,
-            physics=physics,
-            headless=headless,
-            viewer=viewer,
-            event_loop=event_loop,
-            abort_fn=self.is_abort_requested,
-        )
-        return _SimContextWrapper(inner, self)
-
-    def request_abort(self):
-        if self._context is not None and hasattr(self._context, "ownership") and self._context.ownership is not None:
-            self._context.ownership.abort_all()
-        self._abort_event.set()
-
-    def clear_abort(self):
-        if self._context is not None and hasattr(self._context, "ownership") and self._context.ownership is not None:
-            self._context.ownership.clear_all()
-        self._abort_event.clear()
-
-    def is_abort_requested(self):
-        return self._abort_event.is_set()
-
-
-class _SimContextWrapper:
-    """Sets robot._active_context on enter/exit."""
-
-    def __init__(self, inner, robot):
-        self._inner = inner
-        self._robot = robot
-
-    def __enter__(self):
-        ctx = self._inner.__enter__()
-        self._robot._active_context = ctx
-        return ctx
-
-    def __exit__(self, *args):
-        self._robot._active_context = None
-        return self._inner.__exit__(*args)
-
-
-class _NullGraspSource:
-    """GraspSource that returns empty results (no objects to grasp)."""
-
-    def get_grasps(self, object_name, hand_type):
-        return []
-
-    def get_placements(self, destination, object_name):
-        return []
-
-    def get_graspable_objects(self):
-        return []
-
-    def get_place_destinations(self, object_name):
-        return []
+        return super().grasp_source
 
 
 def _setup_ur5e(scene_path, objects):

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -113,45 +113,47 @@ class _SimpleRobot(RobotBase):
         self._objects_config = None  # set externally after creation
 
     def reset(self):
-        """Reset scene: release objects, return arm home, re-scatter."""
+        """Reset scene to initial state, then re-scatter objects.
+
+        Same pattern as geodude: mj_resetData → hold controller → release
+        grasps → hide objects → re-scatter.
+        """
         import mujoco
 
         self.request_abort()
         self.clear_abort()
 
-        # Release any held objects
-        for arm_name, arm in self.arms.items():
-            if arm.gripper and arm.gripper.is_holding:
-                if self._context is not None:
-                    self._context.arm(arm_name).release()
+        # Reset MuJoCo state (qpos, qvel, ctrl all to defaults)
+        mujoco.mj_resetData(self.model, self.data)
 
-        # Clear grasp manager state
+        # Restore arm to home (model defaults may not be the right config)
+        ready = self.named_poses.get("ready", {})
+        for arm_name, arm in self.arms.items():
+            if arm_name in ready:
+                for i, idx in enumerate(arm.joint_qpos_indices):
+                    self.data.qpos[idx] = ready[arm_name][i]
+            if arm.gripper and arm.gripper.actuator_id is not None:
+                self.data.ctrl[arm.gripper.actuator_id] = arm.gripper.ctrl_open
+
+        # Sync controller targets to new positions
+        if self._context is not None:
+            self._context.hold()
+
+        # Release grasps
         for arm_name in list(self.arms.keys()):
             for obj in list(self.grasp_manager.get_grasped_by(arm_name)):
                 self.grasp_manager.mark_released(obj)
                 self.grasp_manager.detach_object(obj)
 
-        # Hide all objects
+        # Hide all objects, then re-scatter
         if self._env.registry is not None:
             for obj_type in list(self._env.registry.objects.keys()):
                 for name in list(self._env.registry.objects[obj_type]["instances"]):
                     if self._env.registry.is_active(name):
                         self._env.registry.hide(name)
 
-        # Reset arm to home
-        ready = self.named_poses.get("ready", {})
-        for arm_name, arm in self.arms.items():
-            if arm_name in ready:
-                for i, idx in enumerate(arm.joint_qpos_indices):
-                    self.data.qpos[idx] = ready[arm_name][i]
-            if arm.gripper:
-                arm.gripper.kinematic_open()
-                if arm.gripper.actuator_id is not None:
-                    self.data.ctrl[arm.gripper.actuator_id] = arm.gripper.ctrl_open
-
         mujoco.mj_forward(self.model, self.data)
 
-        # Re-scatter objects
         if self._objects_config and self._env.registry is not None:
             all_objects = dict(self._objects_config)
             all_objects["yellow_tote"] = 1
@@ -159,8 +161,6 @@ class _SimpleRobot(RobotBase):
 
         if self._context is not None:
             self._context.sync()
-            if hasattr(self._context, "hold"):
-                self._context.hold()
 
         print("Scene reset.")
 

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -159,12 +159,16 @@ class _SimpleRobot(RobotBase):
         return super().grasp_source
 
 
-def _save_robot_xml(spec) -> str:
-    """Save assembled robot MjSpec to a temp file for Environment."""
+def _save_robot_xml(spec, source_dir: str) -> str:
+    """Save assembled robot MjSpec to a temp file in the source directory.
+
+    Must be in the same directory as the original scene XML so that
+    relative mesh/texture paths resolve correctly.
+    """
     import tempfile
 
     xml_str = spec.to_xml()
-    f = tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False)
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False, dir=source_dir)
     f.write(xml_str)
     f.close()
     return f.name
@@ -206,7 +210,7 @@ def _setup_ur5e(scene_path, objects):
 
     # Save assembled robot XML, then use Environment to add objects
     # (Environment handles body naming, registry, and object lifecycle)
-    robot_xml = _save_robot_xml(spec)
+    robot_xml = _save_robot_xml(spec, str(scene_path.parent))
 
     if objects:
         scene_config = _create_scene_config(objects)
@@ -243,7 +247,7 @@ def _setup_franka(scene_path, objects):
     spec = mujoco.MjSpec.from_file(str(scene_path))
     add_franka_ee_site(spec)
 
-    robot_xml = _save_robot_xml(spec)
+    robot_xml = _save_robot_xml(spec, str(scene_path.parent))
 
     if objects:
         scene_config = _create_scene_config(objects)

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -157,6 +157,13 @@ def _setup_franka(objects):
         g.type = mujoco.mjtGeom.mjGEOM_BOX
         g.size = [0.30, 0.30, 0.005]
         g.rgba = [0.6, 0.6, 0.6, 1.0]
+        # Worktop site on plate surface — enables robot.place("worktop")
+        s = plate.add_site()
+        s.name = "worktop"
+        s.pos = [0, 0, 0.005]
+        s.size = [0.25, 0.25, 0.001]
+        s.type = mujoco.mjtGeom.mjGEOM_BOX
+        s.rgba = [0, 0, 0, 0]
 
         # Add yellow_tote to the scene config for recycling
         scene_config = dict(objects)

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -286,7 +286,7 @@ def _scatter_objects(env, objects: dict):
         geo = gp.get("type")
         if geo in ("open_box", "tote"):
             # Place container to the side
-            env.registry.activate(obj_type, pos=[-0.3, 0.0, 0.15])
+            env.registry.activate(obj_type, pos=[-0.3, 0.0, 0.0])
             mujoco.mj_forward(env.model, env.data)
             continue
 

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -179,9 +179,11 @@ def _setup_franka(objects):
         env.data.qpos[idx] = FRANKA_HOME[i]
     mujoco.mj_forward(env.model, env.data)
 
-    # Activate and scatter objects on a table in front of the robot
+    # Activate and scatter objects (include tote from scene_config)
     if objects and env.registry is not None:
-        _scatter_objects(env, objects)
+        all_objects = dict(objects)
+        all_objects["yellow_tote"] = 1
+        _scatter_objects(env, all_objects)
 
     return _SimpleRobot(env, arm, FRANKA_HOME, has_objects=bool(objects))
 

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -159,19 +159,43 @@ class _SimpleRobot(RobotBase):
         return super().grasp_source
 
 
+def _save_robot_xml(spec) -> str:
+    """Save assembled robot MjSpec to a temp file for Environment."""
+    import tempfile
+
+    xml_str = spec.to_xml()
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False)
+    f.write(xml_str)
+    f.close()
+    return f.name
+
+
+def _create_scene_config(objects: dict) -> str:
+    """Create a temp scene_config.yaml from objects dict."""
+    import tempfile
+
+    import yaml
+
+    config = {"objects": {obj_type: {"count": count} for obj_type, count in objects.items()}}
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+    yaml.dump(config, f)
+    f.close()
+    return f.name
+
+
 def _setup_ur5e(scene_path, objects):
     """Set up UR5e + Robotiq."""
     import geodude_assets
     import mujoco
     from mj_environment import Environment
+    from prl_assets import OBJECTS_DIR
 
     from mj_manipulator.arms.ur5e import UR5E_HOME, UR5E_ROBOTIQ_EE_SITE, create_ur5e_arm
     from mj_manipulator.grasp_manager import GraspManager
     from mj_manipulator.grippers.robotiq import RobotiqGripper
 
+    # Assemble robot: UR5e + Robotiq gripper
     spec = mujoco.MjSpec.from_file(str(scene_path))
-
-    # Attach Robotiq gripper
     robotiq_path = geodude_assets.MODELS_DIR / "robotiq_2f140" / "2f140.xml"
     robotiq_spec = mujoco.MjSpec.from_file(str(robotiq_path))
     wrist = spec.worldbody.find_child("wrist_3_link")
@@ -180,16 +204,21 @@ def _setup_ur5e(scene_path, objects):
     frame.quat = [-1, 1, 0, 0]
     frame.attach_body(robotiq_spec.worldbody.first_body(), prefix="gripper/")
 
-    # Add objects if specified
+    # Save assembled robot XML, then use Environment to add objects
+    # (Environment handles body naming, registry, and object lifecycle)
+    robot_xml = _save_robot_xml(spec)
+
     if objects:
-        _attach_prl_objects(spec, objects)
+        scene_config = _create_scene_config(objects)
+        env = Environment(
+            base_scene_xml=robot_xml,
+            objects_dir=str(OBJECTS_DIR),
+            scene_config_yaml=scene_config,
+        )
+    else:
+        env = Environment(base_scene_xml=robot_xml)
 
-    model = spec.compile()
-    data = mujoco.MjData(model)
-    mujoco.mj_forward(model, data)
-    env = Environment.from_model(model, data)
     gm = GraspManager(env.model, env.data)
-
     gripper = RobotiqGripper(env.model, env.data, "ur5e", prefix="gripper/", grasp_manager=gm)
     arm = create_ur5e_arm(env, ee_site=UR5E_ROBOTIQ_EE_SITE, gripper=gripper, grasp_manager=gm)
 
@@ -204,23 +233,29 @@ def _setup_franka(scene_path, objects):
     """Set up Franka Panda."""
     import mujoco
     from mj_environment import Environment
+    from prl_assets import OBJECTS_DIR
 
     from mj_manipulator.arms.franka import FRANKA_HOME, add_franka_ee_site, create_franka_arm
     from mj_manipulator.grasp_manager import GraspManager
     from mj_manipulator.grippers.franka import FrankaGripper
 
+    # Assemble robot: Franka + EE site
     spec = mujoco.MjSpec.from_file(str(scene_path))
     add_franka_ee_site(spec)
 
+    robot_xml = _save_robot_xml(spec)
+
     if objects:
-        _attach_prl_objects(spec, objects)
+        scene_config = _create_scene_config(objects)
+        env = Environment(
+            base_scene_xml=robot_xml,
+            objects_dir=str(OBJECTS_DIR),
+            scene_config_yaml=scene_config,
+        )
+    else:
+        env = Environment(base_scene_xml=robot_xml)
 
-    model = spec.compile()
-    data = mujoco.MjData(model)
-    mujoco.mj_forward(model, data)
-    env = Environment.from_model(model, data)
     gm = GraspManager(env.model, env.data)
-
     gripper = FrankaGripper(env.model, env.data, "franka", grasp_manager=gm)
     arm = create_franka_arm(env, gripper=gripper, grasp_manager=gm)
 

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -185,10 +185,6 @@ def _setup_franka(objects):
         all_objects["yellow_tote"] = 1
         _scatter_objects(env, all_objects)
 
-        # Settle physics so objects aren't bouncing when the console starts
-        for _ in range(500):
-            mujoco.mj_step(env.model, env.data)
-
     return _SimpleRobot(env, arm, FRANKA_HOME, has_objects=bool(objects))
 
 

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -185,6 +185,10 @@ def _setup_franka(objects):
         all_objects["yellow_tote"] = 1
         _scatter_objects(env, all_objects)
 
+        # Settle physics so objects aren't bouncing when the console starts
+        for _ in range(500):
+            mujoco.mj_step(env.model, env.data)
+
     return _SimpleRobot(env, arm, FRANKA_HOME, has_objects=bool(objects))
 
 

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -90,7 +90,7 @@ class _SimpleRobot:
     to bring up a new robot with the full console experience.
     """
 
-    def __init__(self, env, arm, home_config, grasp_source=None):
+    def __init__(self, env, arm, home_config, has_objects=False):
         import threading
 
         self.model = env.model
@@ -102,14 +102,27 @@ class _SimpleRobot:
 
         self.grasp_manager = arm.grasp_manager or _GM(self.model, self.data)
         self.named_poses = {"ready": {arm.config.name: list(home_config)}}
-        self._grasp_source = grasp_source
+        self._has_objects = has_objects
+        self._grasp_source = None
         self._context = None
         self._abort_event = threading.Event()
 
     @property
     def grasp_source(self):
         if self._grasp_source is None:
-            self._grasp_source = _NullGraspSource()
+            if self._has_objects:
+                from mj_manipulator.grasp_sources.prl_assets import PrlAssetsGraspSource
+
+                registry = getattr(self._env, "registry", None)
+                self._grasp_source = PrlAssetsGraspSource(
+                    self.model,
+                    self.data,
+                    self.grasp_manager,
+                    self.arms,
+                    registry=registry,
+                )
+            else:
+                self._grasp_source = _NullGraspSource()
         return self._grasp_source
 
     @property
@@ -220,7 +233,7 @@ def _setup_ur5e(scene_path, objects):
         env.data.qpos[idx] = UR5E_HOME[i]
     mujoco.mj_forward(env.model, env.data)
 
-    return _SimpleRobot(env, arm, UR5E_HOME)
+    return _SimpleRobot(env, arm, UR5E_HOME, has_objects=bool(objects))
 
 
 def _setup_franka(scene_path, objects):
@@ -255,7 +268,7 @@ def _setup_franka(scene_path, objects):
         env.data.qpos[idx] = FRANKA_HOME[i]
     mujoco.mj_forward(env.model, env.data)
 
-    return _SimpleRobot(env, arm, FRANKA_HOME)
+    return _SimpleRobot(env, arm, FRANKA_HOME, has_objects=bool(objects))
 
 
 def _attach_prl_objects(spec, objects: dict):

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -47,30 +47,37 @@ def main() -> None:
 
     robot = _setup_robot(args.robot, objects)
 
+    arm_name = list(robot.arms.keys())[0]
+
     def commands():
         """Print available commands."""
         print(
-            """
+            f"""
 Quick Reference
 ===============
 
+Scene:
+  robot.find_objects()              — list all graspable objects
+  robot.get_object_pose("can_0")    — 4x4 pose matrix
+  robot.holding()                   — (arm, name) or None
+
 Actions:
-  pickup()                — pick up nearest reachable object
-  pickup("can_0")         — pick up specific object
-  place("yellow_tote")    — place in recycling bin
-  place("worktop")        — place on table surface
-  go_home()               — return arm to ready
+  robot.pickup()                    — pick up nearest reachable object
+  robot.pickup("can_0")             — pick up specific object
+  robot.place("yellow_tote")        — place in recycling bin
+  robot.place("worktop")            — place on table surface
+  robot.go_home()                   — return arm to ready
 
 Arm:
-  robot.arms["ur5e"].get_ee_pose()   — end-effector 4x4 pose
-  robot.arms["ur5e"].get_joint_positions()
+  robot.arms["{arm_name}"].get_ee_pose()
+  robot.arms["{arm_name}"].get_joint_positions()
 
 Teleop:
   Click "Activate" in the viser viewer
 
 IPython:
   robot.<tab>             — tab completion
-  ?pickup                 — docstring
+  ?robot.pickup           — docstring
   commands()              — this help
 """
         )
@@ -153,6 +160,50 @@ class _SimpleRobot:
             else:
                 self._grasp_source = _NullGraspSource()
         return self._grasp_source
+
+    def pickup(self, target=None, **kwargs):
+        """Pick up an object."""
+        from mj_manipulator.primitives import pickup
+
+        return pickup(self, target, **kwargs)
+
+    def place(self, destination=None, **kwargs):
+        """Place the held object."""
+        from mj_manipulator.primitives import place
+
+        return place(self, destination, **kwargs)
+
+    def go_home(self, **kwargs):
+        """Return to ready configuration."""
+        from mj_manipulator.primitives import go_home
+
+        return go_home(self, **kwargs)
+
+    def find_objects(self, target=None):
+        """List graspable objects in the scene."""
+        if target:
+            return [o for o in self.grasp_source.get_graspable_objects() if target in o]
+        return self.grasp_source.get_graspable_objects()
+
+    def holding(self):
+        """Get (arm_name, object_name) if holding, else None."""
+        for arm_name, arm in self.arms.items():
+            if arm.gripper and arm.gripper.is_holding and arm.gripper.held_object:
+                return (arm_name, arm.gripper.held_object)
+        return None
+
+    def get_object_pose(self, body_name):
+        """Get 4x4 world-frame pose of a body."""
+        import mujoco as mj
+        import numpy as np
+
+        bid = mj.mj_name2id(self.model, mj.mjtObj.mjOBJ_BODY, body_name)
+        if bid < 0:
+            raise ValueError(f"Body not found: {body_name}")
+        pose = np.eye(4)
+        pose[:3, :3] = self.data.xmat[bid].reshape(3, 3)
+        pose[:3, 3] = self.data.xpos[bid]
+        return pose
 
     @property
     def _active_context(self):

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -221,7 +221,7 @@ def _scatter_objects(env, objects: dict):
         geo = gp.get("type")
         if geo in ("open_box", "tote"):
             # Place container to the side
-            env.registry.activate(obj_type, pos=[-0.3, 0.0, 0.0])
+            env.registry.activate(obj_type, pos=[-0.3, 0.0, 0.15])
             mujoco.mj_forward(env.model, env.data)
             continue
 

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -125,19 +125,6 @@ class _SimpleRobot(RobotBase):
         return super().grasp_source
 
 
-def _create_scene_config(objects: dict) -> str:
-    """Create a temp scene_config.yaml from objects dict."""
-    import tempfile
-
-    import yaml
-
-    config = {"objects": {obj_type: {"count": count} for obj_type, count in objects.items()}}
-    f = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
-    yaml.dump(config, f)
-    f.close()
-    return f.name
-
-
 def _setup_franka(objects):
     """Set up Franka Panda with optional prl_assets objects."""
     import mujoco
@@ -154,28 +141,18 @@ def _setup_franka(objects):
         print("Run ./setup.sh from the robot-code workspace to clone mujoco_menagerie.")
         sys.exit(1)
 
-    # Add EE site to the Franka scene, save to temp file in same dir
-    # so mesh paths resolve correctly
+    # Assemble robot via MjSpec, then use Environment.from_spec()
+    # which handles objects + registry with native path resolution.
     spec = mujoco.MjSpec.from_file(str(scene_path))
     add_franka_ee_site(spec)
-
-    import tempfile
-
-    robot_xml = tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False, dir=str(scene_path.parent))
-    robot_xml.write(spec.to_xml())
-    robot_xml.close()
 
     if objects:
         from prl_assets import OBJECTS_DIR
 
-        scene_config = _create_scene_config(objects)
-        env = Environment(
-            base_scene_xml=robot_xml.name,
-            objects_dir=str(OBJECTS_DIR),
-            scene_config_yaml=scene_config,
-        )
+        env = Environment.from_spec(spec, objects_dir=str(OBJECTS_DIR), scene_config=objects)
     else:
-        env = Environment(base_scene_xml=robot_xml.name)
+        model = spec.compile()
+        env = Environment.from_model(model)
 
     gm = GraspManager(env.model, env.data)
     gripper = FrankaGripper(env.model, env.data, "franka", grasp_manager=gm)

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -149,6 +149,15 @@ def _setup_franka(objects):
     if objects:
         from prl_assets import OBJECTS_DIR
 
+        # Add a table for objects to sit on
+        table = spec.worldbody.add_body()
+        table.name = "table"
+        table.pos = [0.45, 0.0, 0.23]
+        g = table.add_geom()
+        g.type = mujoco.mjtGeom.mjGEOM_BOX
+        g.size = [0.15, 0.15, 0.23]
+        g.rgba = [0.4, 0.3, 0.2, 1.0]
+
         env = Environment.from_spec(spec, objects_dir=str(OBJECTS_DIR), scene_config=objects)
     else:
         model = spec.compile()
@@ -166,4 +175,67 @@ def _setup_franka(objects):
         env.data.qpos[idx] = FRANKA_HOME[i]
     mujoco.mj_forward(env.model, env.data)
 
+    # Activate and scatter objects on a table in front of the robot
+    if objects and env.registry is not None:
+        _scatter_objects(env, objects)
+
     return _SimpleRobot(env, arm, FRANKA_HOME, has_objects=bool(objects))
+
+
+def _scatter_objects(env, objects: dict):
+    """Activate objects and place them on a table in front of the robot."""
+    import mujoco
+    import numpy as np
+    from asset_manager import AssetManager
+    from prl_assets import OBJECTS_DIR
+    from tsr.placement import StablePlacer
+
+    assets = AssetManager(str(OBJECTS_DIR))
+
+    # Table: 30x30cm, 46cm tall, centered at (0.45, 0, 0.46)
+    table_surface = np.eye(4)
+    table_surface[:3, 3] = [0.45, 0.0, 0.46]
+    placer = StablePlacer(0.12, 0.12)
+
+    placed_positions = []
+    for obj_type, count in objects.items():
+        if isinstance(count, dict):
+            count = count.get("count", 1)
+        try:
+            gp = assets.get(obj_type)["geometric_properties"]
+        except (KeyError, TypeError):
+            continue
+
+        geo = gp.get("type")
+        if geo == "cylinder":
+            templates = placer.place_cylinder(gp["radius"], gp["height"])
+        elif geo == "box":
+            templates = placer.place_box(gp["size"][0], gp["size"][1], gp["size"][2])
+        else:
+            continue
+
+        if not templates:
+            continue
+
+        for _ in range(count):
+            tsr = templates[0].instantiate(table_surface)
+            # Sample a non-colliding position
+            for _attempt in range(50):
+                T = tsr.sample()
+                pos = T[:3, 3]
+                min_sep = 0.06
+                if all(np.linalg.norm(pos[:2] - np.array(p[:2])) > min_sep for p in placed_positions):
+                    break
+
+            name = env.registry.activate(obj_type, pos=list(pos))
+            placed_positions.append(list(pos))
+
+            # Apply full pose (includes randomized yaw)
+            body_id = mujoco.mj_name2id(env.model, mujoco.mjtObj.mjOBJ_BODY, name)
+            jnt_id = env.model.body_jntadr[body_id]
+            qpos_adr = env.model.jnt_qposadr[jnt_id]
+            quat = np.zeros(4)
+            mujoco.mju_mat2Quat(quat, T[:3, :3].flatten())
+            env.data.qpos[qpos_adr + 3 : qpos_adr + 7] = quat
+
+    mujoco.mj_forward(env.model, env.data)

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -3,16 +3,16 @@
 
 """CLI entry point for mj_manipulator interactive console.
 
-Launches an IPython console with a single-arm robot (UR5e or Franka),
-physics simulation, and viser web viewer with teleop.
+Launches an IPython console with a Franka Panda, physics simulation,
+and viser web viewer with teleop. Objects from prl_assets can be
+spawned into the scene.
 
 Usage::
 
-    python -m mj_manipulator                        # UR5e + viser (default)
-    python -m mj_manipulator --robot franka          # Franka + viser
-    python -m mj_manipulator --physics               # with physics simulation
-    python -m mj_manipulator --objects '{"can": 3}'  # spawn objects
-    python -m mj_manipulator --no-viser              # headless, no viewer
+    python -m mj_manipulator                          # Franka + viser
+    python -m mj_manipulator --physics                # with physics sim
+    python -m mj_manipulator --objects '{"can": 3}'   # spawn objects
+    python -m mj_manipulator --no-viser               # headless
 """
 
 from __future__ import annotations
@@ -28,12 +28,6 @@ def main() -> None:
         prog="mj_manipulator",
         description="Interactive manipulation console",
     )
-    parser.add_argument(
-        "--robot",
-        choices=["ur5e", "franka"],
-        default="ur5e",
-        help="Robot type (default: ur5e)",
-    )
     parser.add_argument("--physics", action="store_true", help="Enable physics simulation")
     parser.add_argument("--no-viser", action="store_true", help="Disable viser web viewer")
     parser.add_argument("--objects", type=str, default=None, help="Objects JSON, e.g. '{\"can\": 3}'")
@@ -45,16 +39,14 @@ def main() -> None:
 
         objects = json.loads(args.objects)
 
-    print(f"\nLoading {args.robot}...", flush=True)
+    print("\nLoading Franka...", flush=True)
 
-    robot = _setup_robot(args.robot, objects)
-
-    arm_name = list(robot.arms.keys())[0]
+    robot = _setup_franka(objects)
 
     def commands():
         """Print available commands."""
         print(
-            f"""
+            """
 Quick Reference
 ===============
 
@@ -71,8 +63,8 @@ Actions:
   robot.go_home()                   — return arm to ready
 
 Arm:
-  robot.arms["{arm_name}"].get_ee_pose()
-  robot.arms["{arm_name}"].get_joint_positions()
+  robot.arms["franka"].get_ee_pose()
+  robot.arms["franka"].get_joint_positions()
 
 Teleop:
   Click "Activate" in the viser viewer
@@ -90,42 +82,16 @@ IPython:
         robot,
         physics=args.physics,
         viser=not args.no_viser,
-        robot_name=args.robot.upper(),
+        robot_name="Franka",
         extra_ns={"commands": commands},
     )
 
 
-def _setup_robot(robot_type: str, objects: dict):
-    """Create a single-arm robot with optional objects."""
-
-    from mj_manipulator.menagerie import menagerie_scene
-
-    if robot_type == "ur5e":
-        scene_path = menagerie_scene("universal_robots_ur5e")
-        if not scene_path.exists():
-            print(f"ERROR: UR5e scene not found at {scene_path}")
-            print("Run ./setup.sh from the robot-code workspace to clone mujoco_menagerie.")
-            sys.exit(1)
-        robot = _setup_ur5e(scene_path, objects)
-    elif robot_type == "franka":
-        scene_path = menagerie_scene("franka_emika_panda")
-        if not scene_path.exists():
-            print(f"ERROR: Franka scene not found at {scene_path}")
-            print("Run ./setup.sh from the robot-code workspace to clone mujoco_menagerie.")
-            sys.exit(1)
-        robot = _setup_franka(scene_path, objects)
-    else:
-        print(f"Unknown robot: {robot_type}")
-        sys.exit(1)
-
-    return robot
-
-
 class _SimpleRobot(RobotBase):
-    """Minimal robot for the CLI demo. Inherits all convenience methods
-    from RobotBase (pickup, place, go_home, find_objects, etc.).
+    """Minimal robot for the CLI demo.
 
-    This is the reference implementation — ~20 LOC on top of RobotBase.
+    Inherits all convenience methods from RobotBase:
+    pickup, place, go_home, find_objects, holding, get_object_pose.
     """
 
     def __init__(self, env, arm, home_config, has_objects=False):
@@ -159,21 +125,6 @@ class _SimpleRobot(RobotBase):
         return super().grasp_source
 
 
-def _save_robot_xml(spec, source_dir: str) -> str:
-    """Save assembled robot MjSpec to a temp file in the source directory.
-
-    Must be in the same directory as the original scene XML so that
-    relative mesh/texture paths resolve correctly.
-    """
-    import tempfile
-
-    xml_str = spec.to_xml()
-    f = tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False, dir=source_dir)
-    f.write(xml_str)
-    f.close()
-    return f.name
-
-
 def _create_scene_config(objects: dict) -> str:
     """Create a temp scene_config.yaml from objects dict."""
     import tempfile
@@ -187,77 +138,44 @@ def _create_scene_config(objects: dict) -> str:
     return f.name
 
 
-def _setup_ur5e(scene_path, objects):
-    """Set up UR5e + Robotiq."""
-    import geodude_assets
+def _setup_franka(objects):
+    """Set up Franka Panda with optional prl_assets objects."""
     import mujoco
     from mj_environment import Environment
-    from prl_assets import OBJECTS_DIR
-
-    from mj_manipulator.arms.ur5e import UR5E_HOME, UR5E_ROBOTIQ_EE_SITE, create_ur5e_arm
-    from mj_manipulator.grasp_manager import GraspManager
-    from mj_manipulator.grippers.robotiq import RobotiqGripper
-
-    # Assemble robot: UR5e + Robotiq gripper
-    spec = mujoco.MjSpec.from_file(str(scene_path))
-    robotiq_path = geodude_assets.MODELS_DIR / "robotiq_2f140" / "2f140.xml"
-    robotiq_spec = mujoco.MjSpec.from_file(str(robotiq_path))
-    wrist = spec.worldbody.find_child("wrist_3_link")
-    frame = wrist.add_frame()
-    frame.pos = [0, 0.1, 0]
-    frame.quat = [-1, 1, 0, 0]
-    frame.attach_body(robotiq_spec.worldbody.first_body(), prefix="gripper/")
-
-    # Save assembled robot XML, then use Environment to add objects
-    # (Environment handles body naming, registry, and object lifecycle)
-    robot_xml = _save_robot_xml(spec, str(scene_path.parent))
-
-    if objects:
-        scene_config = _create_scene_config(objects)
-        env = Environment(
-            base_scene_xml=robot_xml,
-            objects_dir=str(OBJECTS_DIR),
-            scene_config_yaml=scene_config,
-        )
-    else:
-        env = Environment(base_scene_xml=robot_xml)
-
-    gm = GraspManager(env.model, env.data)
-    gripper = RobotiqGripper(env.model, env.data, "ur5e", prefix="gripper/", grasp_manager=gm)
-    arm = create_ur5e_arm(env, ee_site=UR5E_ROBOTIQ_EE_SITE, gripper=gripper, grasp_manager=gm)
-
-    for i, idx in enumerate(arm.joint_qpos_indices):
-        env.data.qpos[idx] = UR5E_HOME[i]
-    mujoco.mj_forward(env.model, env.data)
-
-    return _SimpleRobot(env, arm, UR5E_HOME, has_objects=bool(objects))
-
-
-def _setup_franka(scene_path, objects):
-    """Set up Franka Panda."""
-    import mujoco
-    from mj_environment import Environment
-    from prl_assets import OBJECTS_DIR
 
     from mj_manipulator.arms.franka import FRANKA_HOME, add_franka_ee_site, create_franka_arm
     from mj_manipulator.grasp_manager import GraspManager
     from mj_manipulator.grippers.franka import FrankaGripper
+    from mj_manipulator.menagerie import menagerie_scene
 
-    # Assemble robot: Franka + EE site
+    scene_path = menagerie_scene("franka_emika_panda")
+    if not scene_path.exists():
+        print(f"ERROR: Franka scene not found at {scene_path}")
+        print("Run ./setup.sh from the robot-code workspace to clone mujoco_menagerie.")
+        sys.exit(1)
+
+    # Add EE site to the Franka scene, save to temp file in same dir
+    # so mesh paths resolve correctly
     spec = mujoco.MjSpec.from_file(str(scene_path))
     add_franka_ee_site(spec)
 
-    robot_xml = _save_robot_xml(spec, str(scene_path.parent))
+    import tempfile
+
+    robot_xml = tempfile.NamedTemporaryFile(mode="w", suffix=".xml", delete=False, dir=str(scene_path.parent))
+    robot_xml.write(spec.to_xml())
+    robot_xml.close()
 
     if objects:
+        from prl_assets import OBJECTS_DIR
+
         scene_config = _create_scene_config(objects)
         env = Environment(
-            base_scene_xml=robot_xml,
+            base_scene_xml=robot_xml.name,
             objects_dir=str(OBJECTS_DIR),
             scene_config_yaml=scene_config,
         )
     else:
-        env = Environment(base_scene_xml=robot_xml)
+        env = Environment(base_scene_xml=robot_xml.name)
 
     gm = GraspManager(env.model, env.data)
     gripper = FrankaGripper(env.model, env.data, "franka", grasp_manager=gm)
@@ -272,55 +190,3 @@ def _setup_franka(scene_path, objects):
     mujoco.mj_forward(env.model, env.data)
 
     return _SimpleRobot(env, arm, FRANKA_HOME, has_objects=bool(objects))
-
-
-def _attach_prl_objects(spec, objects: dict):
-    """Attach prl_assets objects + table + recycling bin to the scene."""
-    import mujoco
-    from prl_assets import OBJECTS_DIR
-
-    # Table
-    table = spec.worldbody.add_body()
-    table.name = "table"
-    table.pos = [0.45, -0.20, 0.23]
-    g = table.add_geom()
-    g.type = mujoco.mjtGeom.mjGEOM_BOX
-    g.size = [0.15, 0.15, 0.23]
-    g.rgba = [0.4, 0.3, 0.2, 1.0]
-
-    # Worktop site on the table surface (for surface placement)
-    s = table.add_site()
-    s.name = "worktop"
-    s.pos = [0, 0, 0.23]  # top of the table
-    s.size = [0.12, 0.12, 0.001]
-    s.type = mujoco.mjtGeom.mjGEOM_BOX
-    s.rgba = [0, 0, 0, 0]  # invisible
-
-    # Recycling bin on the floor
-    from asset_manager import AssetManager
-
-    assets = AssetManager(str(OBJECTS_DIR))
-    try:
-        bin_xml = assets.get_path("yellow_tote", "mujoco")
-        bin_spec = mujoco.MjSpec.from_file(bin_xml)
-        f = spec.worldbody.add_frame()
-        f.pos = [0.25, -0.70, 0.0]
-        f.attach_body(bin_spec.worldbody.first_body(), prefix="yellow_tote_0/")
-    except (KeyError, TypeError):
-        pass  # no tote model available
-
-    # Attach objects on the table
-    idx = 0
-    for obj_type, count in objects.items():
-        try:
-            xml_path = assets.get_path(obj_type, "mujoco")
-        except (KeyError, TypeError):
-            continue
-        for i in range(count):
-            obj_spec = mujoco.MjSpec.from_file(xml_path)
-            f = spec.worldbody.add_frame()
-            x = 0.40 + (idx % 3) * 0.05
-            y = -0.25 + (idx // 3) * 0.05
-            f.pos = [x, y, 0.46 + 0.05]
-            f.attach_body(obj_spec.worldbody.first_body(), prefix=f"{obj_type}_{i}/")
-            idx += 1

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -286,7 +286,7 @@ def _scatter_objects(env, objects: dict):
         geo = gp.get("type")
         if geo in ("open_box", "tote"):
             # Place container to the side
-            env.registry.activate(obj_type, pos=[-0.3, 0.0, 0.0])
+            env.registry.activate(obj_type, pos=[-0.3, 0.0, 0.12])
             mujoco.mj_forward(env.model, env.data)
             continue
 

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -66,6 +66,9 @@ Arm:
   robot.arms["franka"].get_ee_pose()
   robot.arms["franka"].get_joint_positions()
 
+Scene:
+  reset()                           — re-scatter objects, arm to ready
+
 Teleop:
   Click "Activate" in the viser viewer
 
@@ -83,7 +86,7 @@ IPython:
         physics=args.physics,
         viser=not args.no_viser,
         robot_name="Franka",
-        extra_ns={"commands": commands},
+        extra_ns={"commands": commands, "reset": robot.reset},
     )
 
 
@@ -107,6 +110,59 @@ class _SimpleRobot(RobotBase):
         )
         self._env = env
         self._has_objects = has_objects
+        self._objects_config = None  # set externally after creation
+
+    def reset(self):
+        """Reset scene: release objects, return arm home, re-scatter."""
+        import mujoco
+
+        self.request_abort()
+        self.clear_abort()
+
+        # Release any held objects
+        for arm_name, arm in self.arms.items():
+            if arm.gripper and arm.gripper.is_holding:
+                if self._context is not None:
+                    self._context.arm(arm_name).release()
+
+        # Clear grasp manager state
+        for arm_name in list(self.arms.keys()):
+            for obj in list(self.grasp_manager.get_grasped_by(arm_name)):
+                self.grasp_manager.mark_released(obj)
+                self.grasp_manager.detach_object(obj)
+
+        # Hide all objects
+        if self._env.registry is not None:
+            for obj_type in list(self._env.registry.objects.keys()):
+                for name in list(self._env.registry.objects[obj_type]["instances"]):
+                    if self._env.registry.is_active(name):
+                        self._env.registry.hide(name)
+
+        # Reset arm to home
+        ready = self.named_poses.get("ready", {})
+        for arm_name, arm in self.arms.items():
+            if arm_name in ready:
+                for i, idx in enumerate(arm.joint_qpos_indices):
+                    self.data.qpos[idx] = ready[arm_name][i]
+            if arm.gripper:
+                arm.gripper.kinematic_open()
+                if arm.gripper.actuator_id is not None:
+                    self.data.ctrl[arm.gripper.actuator_id] = arm.gripper.ctrl_open
+
+        mujoco.mj_forward(self.model, self.data)
+
+        # Re-scatter objects
+        if self._objects_config and self._env.registry is not None:
+            all_objects = dict(self._objects_config)
+            all_objects["yellow_tote"] = 1
+            _scatter_objects(self._env, all_objects)
+
+        if self._context is not None:
+            self._context.sync()
+            if hasattr(self._context, "hold"):
+                self._context.hold()
+
+        print("Scene reset.")
 
     @property
     def grasp_source(self):
@@ -192,7 +248,9 @@ def _setup_franka(objects):
         all_objects["yellow_tote"] = 1
         _scatter_objects(env, all_objects)
 
-    return _SimpleRobot(env, arm, FRANKA_HOME, has_objects=bool(objects))
+    robot = _SimpleRobot(env, arm, FRANKA_HOME, has_objects=bool(objects))
+    robot._objects_config = objects if objects else None
+    return robot
 
 
 def _scatter_objects(env, objects: dict):

--- a/src/mj_manipulator/grasp_sources/__init__.py
+++ b/src/mj_manipulator/grasp_sources/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""GraspSource implementations for common object databases."""

--- a/src/mj_manipulator/grasp_sources/prl_assets.py
+++ b/src/mj_manipulator/grasp_sources/prl_assets.py
@@ -1,0 +1,561 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""GraspSource backed by prl_assets object geometry.
+
+Generates grasp and placement TSRs by reading object dimensions from
+prl_assets meta.yaml files. Works with any robot — only needs MuJoCo
+model/data and a GraspManager.
+
+Usage::
+
+    from mj_manipulator.grasp_sources.prl_assets import PrlAssetsGraspSource
+
+    source = PrlAssetsGraspSource(model, data, grasp_manager, arms)
+    tsrs = source.get_grasps("can_0", "parallel_jaw")
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+import mujoco
+import numpy as np
+
+if TYPE_CHECKING:
+    from mj_manipulator.arm import Arm
+    from mj_manipulator.grasp_manager import GraspManager
+
+logger = logging.getLogger(__name__)
+
+_CONTAINER_TYPES = frozenset(("open_box", "tote"))
+
+
+class PrlAssetsGraspSource:
+    """GraspSource backed by prl_assets geometry.
+
+    Implements the mj_manipulator GraspSource protocol by loading object
+    dimensions from prl_assets' AssetManager and generating TSRs using
+    the tsr library's hand models.
+
+    Args:
+        model: MuJoCo model.
+        data: MuJoCo data.
+        grasp_manager: For tracking grasped objects.
+        arms: Dict of arm name → Arm (for grasp transform computation).
+        registry: Optional object registry with is_active() method.
+    """
+
+    def __init__(
+        self,
+        model: mujoco.MjModel,
+        data: mujoco.MjData,
+        grasp_manager: GraspManager,
+        arms: dict[str, Arm],
+        registry: object | None = None,
+    ) -> None:
+        self._model = model
+        self._data = data
+        self._gm = grasp_manager
+        self._arms = arms
+        self._registry = registry
+
+    def get_grasps(self, object_name: str, hand_type: str) -> list:
+        """Get grasp TSRs for an object from its prl_assets geometry."""
+        obj_type = _instance_to_type(object_name)
+        if obj_type is None:
+            return []
+        return self._generate_tsrs_for_object(object_name, obj_type)
+
+    def get_placements(self, destination: str, object_name: str) -> list:
+        """Get placement TSRs for an object at a destination."""
+        dest_type = _instance_to_type(destination)
+        if dest_type is None:
+            return self._get_site_placements(destination, object_name)
+
+        held_height = self._get_held_object_height()
+        T_gripper_object = self._get_grasp_transform()
+        return self._generate_place_tsrs(
+            destination,
+            dest_type,
+            held_height=held_height,
+            T_gripper_object=T_gripper_object,
+        )
+
+    def get_graspable_objects(self) -> list[str]:
+        """Get all graspable objects currently in the scene."""
+        objects = self._find_scene_objects(None)
+        return [body_name for body_name, _ in objects]
+
+    def get_place_destinations(self, object_name: str) -> list[str]:
+        """Get valid placement destinations for an object."""
+        from asset_manager import AssetManager
+        from prl_assets import OBJECTS_DIR
+
+        assets = AssetManager(str(OBJECTS_DIR))
+
+        destinations = []
+        for i in range(self._model.nbody):
+            name = mujoco.mj_id2name(self._model, mujoco.mjtObj.mjOBJ_BODY, i)
+            if not name:
+                continue
+            if not self._is_active(name):
+                continue
+            m = re.match(r"^(.+?)_(\d+)$", name)
+            if not m:
+                continue
+            obj_type = m.group(1)
+            try:
+                gp = assets.get(obj_type)["geometric_properties"]
+                geo_type = gp.get("type")
+                if geo_type in _CONTAINER_TYPES or geo_type in ("box", "cylinder"):
+                    destinations.append(name)
+            except (KeyError, TypeError):
+                continue
+
+        # Also check for worktop site
+        try:
+            wt_id = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_SITE, "worktop")
+            if wt_id >= 0:
+                destinations.append("worktop")
+        except Exception:
+            pass
+
+        return destinations
+
+    # -- Internal helpers -------------------------------------------------------
+
+    def _is_active(self, body_name: str) -> bool:
+        """Check if a body is active (visible) in the scene."""
+        if self._registry is None:
+            return True
+        try:
+            return self._registry.is_active(body_name)
+        except Exception:
+            return True
+
+    def _get_body_pose(self, body_name: str) -> np.ndarray:
+        """Get 4x4 world-frame pose of a MuJoCo body."""
+        bid = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_BODY, body_name)
+        if bid < 0:
+            raise ValueError(f"Body not found: {body_name}")
+        pose = np.eye(4)
+        pose[:3, :3] = self._data.xmat[bid].reshape(3, 3)
+        pose[:3, 3] = self._data.xpos[bid]
+        return pose
+
+    def _holding(self) -> tuple[str, str] | None:
+        """Get (arm_name, object_name) if any arm is holding an object."""
+        for arm_name, arm in self._arms.items():
+            if arm.gripper and arm.gripper.is_holding and arm.gripper.held_object:
+                return (arm_name, arm.gripper.held_object)
+        return None
+
+    def _find_scene_objects(self, target: str | None) -> list[tuple[str, str]]:
+        """Find objects in the scene matching a target specification."""
+        from asset_manager import AssetManager
+        from prl_assets import OBJECTS_DIR
+
+        assets = AssetManager(str(OBJECTS_DIR))
+
+        all_bodies = []
+        for i in range(self._model.nbody):
+            name = mujoco.mj_id2name(self._model, mujoco.mjtObj.mjOBJ_BODY, i)
+            if not name:
+                continue
+            if not self._is_active(name):
+                continue
+            all_bodies.append(name)
+
+        if target is not None:
+            instance_match = re.match(r"^(.+)_(\d+)$", target)
+            if instance_match:
+                obj_type = instance_match.group(1)
+                if target in all_bodies:
+                    return [(target, obj_type)]
+                return []
+
+            matches = []
+            for body in all_bodies:
+                m = re.match(r"^(.+?)_(\d+)$", body)
+                if m and m.group(1) == target:
+                    if not self._gm.is_grasped(body):
+                        matches.append((body, target))
+            return matches
+
+        matches = []
+        known_types = set()
+        for body in all_bodies:
+            m = re.match(r"^(.+?)_(\d+)$", body)
+            if not m:
+                continue
+            obj_type = m.group(1)
+            if self._gm.is_grasped(body):
+                continue
+            if obj_type not in known_types:
+                try:
+                    assets.get(obj_type)["geometric_properties"]
+                    known_types.add(obj_type)
+                except (KeyError, TypeError):
+                    continue
+            if obj_type in known_types:
+                matches.append((body, obj_type))
+        return matches
+
+    def _generate_tsrs_for_object(self, body_name: str, obj_type: str) -> list:
+        """Generate grasp TSRs for a single object from its prl_assets geometry."""
+        from asset_manager import AssetManager
+        from prl_assets import OBJECTS_DIR
+        from tsr.hands import Robotiq2F140
+
+        assets = AssetManager(str(OBJECTS_DIR))
+        try:
+            gp = assets.get(obj_type)["geometric_properties"]
+        except (KeyError, TypeError):
+            return []
+
+        try:
+            obj_pose = self._get_body_pose(body_name)
+        except ValueError:
+            return []
+
+        hand = Robotiq2F140()
+        if gp.get("type") == "cylinder":
+            T_bottom = obj_pose.copy()
+            local_z = obj_pose[:3, 2]
+            T_bottom[:3, 3] -= local_z * (gp["height"] / 2)
+            templates = hand.grasp_cylinder_side(gp["radius"], gp["height"])
+            return [t.instantiate(T_bottom) for t in templates]
+        elif gp.get("type") == "box":
+            size = gp["size"]
+            T_bottom = obj_pose.copy()
+            local_z = obj_pose[:3, 2]
+            T_bottom[:3, 3] -= local_z * (size[2] / 2)
+            templates = []
+            for grasp_fn in [
+                hand.grasp_box_face_x,
+                hand.grasp_box_face_y,
+                hand.grasp_box_top,
+                hand.grasp_box_bottom,
+            ]:
+                try:
+                    templates.extend(grasp_fn(size[0], size[1], size[2]))
+                except ValueError as e:
+                    logger.info(
+                        "%s: skipping %s — %s",
+                        body_name,
+                        grasp_fn.__name__,
+                        e,
+                    )
+            return [t.instantiate(T_bottom) for t in templates]
+
+        return []
+
+    def _generate_place_tsrs(
+        self,
+        body_name: str,
+        dest_type: str,
+        held_height: float = 0.0,
+        T_gripper_object: np.ndarray | None = None,
+    ) -> list:
+        """Generate placement TSRs — dispatches between container and surface."""
+        from asset_manager import AssetManager
+        from prl_assets import OBJECTS_DIR
+
+        assets = AssetManager(str(OBJECTS_DIR))
+        try:
+            gp = assets.get(dest_type)["geometric_properties"]
+        except (KeyError, TypeError):
+            return []
+
+        geo_type = gp.get("type")
+
+        if geo_type in _CONTAINER_TYPES:
+            return self._generate_container_drop_tsrs(body_name, dest_type, held_height)
+
+        try:
+            dest_pose = self._get_body_pose(body_name)
+        except (ValueError, AttributeError):
+            return []
+
+        faces = _get_upward_faces(dest_pose, gp)
+        if not faces:
+            return []
+
+        held_type = self._get_held_object_type()
+        all_tsrs = []
+        for surface_pose, hx, hy in faces:
+            tsrs = _generate_surface_place_tsrs(
+                surface_pose,
+                hx,
+                hy,
+                held_type,
+                T_gripper_object=T_gripper_object,
+            )
+            all_tsrs.extend(tsrs)
+        return all_tsrs
+
+    def _generate_container_drop_tsrs(
+        self,
+        body_name: str,
+        dest_type: str,
+        held_height: float = 0.0,
+    ) -> list:
+        """Generate drop-zone TSRs for a container."""
+        from asset_manager import AssetManager
+        from prl_assets import OBJECTS_DIR
+        from tsr import TSR
+
+        assets = AssetManager(str(OBJECTS_DIR))
+        try:
+            meta = assets.get(dest_type)
+            gp = meta["geometric_properties"]
+            policy = meta.get("policy", {}).get("placement", {})
+        except (KeyError, TypeError):
+            return []
+
+        if gp.get("type") not in _CONTAINER_TYPES:
+            return []
+
+        try:
+            dest_pose = self._get_body_pose(body_name)
+        except ValueError:
+            return []
+
+        outer = gp["outer_dimensions"]
+        wall = gp.get("wall_thickness", 0.003)
+        margin = policy.get("drop_zone_margin", 0.05)
+
+        hx = (outer[0] / 2) - wall - margin
+        hy = (outer[1] / 2) - wall - margin
+
+        local_z = dest_pose[:3, 2]
+        clearance = max(0.25, held_height + 0.10)
+        drop_pos = dest_pose[:3, 3] + local_z * (outer[2] + clearance)
+
+        approach = -local_z
+        gripper_x = dest_pose[:3, 0]
+        gripper_y = np.cross(approach, gripper_x)
+
+        T0_w = np.eye(4)
+        T0_w[:3, 0] = gripper_x
+        T0_w[:3, 1] = gripper_y
+        T0_w[:3, 2] = approach
+        T0_w[:3, 3] = drop_pos
+
+        Bw = np.zeros((6, 2))
+        Bw[0, :] = [-hx, hx]
+        Bw[1, :] = [-hy, hy]
+        Bw[2, :] = [-0.02, 0.05]
+        Bw[5, :] = [-np.pi, np.pi]
+
+        return [TSR(T0_w=T0_w, Bw=Bw)]
+
+    def _get_held_object_height(self) -> float:
+        """Get the height of the currently held object, or 0 if unknown."""
+        from asset_manager import AssetManager
+        from prl_assets import OBJECTS_DIR
+
+        held = self._holding()
+        if not held:
+            return 0.0
+
+        _, obj_name = held
+        assets = AssetManager(str(OBJECTS_DIR))
+        obj_type = _instance_to_type(obj_name)
+        if not obj_type:
+            return 0.0
+
+        try:
+            gp = assets.get(obj_type)["geometric_properties"]
+            if gp["type"] == "cylinder":
+                return max(gp["height"], gp["radius"] * 2)
+            elif gp["type"] == "box":
+                return max(gp["size"])
+        except (KeyError, TypeError):
+            pass
+        return 0.0
+
+    def _get_held_object_type(self) -> str | None:
+        """Get the prl_assets type of the currently held object."""
+        held = self._holding()
+        if not held:
+            return None
+        _, obj_name = held
+        return _instance_to_type(obj_name)
+
+    def _get_grasp_transform(self) -> np.ndarray | None:
+        """Get T_site_object for the currently held object."""
+        held = self._holding()
+        if not held:
+            return None
+        side, obj_name = held
+
+        T_body_object = self._gm.get_grasp_transform(obj_name)
+        if T_body_object is None:
+            return None
+
+        arm = self._arms[side]
+        body_name = arm.gripper.attachment_body
+        body_id = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_BODY, body_name)
+        site_id = arm.ee_site_id
+
+        T_world_body = np.eye(4)
+        T_world_body[:3, :3] = self._data.xmat[body_id].reshape(3, 3)
+        T_world_body[:3, 3] = self._data.xpos[body_id]
+
+        T_world_site = np.eye(4)
+        T_world_site[:3, :3] = self._data.site_xmat[site_id].reshape(3, 3)
+        T_world_site[:3, 3] = self._data.site_xpos[site_id]
+
+        T_body_site = np.linalg.inv(T_world_body) @ T_world_site
+        T_site_object = np.linalg.inv(T_body_site) @ T_body_object
+        return T_site_object
+
+    def _get_site_placements(self, site_name: str, object_name: str) -> list:
+        """Get placement TSRs for a named site (e.g. 'worktop')."""
+        try:
+            wt_id = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_SITE, site_name)
+        except Exception:
+            return []
+        if wt_id < 0:
+            return []
+
+        wt_size = self._model.site_size[wt_id]
+        surface_pose = np.eye(4)
+        surface_pose[:3, 3] = self._data.site_xpos[wt_id].copy()
+
+        held_type = self._get_held_object_type()
+        T_gripper_object = self._get_grasp_transform()
+
+        return _generate_surface_place_tsrs(
+            surface_pose,
+            float(wt_size[0]),
+            float(wt_size[1]),
+            held_type,
+            T_gripper_object=T_gripper_object,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _instance_to_type(name: str) -> str | None:
+    """Extract object type from instance name (e.g. 'can_0' → 'can')."""
+    m = re.match(r"^(.+?)_(\d+)$", name)
+    return m.group(1) if m else None
+
+
+_UPWARD_THRESHOLD = 0.95
+
+
+def _get_upward_faces(
+    dest_pose: np.ndarray,
+    gp: dict,
+) -> list[tuple[np.ndarray, float, float]]:
+    """Enumerate flat faces pointing upward."""
+    R = dest_pose[:3, :3]
+    origin = dest_pose[:3, 3]
+    geo_type = gp.get("type")
+
+    candidates: list[tuple[np.ndarray, float, float, float]] = []
+
+    if geo_type == "box":
+        lx, ly, lz = gp["size"]
+        candidates.append((np.array([0, 0, +1.0]), lz / 2, lx / 2, ly / 2))
+        candidates.append((np.array([0, 0, -1.0]), lz / 2, lx / 2, ly / 2))
+        candidates.append((np.array([0, +1.0, 0]), ly / 2, lx / 2, lz / 2))
+        candidates.append((np.array([0, -1.0, 0]), ly / 2, lx / 2, lz / 2))
+        candidates.append((np.array([+1.0, 0, 0]), lx / 2, ly / 2, lz / 2))
+        candidates.append((np.array([-1.0, 0, 0]), lx / 2, ly / 2, lz / 2))
+    elif geo_type == "cylinder":
+        r, h = gp["radius"], gp["height"]
+        candidates.append((np.array([0, 0, +1.0]), h / 2, r, r))
+        candidates.append((np.array([0, 0, -1.0]), h / 2, r, r))
+
+    results = []
+    up = np.array([0.0, 0.0, 1.0])
+    for local_normal, offset, hx, hy in candidates:
+        normal_world = R @ local_normal
+        if normal_world @ up < _UPWARD_THRESHOLD:
+            continue
+
+        face_center = origin + R @ (local_normal * offset)
+        surface_pose = np.eye(4)
+        surface_pose[:3, 3] = face_center
+        surface_pose[:3, 2] = normal_world
+
+        abs_normal = np.abs(local_normal)
+        if abs_normal[0] < 0.5:
+            local_x = np.array([1.0, 0, 0])
+        elif abs_normal[1] < 0.5:
+            local_x = np.array([0, 1.0, 0])
+        else:
+            local_x = np.array([0, 0, 1.0])
+        surface_x = R @ local_x
+        surface_x -= normal_world * (surface_x @ normal_world)
+        surface_x /= np.linalg.norm(surface_x)
+        surface_pose[:3, 0] = surface_x
+        surface_pose[:3, 1] = np.cross(normal_world, surface_x)
+
+        results.append((surface_pose, hx, hy))
+
+    return results
+
+
+def _generate_surface_place_tsrs(
+    surface_pose: np.ndarray,
+    surface_hx: float,
+    surface_hy: float,
+    held_obj_type: str | None,
+    T_gripper_object: np.ndarray | None = None,
+) -> list:
+    """Generate stable placement TSRs for a flat surface."""
+    from asset_manager import AssetManager
+    from prl_assets import OBJECTS_DIR
+    from tsr.placement import StablePlacer
+
+    if held_obj_type is None:
+        return []
+
+    assets = AssetManager(str(OBJECTS_DIR))
+    try:
+        gp = assets.get(held_obj_type)["geometric_properties"]
+    except (KeyError, TypeError):
+        return []
+
+    margin = 0.05
+    placer = StablePlacer(
+        table_x=max(0.01, surface_hx - margin),
+        table_y=max(0.01, surface_hy - margin),
+    )
+
+    geo_type = gp.get("type")
+    if geo_type == "cylinder":
+        templates = placer.place_cylinder(gp["radius"], gp["height"], subject=held_obj_type)
+    elif geo_type == "box":
+        templates = placer.place_box(gp["size"][0], gp["size"][1], gp["size"][2], subject=held_obj_type)
+    elif geo_type == "sphere":
+        templates = placer.place_sphere(gp["radius"], subject=held_obj_type)
+    else:
+        return []
+
+    if not templates:
+        return []
+    template = templates[0]
+
+    if T_gripper_object is not None:
+        import dataclasses
+
+        T_object_gripper = np.linalg.inv(T_gripper_object)
+        template = dataclasses.replace(template, Tw_e=template.Tw_e @ T_object_gripper)
+
+    tsr = template.instantiate(surface_pose)
+    clearance = 0.005
+    tsr.Bw[2, :] += clearance
+
+    return [tsr]

--- a/src/mj_manipulator/grasp_sources/prl_assets.py
+++ b/src/mj_manipulator/grasp_sources/prl_assets.py
@@ -67,7 +67,7 @@ class PrlAssetsGraspSource:
         obj_type = _instance_to_type(object_name)
         if obj_type is None:
             return []
-        return self._generate_tsrs_for_object(object_name, obj_type)
+        return self._generate_tsrs_for_object(object_name, obj_type, hand_type)
 
     def get_placements(self, destination: str, object_name: str) -> list:
         """Get placement TSRs for an object at a destination."""
@@ -204,11 +204,10 @@ class PrlAssetsGraspSource:
                 matches.append((body, obj_type))
         return matches
 
-    def _generate_tsrs_for_object(self, body_name: str, obj_type: str) -> list:
+    def _generate_tsrs_for_object(self, body_name: str, obj_type: str, hand_type: str = "parallel_jaw") -> list:
         """Generate grasp TSRs for a single object from its prl_assets geometry."""
         from asset_manager import AssetManager
         from prl_assets import OBJECTS_DIR
-        from tsr.hands import Robotiq2F140
 
         assets = AssetManager(str(OBJECTS_DIR))
         try:
@@ -221,7 +220,7 @@ class PrlAssetsGraspSource:
         except ValueError:
             return []
 
-        hand = Robotiq2F140()
+        hand = _get_hand(hand_type)
         if gp.get("type") == "cylinder":
             T_bottom = obj_pose.copy()
             local_z = obj_pose[:3, 2]
@@ -442,6 +441,15 @@ class PrlAssetsGraspSource:
 # ---------------------------------------------------------------------------
 # Module-level helpers
 # ---------------------------------------------------------------------------
+
+
+def _get_hand(hand_type: str):
+    """Get the TSR hand model for a gripper type."""
+    from tsr.hands import FrankaHand, Robotiq2F140
+
+    if "franka" in hand_type.lower():
+        return FrankaHand()
+    return Robotiq2F140()
 
 
 def _instance_to_type(name: str) -> str | None:

--- a/src/mj_manipulator/grasp_sources/prl_assets.py
+++ b/src/mj_manipulator/grasp_sources/prl_assets.py
@@ -323,7 +323,7 @@ class PrlAssetsGraspSource:
         except ValueError:
             return []
 
-        outer = gp["outer_dimensions"]
+        outer = gp["outer_size"]
         wall = gp.get("wall_thickness", 0.003)
         margin = policy.get("drop_zone_margin", 0.05)
 

--- a/src/mj_manipulator/grippers/franka.py
+++ b/src/mj_manipulator/grippers/franka.py
@@ -54,6 +54,10 @@ _FINGER_CLOSED = 0.0  # Fully closed position
 class FrankaGripper(_BaseGripper):
     """Franka Emika Panda hand gripper.
 
+    .. attribute:: hand_type
+       TSR hand model identifier. Used by GraspSource to select
+       the correct grasp templates (FrankaHand vs Robotiq2F140).
+
     The Franka hand is a simple parallel jaw gripper with two prismatic
     finger joints driven by a tendon actuator. In kinematic mode, the
     fingers are linearly interpolated between open and closed positions.
@@ -68,6 +72,8 @@ class FrankaGripper(_BaseGripper):
         prefix: MuJoCo name prefix for all gripper elements.
         grasp_manager: Optional grasp state tracker.
     """
+
+    hand_type: str = "franka"
 
     def __init__(
         self,

--- a/src/mj_manipulator/grippers/robotiq.py
+++ b/src/mj_manipulator/grippers/robotiq.py
@@ -197,6 +197,8 @@ class RobotiqGripper(_BaseGripper):
         grasp_manager: Optional grasp state tracker.
     """
 
+    hand_type: str = "robotiq"
+
     def __init__(
         self,
         model: mujoco.MjModel,

--- a/src/mj_manipulator/robot.py
+++ b/src/mj_manipulator/robot.py
@@ -1,32 +1,37 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Siddhartha Srinivasa
 
-"""Robot protocol for generic manipulation.
+"""Robot protocol and base class for generic manipulation.
 
-Defines the minimal interface a robot must expose for the generic
-console, primitives (pickup/place/go_home), and teleop to work.
+ManipulationRobot defines the minimal interface. RobotBase provides
+convenience methods (pickup, place, go_home, etc.) so concrete robots
+only need to set up arms, grasp_source, and named_poses.
 
-A new robot implements this by composing mj_manipulator Arms::
+Usage::
 
-    class MyRobot:
-        def __init__(self, model_path):
-            self.env = Environment(model_path)
-            self.model = self.env.model
-            self.data = self.env.data
-            arm = create_ur5e_arm(self.env, "ur5e", with_gripper=True)
-            self.arms = {"arm": arm}
-            self.grasp_manager = GraspManager(self.model, self.data)
-            self.grasp_source = MyGraspSource(...)
-            self.named_poses = {"ready": {"arm": [0, -1.57, 1.57, ...]}}
+    from mj_manipulator.robot import RobotBase
+
+    class MyRobot(RobotBase):
+        def __init__(self):
+            env = Environment(model_path)
+            arm = create_ur5e_arm(env, "ur5e", with_gripper=True)
+            gm = GraspManager(env.model, env.data)
+            super().__init__(
+                model=env.model, data=env.data,
+                arms={"ur5e": arm}, grasp_manager=gm,
+                named_poses={"ready": {"ur5e": [...]}},
+            )
 """
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-if TYPE_CHECKING:
-    import mujoco
+import mujoco
+import numpy as np
 
+if TYPE_CHECKING:
     from mj_manipulator.arm import Arm
     from mj_manipulator.grasp_manager import GraspManager
     from mj_manipulator.protocols import GraspSource
@@ -63,7 +68,7 @@ class ManipulationRobot(Protocol):
 
     @property
     def named_poses(self) -> dict[str, dict[str, list[float]]]:
-        """Named joint configurations (e.g. {"ready": {"left": [...], "right": [...]}})."""
+        """Named joint configurations."""
         ...
 
     def sim(
@@ -74,20 +79,165 @@ class ManipulationRobot(Protocol):
         viewer: object = None,
         event_loop: object = None,
     ) -> object:
-        """Create simulation execution context (context manager).
-
-        Returns an object whose __enter__ yields a SimContext.
-        """
+        """Create simulation execution context (context manager)."""
         ...
 
-    def request_abort(self) -> None:
-        """Signal all running operations to stop."""
-        ...
+    def request_abort(self) -> None: ...
+    def clear_abort(self) -> None: ...
+    def is_abort_requested(self) -> bool: ...
 
-    def clear_abort(self) -> None:
-        """Clear the abort flag."""
-        ...
 
-    def is_abort_requested(self) -> bool:
-        """Check if an abort has been requested."""
-        ...
+class RobotBase:
+    """Base class providing manipulation convenience methods.
+
+    Subclass and pass arms, grasp_manager, etc. to __init__. Gets
+    pickup/place/go_home/find_objects/holding/get_object_pose for free.
+    """
+
+    def __init__(
+        self,
+        model: mujoco.MjModel,
+        data: mujoco.MjData,
+        arms: dict[str, Arm],
+        grasp_manager: GraspManager,
+        named_poses: dict[str, dict[str, list[float]]] | None = None,
+        grasp_source: GraspSource | None = None,
+    ):
+        self.model = model
+        self.data = data
+        self.arms = arms
+        self.grasp_manager = grasp_manager
+        self.named_poses = named_poses or {}
+        self._grasp_source = grasp_source
+        self._context = None
+        self._abort_event = threading.Event()
+
+    @property
+    def grasp_source(self) -> GraspSource:
+        if self._grasp_source is None:
+            self._grasp_source = _NullGraspSource()
+        return self._grasp_source
+
+    @grasp_source.setter
+    def grasp_source(self, value: GraspSource) -> None:
+        self._grasp_source = value
+
+    @property
+    def _active_context(self):
+        return self._context
+
+    @_active_context.setter
+    def _active_context(self, ctx):
+        self._context = ctx
+
+    # -- Execution context -----------------------------------------------------
+
+    def sim(self, *, physics=True, headless=False, viewer=None, event_loop=None):
+        """Create simulation execution context."""
+        from mj_manipulator.sim_context import SimContext
+
+        inner = SimContext(
+            self.model,
+            self.data,
+            self.arms,
+            physics=physics,
+            headless=headless,
+            viewer=viewer,
+            event_loop=event_loop,
+            abort_fn=self.is_abort_requested,
+        )
+        return _SimContextWrapper(inner, self)
+
+    # -- Abort -----------------------------------------------------------------
+
+    def request_abort(self):
+        if self._context is not None and hasattr(self._context, "ownership") and self._context.ownership is not None:
+            self._context.ownership.abort_all()
+        self._abort_event.set()
+
+    def clear_abort(self):
+        if self._context is not None and hasattr(self._context, "ownership") and self._context.ownership is not None:
+            self._context.ownership.clear_all()
+        self._abort_event.clear()
+
+    def is_abort_requested(self):
+        return self._abort_event.is_set()
+
+    # -- Manipulation primitives -----------------------------------------------
+
+    def pickup(self, target=None, **kwargs):
+        """Pick up an object."""
+        from mj_manipulator.primitives import pickup
+
+        return pickup(self, target, **kwargs)
+
+    def place(self, destination=None, **kwargs):
+        """Place the held object."""
+        from mj_manipulator.primitives import place
+
+        return place(self, destination, **kwargs)
+
+    def go_home(self, **kwargs):
+        """Return to ready configuration."""
+        from mj_manipulator.primitives import go_home
+
+        return go_home(self, **kwargs)
+
+    # -- Scene queries ---------------------------------------------------------
+
+    def find_objects(self, target=None):
+        """List graspable objects in the scene."""
+        objects = self.grasp_source.get_graspable_objects()
+        if target:
+            return [o for o in objects if target in o]
+        return objects
+
+    def holding(self):
+        """Get (arm_name, object_name) if any arm is holding, else None."""
+        for arm_name, arm in self.arms.items():
+            if arm.gripper and arm.gripper.is_holding and arm.gripper.held_object:
+                return (arm_name, arm.gripper.held_object)
+        return None
+
+    def get_object_pose(self, body_name):
+        """Get 4x4 world-frame pose of a MuJoCo body."""
+        bid = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_BODY, body_name)
+        if bid < 0:
+            raise ValueError(f"Body not found: {body_name}")
+        pose = np.eye(4)
+        pose[:3, :3] = self.data.xmat[bid].reshape(3, 3)
+        pose[:3, 3] = self.data.xpos[bid]
+        return pose
+
+
+class _SimContextWrapper:
+    """Sets robot._active_context on enter/exit."""
+
+    def __init__(self, inner, robot):
+        self._inner = inner
+        self._robot = robot
+
+    def __enter__(self):
+        ctx = self._inner.__enter__()
+        self._robot._active_context = ctx
+        return ctx
+
+    def __exit__(self, *args):
+        self._robot._active_context = None
+        return self._inner.__exit__(*args)
+
+
+class _NullGraspSource:
+    """GraspSource that returns empty results."""
+
+    def get_grasps(self, object_name, hand_type):
+        return []
+
+    def get_placements(self, destination, object_name):
+        return []
+
+    def get_graspable_objects(self):
+        return []
+
+    def get_place_destinations(self, object_name):
+        return []

--- a/src/mj_manipulator/sim_context.py
+++ b/src/mj_manipulator/sim_context.py
@@ -496,8 +496,12 @@ class SimContext:
         position = np.asarray(position)
 
         if self._event_loop is not None and self._controller is not None:
-            # Tick-driven: set targets only, tick() will step physics
+            # Tick-driven: set targets and step physics.
+            # On the owner thread (e.g. CartesianMove inside a BT tree),
+            # we must pump tick() ourselves — nobody else will.
             self._event_loop.run_on_physics_thread(lambda: self._set_reactive_target(arm_name, position, velocity))
+            if threading.get_ident() == self._event_loop._owner_thread:
+                self._event_loop.tick()
         elif self._event_loop is not None:
             self._event_loop.run_on_physics_thread(lambda: self._step_cartesian_impl(arm_name, position, velocity))
         else:


### PR DESCRIPTION
## Summary

Make \`python -m mj_manipulator --objects '{"can": 3}' --physics\` work end-to-end with pickup/place.

### PrlAssetsGraspSource

Moved from geodude into \`mj_manipulator/grasp_sources/prl_assets.py\`. Parameterized on model/data/grasp_manager/arms instead of the full Geodude robot — any robot with prl_assets objects can use it.

### CLI wiring

When \`--objects\` is passed, \`_SimpleRobot\` auto-creates a \`PrlAssetsGraspSource\` so \`pickup()\` generates real TSRs from object geometry.

### Geodude simplification

\`GeodueGraspSource\` shrinks from 542 → 50 LOC — thin wrapper that delegates to the shared \`PrlAssetsGraspSource\`.

## Test plan

- [x] 306 mj_manipulator tests pass
- [x] 113 geodude tests pass
- [ ] \`python -m mj_manipulator --objects '{"can": 3}' --physics\` → pickup works
- [ ] geodude demo still works

Closes #62. Companion: personalrobotics/geodude

🤖 Generated with [Claude Code](https://claude.com/claude-code)