### PR TITLE
Primitives polish: failure reporting, StatusHud, container hiding (#72, #73, #74)

### DIFF
--- a/src/mj_manipulator/console.py
+++ b/src/mj_manipulator/console.py
@@ -162,6 +162,15 @@ def start_console(
                     panel.setup(gui, viser_viewer)
                     viser_viewer._panels.append(panel)
 
+        # -- Status HUD ------------------------------------------------------------
+        if viser and viser_viewer is not None:
+            from mj_manipulator.status_hud import StatusHud
+
+            status_hud = StatusHud(robot, mode)
+            robot._status_hud = status_hud
+            viser_viewer._panels.append(status_hud)
+            status_hud.setup(viser_viewer._server.gui, viser_viewer)
+
         # -- Robot-specific panels via callback --------------------------------
         if panel_setup is not None and viser_viewer is not None and tabs is not None:
             panel_setup(

--- a/src/mj_manipulator/primitives.py
+++ b/src/mj_manipulator/primitives.py
@@ -48,7 +48,68 @@ def _tick_tree(root: py_trees.behaviour.Behaviour, verbose: bool = False) -> boo
     if verbose:
         print(py_trees.display.ascii_tree(root, show_status=True))
 
+    if root.status != Status.SUCCESS:
+        tip = root.tip()
+        if tip is not None and tip.feedback_message and tip.feedback_message != "Aborted":
+            logger.warning("%s: %s", tip.name, tip.feedback_message)
+
     return root.status == Status.SUCCESS
+
+
+def _maybe_hide_in_container(robot, ns: str, destination: str | None, held_name: str) -> None:
+    """Hide object if it was placed into a container (bin, tote).
+
+    Checks the prl_assets metadata for the destination. If it's a container
+    type (open_box, tote), hides the object from the scene.
+    """
+    import re
+
+    # Resolve destination from blackboard if not specified
+    resolved = destination
+    if resolved is None:
+        try:
+            _bb = py_trees.blackboard.Client(name=f"place_resolve{ns}")
+            _bb.register_key(key=f"{ns}/tsr_to_destination", access=Access.READ)
+            _bb.register_key(key=f"{ns}/goal_tsr_index", access=Access.READ)
+            mapping = _bb.get(f"{ns}/tsr_to_destination")
+            idx = _bb.get(f"{ns}/goal_tsr_index")
+            if mapping and idx is not None and idx < len(mapping):
+                resolved = mapping[idx]
+        except (KeyError, RuntimeError):
+            pass
+
+    if resolved is None or resolved == "worktop":
+        return
+
+    # Check if destination is a container type
+    try:
+        from asset_manager import AssetManager
+        from prl_assets import OBJECTS_DIR
+
+        m = re.match(r"^(.+?)_(\d+)$", resolved)
+        dest_type = m.group(1) if m else resolved
+        assets = AssetManager(str(OBJECTS_DIR))
+        gp = assets.get(dest_type)["geometric_properties"]
+        if gp.get("type") not in ("open_box", "tote"):
+            return
+    except (KeyError, TypeError, ImportError):
+        return
+
+    # Hide the object
+    env = getattr(robot, "_env", None)
+    if env is not None and hasattr(env, "registry") and env.registry is not None:
+        if env.registry.is_active(held_name):
+            env.registry.hide(held_name)
+            import mujoco
+
+            mujoco.mj_forward(robot.model, robot.data)
+
+
+def _set_hud_action(robot, arm_name: str, text: str) -> None:
+    """Update HUD status for an arm (no-op if no HUD)."""
+    hud = getattr(robot, "_status_hud", None)
+    if hud is not None:
+        hud.set_action(arm_name, text)
 
 
 def _arm_preempted(robot, arm_name: str) -> bool:
@@ -182,9 +243,14 @@ def _pickup_inner(robot, ctx, target, *, arm, verbose) -> bool:
         bb.register_key(key=f"{ns}/object_name", access=Access.WRITE)
         bb.set(f"{ns}/object_name", target)
 
+        desc = target or "any"
+        _set_hud_action(robot, side, f"⟳ pickup({desc})")
         tree = full_pickup(ns)
         if _tick_tree(tree, verbose=verbose):
+            _set_hud_action(robot, side, f"✓ pickup({desc})")
             return True
+
+        _set_hud_action(robot, side, f"✗ pickup({desc})")
 
         # Stop if abort or this arm was preempted (e.g. teleop)
         if robot.is_abort_requested() or _arm_preempted(robot, side):
@@ -260,12 +326,21 @@ def _place_inner(robot, ctx, destination, *, arm, verbose) -> bool:
         held_name = arm_obj.gripper.held_object
     bb.set(f"{ns}/object_name", held_name)
 
+    desc = destination or "auto"
+    _set_hud_action(robot, arm, f"⟳ place({desc})")
     tree = full_place(ns)
-    if _tick_tree(tree, verbose=verbose):
-        return True
+    ok = _tick_tree(tree, verbose=verbose)
 
-    logger.warning("Place failed for destination '%s'", destination)
-    return False
+    if ok:
+        _set_hud_action(robot, arm, f"✓ place({desc})")
+        # Hide object if placed in a container (simulates disposal)
+        if held_name:
+            _maybe_hide_in_container(robot, ns, destination, held_name)
+    else:
+        _set_hud_action(robot, arm, f"✗ place({desc})")
+        logger.warning("Place failed for destination '%s'", destination)
+
+    return ok
 
 
 def go_home(
@@ -317,18 +392,48 @@ def _go_home_inner(robot, ctx, *, arm, verbose) -> bool:
         if side not in ready_poses:
             continue
         arm_obj = robot.arms[side]
+
+        def abort_fn(s=side):
+            return robot.is_abort_requested() or _arm_preempted(robot, s)
+
         goal = np.array(ready_poses[side])
 
-        abort_fn = robot.is_abort_requested
-        path = arm_obj.plan_to_configuration(goal, abort_fn=abort_fn)
-        if path is None:
-            logger.warning("go_home: planning failed for %s", side)
-            all_ok = False
-            continue
+        try:
+            path = arm_obj.plan_to_configuration(goal, abort_fn=abort_fn)
+        except Exception as e:
+            logger.warning("go_home %s: plan failed: %s", side, e)
+            path = None
 
-        traj = arm_obj.retime(path)
-        if not ctx.execute(traj):
-            logger.warning("go_home: execution failed for %s", side)
+        if path is None:
+            # Retract up first, then retry
+            logger.warning("go_home %s: retract up and retry", side)
+            from mj_manipulator.cartesian import CartesianController
+
+            arm_name = arm_obj.config.name
+
+            def _step_fn(q, qd):
+                ctx.step_cartesian(arm_name, q, qd)
+
+            ctrl = CartesianController.from_arm(arm_obj, step_fn=_step_fn)
+            ctrl.move(
+                np.array([0.0, 0.0, 0.10, 0.0, 0.0, 0.0]),
+                dt=ctx.control_dt,
+                max_distance=0.10,
+                stop_condition=abort_fn,
+            )
+            try:
+                path = arm_obj.plan_to_configuration(goal, abort_fn=abort_fn)
+            except Exception as e:
+                logger.warning("go_home %s: retry failed: %s", side, e)
+                path = None
+
+        if path is not None:
+            traj = arm_obj.retime(path)
+            if not ctx.execute(traj):
+                logger.warning("go_home: execution failed for %s", side)
+                all_ok = False
+        else:
+            logger.warning("go_home: could not plan %s to ready", side)
             all_ok = False
 
     ctx.sync()

--- a/src/mj_manipulator/status_hud.py
+++ b/src/mj_manipulator/status_hud.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Status HUD overlay for the viser browser viewer.
+
+Shows per-arm status: force, held object, and current action.
+Works with any robot that implements ManipulationRobot.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import viser
+from mj_viser import MujocoViewer, PanelBase
+
+from mj_manipulator.ownership import OwnerKind
+
+if TYPE_CHECKING:
+    pass
+
+
+class StatusHud(PanelBase):
+    """Compact status overlay on the 3D viewport.
+
+    Reads live state from the robot each frame. Actions are set by
+    primitives and auto-cleared after a timeout.
+    """
+
+    ACTION_TIMEOUT = 5.0  # seconds before action text clears
+
+    def __init__(self, robot, mode: str = "") -> None:
+        self._robot = robot
+        self._mode = mode
+        self._actions: dict[str, tuple[str, float]] = {}  # arm → (text, timestamp)
+
+    def name(self) -> str:
+        return "StatusHud"
+
+    def set_action(self, arm_name: str, text: str) -> None:
+        """Set the current action text for an arm."""
+        import time
+
+        self._actions[arm_name] = (text, time.monotonic())
+
+    def clear_action(self, arm_name: str) -> None:
+        """Clear the action text for an arm."""
+        self._actions.pop(arm_name, None)
+
+    def setup(self, gui: viser.GuiApi, viewer: MujocoViewer) -> None:
+        self._viewer = viewer
+        viewer.set_hud("status", self._build_status(), "bottom-left")
+
+    def on_sync(self, viewer: MujocoViewer) -> None:
+        viewer.set_hud("status", self._build_status(), "bottom-left")
+
+    def _build_status(self) -> str:
+        import time
+
+        robot = self._robot
+        now = time.monotonic()
+        parts = []
+
+        for arm_name, arm in robot.arms.items():
+            # Label: full name for single-arm, first letter for multi-arm
+            if len(robot.arms) == 1:
+                label = arm_name
+            else:
+                label = arm_name[0].upper()
+
+            # F/T magnitude (skip if no sensor)
+            force_str = ""
+            if arm.has_ft_sensor:
+                wrench = arm.get_ft_wrench()
+                if not np.isnan(wrench[0]):
+                    force_mag = float(np.linalg.norm(wrench[:3]))
+                    force_str = f"[{force_mag:.0f}N] "
+
+            # Held object
+            held = robot.grasp_manager.get_grasped_by(arm_name)
+            held_str = held[0] if held else ""
+
+            # Current action: teleop overrides, timed actions expire
+            action = ""
+            ctx = getattr(robot, "_active_context", None)
+            if ctx is not None and hasattr(ctx, "ownership") and ctx.ownership is not None:
+                kind, _ = ctx.ownership.owner_of(arm_name)
+                if kind == OwnerKind.TELEOP:
+                    action = "teleop"
+                elif kind == OwnerKind.TRAJECTORY:
+                    action = "executing"
+
+            if not action and arm_name in self._actions:
+                text, ts = self._actions[arm_name]
+                if now - ts < self.ACTION_TIMEOUT:
+                    action = text
+                else:
+                    del self._actions[arm_name]
+
+            # Build arm status
+            status = f"<b>{label}</b>: {force_str}"
+            if held_str:
+                status += held_str
+            if action:
+                if held_str:
+                    status += f" | {action}"
+                else:
+                    status += action
+
+            parts.append(status)
+
+        line = " &nbsp;&nbsp; ".join(parts)
+        if self._mode:
+            line += f" &nbsp;&nbsp; {self._mode}"
+        return line


### PR DESCRIPTION
Three improvements ported from geodude to the generic primitives:

1. **Failure reporting (#74)**: _tick_tree logs the BT tip node's feedback_message on failure
2. **StatusHud (#72)**: generic N-arm status overlay showing force, held object, ownership state (teleop/executing), and timed action text. Auto-created by start_console.
3. **Container hiding (#73)**: after successful place, hides objects placed in containers (open_box/tote)

Also: go_home retract-first recovery — if planning fails, retract up 10cm then retry.

Closes #72, closes #73, closes #74