### PR TITLE
Franka demo polish: gravcomp, pad friction, IK-based safe_retract

### DIFF
--- a/demos/verify_cartesian_lift.py
+++ b/demos/verify_cartesian_lift.py
@@ -1,0 +1,190 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Headless regression test for safe_retract.
+
+Runs safe_retract in three scenarios against a clean Franka in an empty
+scene and asserts strict bounds on the resulting EE motion:
+
+  1. Home pose, kinematic mode — planning + perfect-tracking execution.
+  2. Home pose, physics mode — planning + PD control + gravcomp.
+  3. Pre-grasp-like low pose, physics mode — the demo's actual failure
+     case, where the arm reaches down toward the raised plate.
+
+For each scenario we command a 15 cm upward lift (twist = [0,0,0.10,...])
+and report:
+
+    z travel   — actual EE +Z delta  (expected +150.00 mm)
+    x drift    — actual EE X delta   (expected    +0.00)
+    y drift    — actual EE Y delta   (expected    +0.00)
+    rot error  — ||R_end R_start^T - I||_F  (expected ~0)
+    Δq (deg)   — per-joint joint-space delta
+
+This exercises the full scripted-Cartesian execution path
+(``plan_cartesian_path`` → TOPP-RA retime → ``ctx.execute``) in both
+kinematic and physics modes, and is the regression test for the fix to
+personalrobotics/mj_manipulator#68.
+
+Usage:
+    cd mj_manipulator
+    uv run python demos/verify_cartesian_lift.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+import mujoco
+import numpy as np
+from mj_environment import Environment
+
+from mj_manipulator.arms.franka import (
+    FRANKA_HOME,
+    add_franka_ee_site,
+    add_franka_gravcomp,
+    create_franka_arm,
+)
+from mj_manipulator.menagerie import menagerie_scene
+from mj_manipulator.safe_retract import safe_retract
+from mj_manipulator.sim_context import SimContext
+
+# Lift parameters — match the pickup subtree default
+LIFT_TWIST = np.array([0.0, 0.0, 0.10, 0.0, 0.0, 0.0])
+LIFT_DISTANCE = 0.15  # meters
+
+# A "reach down" configuration where the Franka EE hovers above the raised
+# plate (z≈0.05). Hardcoded instead of IK-solved so the test is
+# deterministic and independent of the IK branch selection.
+FRANKA_PREGRASP = np.array(
+    [0.0, 0.6, 0.0, -2.0, 0.0, 2.6, -0.7853],
+    dtype=float,
+)
+
+
+def _make_env() -> Environment:
+    scene_path = menagerie_scene("franka_emika_panda")
+    if not scene_path.exists():
+        print(f"ERROR: Franka scene not found at {scene_path}")
+        sys.exit(1)
+    spec = mujoco.MjSpec.from_file(str(scene_path))
+    add_franka_ee_site(spec)
+    add_franka_gravcomp(spec)
+    return Environment.from_model(spec.compile())
+
+
+def _set_arm(arm, env, q: np.ndarray) -> None:
+    for i, idx in enumerate(arm.joint_qpos_indices):
+        env.data.qpos[idx] = q[i]
+    for idx in arm.joint_qvel_indices:
+        env.data.qvel[idx] = 0.0
+    mujoco.mj_forward(env.model, env.data)
+
+
+def _measure(arm, env, ctx):
+    """Run safe_retract via ``ctx`` and return a dict of measurements."""
+    mujoco.mj_forward(env.model, env.data)
+
+    ee_id = arm.ee_site_id
+    start_pos = env.data.site_xpos[ee_id].copy()
+    start_rot = env.data.site_xmat[ee_id].reshape(3, 3).copy()
+    start_q = arm.get_joint_positions().copy()
+
+    reported = safe_retract(
+        arm,
+        ctx,
+        twist=LIFT_TWIST,
+        max_distance=LIFT_DISTANCE,
+    )
+
+    end_pos = env.data.site_xpos[ee_id].copy()
+    end_rot = env.data.site_xmat[ee_id].reshape(3, 3).copy()
+    end_q = arm.get_joint_positions().copy()
+
+    delta = end_pos - start_pos
+    rot_err = float(np.linalg.norm(end_rot @ start_rot.T - np.eye(3), ord="fro"))
+    joint_delta = np.rad2deg(end_q - start_q)
+
+    return {
+        "reported": reported,
+        "x_drift": float(delta[0]),
+        "y_drift": float(delta[1]),
+        "z_travel": float(delta[2]),
+        "rot_err": rot_err,
+        "joint_delta_deg": joint_delta,
+        "start_ee": start_pos,
+        "end_ee": end_pos,
+    }
+
+
+def _print_row(label: str, m: dict) -> None:
+    print(f"  {label}")
+    print(f"    start EE   = [{m['start_ee'][0]:+.3f}, {m['start_ee'][1]:+.3f}, {m['start_ee'][2]:+.3f}] m")
+    print(f"    end EE     = [{m['end_ee'][0]:+.3f}, {m['end_ee'][1]:+.3f}, {m['end_ee'][2]:+.3f}] m")
+    print(f"    reported   = {m['reported'] * 1000:+7.2f} mm")
+    print(f"    z travel   = {m['z_travel'] * 1000:+7.2f} mm   (expected  +150.00)")
+    print(f"    x drift    = {m['x_drift'] * 1000:+7.2f} mm   (expected    +0.00)")
+    print(f"    y drift    = {m['y_drift'] * 1000:+7.2f} mm   (expected    +0.00)")
+    print(f"    rot err    = {m['rot_err']:.5f}       (expected     0.00000)")
+    jdelta = m["joint_delta_deg"]
+    jstr = " ".join(f"{x:+6.2f}" for x in jdelta)
+    print(f"    Δq (deg)   = [{jstr}]")
+
+
+def _run_scenario(label: str, home_q: np.ndarray, physics: bool) -> dict:
+    env = _make_env()
+    arm = create_franka_arm(env)
+    _set_arm(arm, env, home_q)
+    with SimContext(
+        env.model,
+        env.data,
+        {arm.config.name: arm},
+        physics=physics,
+        headless=True,
+    ) as ctx:
+        return _measure(arm, env, ctx)
+
+
+def main() -> int:
+    print("=" * 72)
+    print("  safe_retract regression test")
+    print("=" * 72)
+    print(f"  twist       = {LIFT_TWIST.tolist()}")
+    print(f"  distance    = {LIFT_DISTANCE * 1000:.0f} mm")
+    print()
+
+    print("Scenario 1: FRANKA_HOME, kinematic mode")
+    m1 = _run_scenario("kinematic/home", FRANKA_HOME, physics=False)
+    _print_row("kinematic/home", m1)
+    print()
+
+    print("Scenario 2: FRANKA_HOME, physics mode (PD + gravcomp)")
+    m2 = _run_scenario("physics/home", FRANKA_HOME, physics=True)
+    _print_row("physics/home", m2)
+    print()
+
+    print("Scenario 3: FRANKA_PREGRASP (low reach-down), physics mode")
+    m3 = _run_scenario("physics/low", FRANKA_PREGRASP, physics=True)
+    _print_row("physics/low", m3)
+    print()
+
+    print("=" * 72)
+    print("  Verdict")
+    print("=" * 72)
+    all_pass = True
+    for name, m in [("kinematic/home", m1), ("physics/home", m2), ("physics/low", m3)]:
+        z_ok = abs(m["z_travel"] - LIFT_DISTANCE) < 0.005  # within 5 mm
+        xy_ok = abs(m["x_drift"]) < 0.002 and abs(m["y_drift"]) < 0.002  # < 2 mm drift
+        rot_ok = m["rot_err"] < 0.02
+        passed = z_ok and xy_ok and rot_ok
+        all_pass = all_pass and passed
+        print(
+            f"  {name:20s}  {'PASS' if passed else 'FAIL'}  "
+            f"(z={'ok' if z_ok else 'bad'}, "
+            f"xy={'ok' if xy_ok else 'bad'}, "
+            f"rot={'ok' if rot_ok else 'bad'})"
+        )
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/mj_manipulator/arm.py
+++ b/src/mj_manipulator/arm.py
@@ -209,6 +209,32 @@ class Arm:
         self.dof: int = len(config.joint_names)
         self._joint_limits: tuple[np.ndarray, np.ndarray] | None = None
 
+        # Check whether gravity compensation is active on the arm subtree.
+        # MuJoCo optimizes gravcomp away at compile time if every body has
+        # gravcomp=0, and runtime changes to body_gravcomp are silently
+        # ignored. The per-arm MjSpec helpers (add_franka_gravcomp,
+        # add_ur5e_gravcomp) must be called BEFORE spec.compile(). Real
+        # robot controllers (Franka FCI, UR RTDE, KUKA FRI, etc.) run
+        # gravity compensation internally; without it in sim, the PD loop
+        # must fight gravity via steady-state position error, producing
+        # sag at rest and tracking lag in motion.
+        first_joint_body = model.jnt_bodyid[self.joint_ids[0]]
+        base_body_id = model.body_parentid[first_joint_body]
+        subtree_has_gravcomp = any(
+            model.body_gravcomp[bid] > 0
+            for bid in range(base_body_id, model.nbody)
+        )
+        if not subtree_has_gravcomp:
+            logger.warning(
+                "Arm '%s' has no gravity compensation on its kinematic "
+                "subtree. Call add_%s_gravcomp(spec) BEFORE spec.compile() "
+                "(or bake gravcomp='1' into the source XML). Without it, "
+                "the PD loop must fight gravity via steady-state position "
+                "error, producing sag at rest and tracking lag in motion.",
+                config.name,
+                config.name,
+            )
+
         # Resolve F/T sensor indices (if configured)
         self._ft_force_adr: int | None = None
         self._ft_torque_adr: int | None = None

--- a/src/mj_manipulator/arm.py
+++ b/src/mj_manipulator/arm.py
@@ -220,10 +220,7 @@ class Arm:
         # sag at rest and tracking lag in motion.
         first_joint_body = model.jnt_bodyid[self.joint_ids[0]]
         base_body_id = model.body_parentid[first_joint_body]
-        subtree_has_gravcomp = any(
-            model.body_gravcomp[bid] > 0
-            for bid in range(base_body_id, model.nbody)
-        )
+        subtree_has_gravcomp = any(model.body_gravcomp[bid] > 0 for bid in range(base_body_id, model.nbody))
         if not subtree_has_gravcomp:
             logger.warning(
                 "Arm '%s' has no gravity compensation on its kinematic "

--- a/src/mj_manipulator/arms/franka.py
+++ b/src/mj_manipulator/arms/franka.py
@@ -62,6 +62,43 @@ _FRANKA_LOCKED_JOINT_INDEX = 4
 # ---------------------------------------------------------------------------
 
 
+def fix_franka_grip_force(model: mujoco.MjModel, target_force: float = 140.0) -> None:
+    """Scale Franka gripper actuator to match real hardware grip force.
+
+    The menagerie model's actuator8 under-produces grip force. The real
+    Franka hand grips at 140N (70N per finger). We scale both gain and
+    bias proportionally so the actuator reaches target_force at full close
+    while ctrl=255 can still hold the fingers open.
+
+    Args:
+        model: Compiled MjModel (modified in place).
+        target_force: Desired grip force at full close [N]. Default 140N
+            from the Franka Emika datasheet.
+    """
+    aid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_ACTUATOR, "actuator8")
+    if aid < 0:
+        return
+
+    # Actuator force model: force = gain * ctrl + bias[1] * length + bias[2] * velocity
+    # To grip at target_force when ctrl=0 and grasping a typical object:
+    #   target_force = |bias[1]| * length_grasp
+    # To hold open when ctrl=255:
+    #   gain * 255 = |bias[1]| * length_open  (zero net force)
+    length_open = 0.08  # 2 × finger_joint open position (0.04m each)
+    length_grasp = 0.066  # typical grasp (e.g., soda can r=33mm)
+
+    new_bias1 = -target_force / length_grasp
+    new_gain = abs(new_bias1) * length_open / 255.0
+
+    # Scale damping proportionally to bias spring
+    old_bias1 = model.actuator_biasprm[aid, 1]
+    scale = new_bias1 / old_bias1 if old_bias1 != 0 else 1.0
+
+    model.actuator_biasprm[aid, 1] = new_bias1
+    model.actuator_biasprm[aid, 2] *= scale
+    model.actuator_gainprm[aid, 0] = new_gain
+
+
 def add_franka_ee_site(
     spec: mujoco.MjSpec,
     site_name: str = "grasp_site",

--- a/src/mj_manipulator/arms/franka.py
+++ b/src/mj_manipulator/arms/franka.py
@@ -131,6 +131,33 @@ def add_franka_ee_site(
     site.pos = pos
 
 
+def add_franka_gravcomp(spec: mujoco.MjSpec) -> None:
+    """Enable gravity compensation on every Franka body in an MjSpec.
+
+    Must be called **before** ``spec.compile()``. MuJoCo optimizes gravcomp
+    away at compile time if every body has ``gravcomp=0``; runtime changes
+    to ``model.body_gravcomp`` are silently ignored.
+
+    The menagerie Franka model ships without gravcomp. Real Franka FCI runs
+    gravity compensation internally at 1 kHz, so enabling it in sim matches
+    hardware behavior — otherwise the PD loop must fight gravity via
+    steady-state position error, producing sag at rest and tracking lag in
+    motion. Call this on every Franka MjSpec loaded from the menagerie,
+    analogous to ``add_franka_ee_site``.
+
+    Args:
+        spec: MjSpec loaded from a Franka scene XML.
+    """
+    _FRANKA_BODIES = [
+        "link0", "link1", "link2", "link3", "link4", "link5", "link6",
+        "link7", "hand", "left_finger", "right_finger",
+    ]
+    for name in _FRANKA_BODIES:
+        body = spec.body(name)
+        if body is not None:
+            body.gravcomp = 1.0
+
+
 # ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------

--- a/src/mj_manipulator/arms/franka.py
+++ b/src/mj_manipulator/arms/franka.py
@@ -232,8 +232,17 @@ def add_franka_gravcomp(spec: mujoco.MjSpec) -> None:
         spec: MjSpec loaded from a Franka scene XML.
     """
     _FRANKA_BODIES = [
-        "link0", "link1", "link2", "link3", "link4", "link5", "link6",
-        "link7", "hand", "left_finger", "right_finger",
+        "link0",
+        "link1",
+        "link2",
+        "link3",
+        "link4",
+        "link5",
+        "link6",
+        "link7",
+        "hand",
+        "left_finger",
+        "right_finger",
     ]
     for name in _FRANKA_BODIES:
         body = spec.body(name)

--- a/src/mj_manipulator/arms/franka.py
+++ b/src/mj_manipulator/arms/franka.py
@@ -131,6 +131,89 @@ def add_franka_ee_site(
     site.pos = pos
 
 
+def add_franka_pad_friction(
+    spec: mujoco.MjSpec,
+    *,
+    sliding_friction: float = 1.5,
+    torsional_friction: float = 0.05,
+    rolling_friction: float = 0.0002,
+    solref: tuple[float, float] = (0.01, 1.0),
+    solimp: tuple[float, float, float, float, float] = (0.9, 0.95, 0.001, 0.5, 2.0),
+) -> None:
+    """Boost fingertip-pad grip to mimic compliant silicone contact.
+
+    Must be called **before** ``spec.compile()``.
+
+    The real Franka hand has **moulded silicone pads** on the fingertips: a
+    ~12 × 22 mm flat face with a shallow cylindrical groove, ~3 mm thick,
+    that deforms a couple of millimeters under 70 N of normal force. The
+    compliance turns line contact against a cylinder into a strip contact
+    ~8 mm wide, dramatically increasing grip against transverse load.
+
+    The menagerie Panda model approximates each pad with **five small
+    rigid boxes** and no friction override. Against a can the contact
+    area collapses to almost a point, the silicone grip is lost, and
+    even a modest acceleration during the lift slides the object out of
+    the gripper. This helper applies two compensations to the pad
+    collision geoms:
+
+    1. **High priority friction**: ``friction=(sliding, torsional,
+       rolling)`` with ``priority=1`` so the pad wins over the held
+       object's friction (normally MuJoCo takes per-parameter max).
+       Default ``sliding_friction=1.5`` is within the physically
+       plausible range for silicone-on-aluminum; torsional and rolling
+       values are above MuJoCo defaults to resist rotational slip.
+
+    2. **Soft contact**: smaller ``solref[0]`` (contact time constant)
+       and tighter ``solimp`` (constraint impedance). This lets the
+       constraint solver produce a slight penetration (~1 mm) that
+       visually matches a deformed silicone pad and enlarges the
+       effective contact area.
+
+    Together these mimic silicone compliance and grip without changing
+    the pad geometry, at the cost of modeling rigid-body contact that
+    behaves "as if" it were compliant. This is the standard sim
+    tradeoff for parallel-jaw grasping tasks — adding compliant-contact
+    primitives to MuJoCo is out of scope.
+
+    Args:
+        spec: MjSpec loaded from a Franka scene XML.
+        sliding_friction: Coulomb friction coefficient (1st friction
+            parameter). Real silicone-on-metal is ~1.0-1.5.
+        torsional_friction: Rotational friction about contact normal
+            (2nd friction parameter). MuJoCo default 0.005 is too low.
+        rolling_friction: Resistance to rolling (3rd friction parameter).
+            MuJoCo default 0.0001 is fine but bumped slightly.
+        solref: ``(timeconst, dampratio)`` contact solver reference.
+            Smaller timeconst = softer contact, more penetration.
+            Default 0.01 s gives ~1 mm of "squish" against a can.
+        solimp: ``(dmin, dmax, width, midpoint, power)`` contact solver
+            impedance. Tighter ``dmin``/``dmax`` produce stiffer contact;
+            ``width`` controls how quickly the solver transitions between
+            them. MuJoCo defaults are ``(0.9, 0.95, 0.001, 0.5, 2.0)``.
+    """
+    friction = [sliding_friction, torsional_friction, rolling_friction]
+    solref_list = list(solref)
+    solimp_list = list(solimp)
+
+    for finger_name in ("left_finger", "right_finger"):
+        body = spec.body(finger_name)
+        if body is None:
+            continue
+        for geom in body.geoms:
+            # Only touch the pad collision boxes — skip visual meshes and
+            # the larger finger collision mesh. The pads are the five
+            # small boxes defined via fingertip_pad_collision_* classes.
+            if geom.type != mujoco.mjtGeom.mjGEOM_BOX:
+                continue
+            if geom.contype == 0:  # visual group
+                continue
+            geom.friction = friction
+            geom.solref = solref_list
+            geom.solimp = solimp_list
+            geom.priority = 1
+
+
 def add_franka_gravcomp(spec: mujoco.MjSpec) -> None:
     """Enable gravity compensation on every Franka body in an MjSpec.
 

--- a/src/mj_manipulator/bt/__init__.py
+++ b/src/mj_manipulator/bt/__init__.py
@@ -26,6 +26,7 @@ from mj_manipulator.bt.nodes import (
     PlanToTSRs,
     Release,
     Retime,
+    SafeRetract,
     Sync,
 )
 from mj_manipulator.bt.subtrees import (
@@ -48,6 +49,7 @@ __all__ = [
     "Grasp",
     "Release",
     "CartesianMove",
+    "SafeRetract",
     "CheckNotNearConfig",
     "Sync",
     "GenerateGrasps",

--- a/src/mj_manipulator/bt/nodes.py
+++ b/src/mj_manipulator/bt/nodes.py
@@ -233,6 +233,56 @@ class Release(_ManipulationNode):
         return Status.SUCCESS
 
 
+class SafeRetract(_ManipulationNode):
+    """Move along a twist until NEW collisions appear (post-grasp lift).
+
+    Unlike CartesianMove, this tracks the baseline contact state and stops
+    if new contacts appear. Start-state collisions (e.g. held object
+    touching source surface) are tolerated.
+
+    Reads: ``{ns}/arm``, ``{ns}/twist``, ``{ns}/distance``, ``/context``
+    """
+
+    def __init__(self, ns: str = "", name: str = "SafeRetract"):
+        super().__init__(name, ns)
+        self.bb.register_key(key=self._key("arm"), access=Access.READ)
+        self.bb.register_key(key=self._key("arm_name"), access=Access.READ)
+        self.bb.register_key(key=self._key("twist"), access=Access.READ)
+        self.bb.register_key(key=self._key("distance"), access=Access.READ)
+        self.bb.register_key(key="/context", access=Access.READ)
+        try:
+            self.bb.register_key(key="/abort_fn", access=Access.READ)
+        except KeyError:
+            pass
+
+    def update(self) -> Status:
+        from mj_manipulator.safe_retract import safe_retract
+
+        arm = self.bb.get(self._key("arm"))
+        arm_name = self.bb.get(self._key("arm_name"))
+        twist = self.bb.get(self._key("twist"))
+        distance = self.bb.get(self._key("distance"))
+        ctx = self.bb.get("/context")
+
+        try:
+            abort_fn = self.bb.get("/abort_fn")
+        except KeyError:
+            abort_fn = None
+
+        def step_fn(q, qd):
+            ctx.step_cartesian(arm_name, q, qd)
+
+        safe_retract(
+            arm,
+            step_fn,
+            twist,
+            max_distance=distance,
+            dt=ctx.control_dt,
+            stop_condition=abort_fn,
+        )
+        return Status.SUCCESS
+
+
 class CartesianMove(_ManipulationNode):
     """Move end-effector along a twist using Cartesian velocity control.
 

--- a/src/mj_manipulator/bt/nodes.py
+++ b/src/mj_manipulator/bt/nodes.py
@@ -236,9 +236,10 @@ class Release(_ManipulationNode):
 class SafeRetract(_ManipulationNode):
     """Move along a twist until NEW collisions appear (post-grasp lift).
 
-    Unlike CartesianMove, this tracks the baseline contact state and stops
-    if new contacts appear. Start-state collisions (e.g. held object
-    touching source surface) are tolerated.
+    Plans a Cartesian path along the twist direction and executes it via
+    the standard trajectory runner with a baseline-contact abort predicate.
+    Start-state collisions (e.g. held object touching source surface) are
+    tolerated; only *new* contacts stop the motion.
 
     Reads: ``{ns}/arm``, ``{ns}/twist``, ``{ns}/distance``, ``/context``
     """
@@ -246,7 +247,6 @@ class SafeRetract(_ManipulationNode):
     def __init__(self, ns: str = "", name: str = "SafeRetract"):
         super().__init__(name, ns)
         self.bb.register_key(key=self._key("arm"), access=Access.READ)
-        self.bb.register_key(key=self._key("arm_name"), access=Access.READ)
         self.bb.register_key(key=self._key("twist"), access=Access.READ)
         self.bb.register_key(key=self._key("distance"), access=Access.READ)
         self.bb.register_key(key="/context", access=Access.READ)
@@ -259,7 +259,6 @@ class SafeRetract(_ManipulationNode):
         from mj_manipulator.safe_retract import safe_retract
 
         arm = self.bb.get(self._key("arm"))
-        arm_name = self.bb.get(self._key("arm_name"))
         twist = self.bb.get(self._key("twist"))
         distance = self.bb.get(self._key("distance"))
         ctx = self.bb.get("/context")
@@ -269,15 +268,11 @@ class SafeRetract(_ManipulationNode):
         except KeyError:
             abort_fn = None
 
-        def step_fn(q, qd):
-            ctx.step_cartesian(arm_name, q, qd)
-
         safe_retract(
             arm,
-            step_fn,
+            ctx,
             twist,
             max_distance=distance,
-            dt=ctx.control_dt,
             stop_condition=abort_fn,
         )
         return Status.SUCCESS

--- a/src/mj_manipulator/bt/subtrees.py
+++ b/src/mj_manipulator/bt/subtrees.py
@@ -30,6 +30,7 @@ from mj_manipulator.bt.nodes import (
     PlanToTSRs,
     Release,
     Retime,
+    SafeRetract,
     Sync,
 )
 
@@ -83,7 +84,7 @@ def pickup(ns: str) -> py_trees.composites.Sequence:
             Sync(ns=ns),
             set_twist,
             set_distance,
-            CartesianMove(ns=ns),
+            SafeRetract(ns=ns),
             Sync(ns=ns),
         ],
     )

--- a/src/mj_manipulator/bt/subtrees.py
+++ b/src/mj_manipulator/bt/subtrees.py
@@ -51,43 +51,47 @@ def plan_and_execute(ns: str, tsrs_key: str = "tsrs") -> py_trees.composites.Seq
     )
 
 
-def pickup(ns: str) -> py_trees.composites.Sequence:
-    """Full pickup: plan → execute → grasp → lift.
+def pickup(ns: str, *, with_lift: bool = True) -> py_trees.composites.Sequence:
+    """Full pickup: plan → execute → grasp → (optional cartesian lift).
 
     Requires on blackboard:
         ``{ns}/arm``, ``{ns}/grasp_tsrs``, ``{ns}/timeout``,
         ``{ns}/arm_name``, ``{ns}/object_name``
 
-    Sets ``{ns}/twist`` and ``{ns}/distance`` for the lift.
-    """
-    # SetBlackboardVariable for lift parameters
-    set_twist = py_trees.behaviours.SetBlackboardVariable(
-        name="set_lift_twist",
-        variable_name=f"{ns}/twist",
-        variable_value=np.array([0.0, 0.0, 0.10, 0.0, 0.0, 0.0]),
-        overwrite=True,
-    )
-    set_distance = py_trees.behaviours.SetBlackboardVariable(
-        name="set_lift_distance",
-        variable_name=f"{ns}/distance",
-        variable_value=0.15,
-        overwrite=True,
-    )
+    Args:
+        ns: Blackboard namespace for this arm.
+        with_lift: If True (default), append a 15cm cartesian ``SafeRetract``
+            after the grasp — appropriate for fixed-base arms (Franka) where
+            the arm itself must clear the grasp. Set to False for arms mounted
+            on a linear base (e.g. geodude's Vention gantry) where the base
+            handles the post-grasp clearance and a cartesian arm lift would
+            be redundant or harmful.
 
-    return py_trees.composites.Sequence(
-        name="pickup",
-        memory=True,
-        children=[
-            plan_and_execute(ns, tsrs_key="grasp_tsrs"),
-            Sync(ns=ns),
-            Grasp(ns=ns),
-            Sync(ns=ns),
-            set_twist,
-            set_distance,
-            SafeRetract(ns=ns),
-            Sync(ns=ns),
-        ],
-    )
+    Sets ``{ns}/twist`` and ``{ns}/distance`` when ``with_lift=True``.
+    """
+    children: list[py_trees.behaviour.Behaviour] = [
+        plan_and_execute(ns, tsrs_key="grasp_tsrs"),
+        Sync(ns=ns),
+        Grasp(ns=ns),
+        Sync(ns=ns),
+    ]
+
+    if with_lift:
+        set_twist = py_trees.behaviours.SetBlackboardVariable(
+            name="set_lift_twist",
+            variable_name=f"{ns}/twist",
+            variable_value=np.array([0.0, 0.0, 0.10, 0.0, 0.0, 0.0]),
+            overwrite=True,
+        )
+        set_distance = py_trees.behaviours.SetBlackboardVariable(
+            name="set_lift_distance",
+            variable_name=f"{ns}/distance",
+            variable_value=0.15,
+            overwrite=True,
+        )
+        children.extend([set_twist, set_distance, SafeRetract(ns=ns), Sync(ns=ns)])
+
+    return py_trees.composites.Sequence(name="pickup", memory=True, children=children)
 
 
 def recover(ns: str) -> py_trees.composites.Sequence:
@@ -141,18 +145,23 @@ def recover(ns: str) -> py_trees.composites.Sequence:
     )
 
 
-def pickup_with_recovery(ns: str) -> py_trees.composites.Selector:
+def pickup_with_recovery(ns: str, *, with_lift: bool = True) -> py_trees.composites.Selector:
     """Pickup with fallback recovery on failure.
 
     If pickup fails at any stage, releases, retracts, and returns home.
     The Selector still returns FAILURE because recovery wraps with
     SuccessIsFailure — cleanup succeeded but the task did not.
+
+    Args:
+        ns: Blackboard namespace.
+        with_lift: Forwarded to :func:`pickup`. Set to False for gantry-mounted
+            arms that handle post-grasp clearance via a base lift.
     """
     return py_trees.composites.Selector(
         name="pickup_or_recover",
         memory=True,
         children=[
-            pickup(ns),
+            pickup(ns, with_lift=with_lift),
             py_trees.decorators.SuccessIsFailure(
                 name="recover_then_fail",
                 child=recover(ns),

--- a/src/mj_manipulator/cartesian_path.py
+++ b/src/mj_manipulator/cartesian_path.py
@@ -110,25 +110,20 @@ def plan_cartesian_path(
     """
     if arm.ik_solver is None:
         raise RuntimeError(
-            f"plan_cartesian_path requires an arm with an IK solver; "
-            f"arm '{arm.config.name}' was created without one."
+            f"plan_cartesian_path requires an arm with an IK solver; arm '{arm.config.name}' was created without one."
         )
 
     if not waypoints:
         raise ValueError("plan_cartesian_path: waypoints must be non-empty")
 
-    q_current = (
-        arm.get_joint_positions().copy() if q_start is None else np.asarray(q_start, dtype=float).copy()
-    )
+    q_current = arm.get_joint_positions().copy() if q_start is None else np.asarray(q_start, dtype=float).copy()
 
     joint_path: list[np.ndarray] = [q_current]
 
     for i, pose in enumerate(waypoints):
         pose = np.asarray(pose, dtype=float)
         if pose.shape != (4, 4):
-            raise ValueError(
-                f"plan_cartesian_path: waypoint {i} has shape {pose.shape}, expected (4, 4)"
-            )
+            raise ValueError(f"plan_cartesian_path: waypoint {i} has shape {pose.shape}, expected (4, 4)")
 
         solutions = arm.ik_solver.solve_valid(pose, q_init=q_current)
         if not solutions:
@@ -142,8 +137,7 @@ def plan_cartesian_path(
                 )
                 break
             raise ValueError(
-                f"plan_cartesian_path: no valid IK solution at waypoint {i} "
-                f"(pose translation = {pose[:3, 3]})"
+                f"plan_cartesian_path: no valid IK solution at waypoint {i} (pose translation = {pose[:3, 3]})"
             )
 
         q_next = min(solutions, key=lambda q: float(np.linalg.norm(q - q_current)))

--- a/src/mj_manipulator/cartesian_path.py
+++ b/src/mj_manipulator/cartesian_path.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Plan a joint-space trajectory that follows an SE(3) waypoint sequence.
+
+:func:`plan_cartesian_path` is the building block for **scripted** Cartesian
+motion — motions where the caller knows the desired end-effector path ahead
+of time and wants the arm to follow it as a retimed trajectory. Examples:
+
+- Post-grasp lift: straight-line +Z waypoints from the grasp pose
+- Pre-grasp approach: straight-line toward the grasp pose along the approach axis
+- Post-place retreat: straight-line backout after release
+- Tool-frame probes: small increments along tool Z until contact
+
+The returned :class:`~mj_manipulator.trajectory.Trajectory` is intended to be
+executed via :meth:`SimContext.execute`, which enforces joint velocity and
+acceleration limits via TOPP-RA retiming. Because the execution path is
+identical to the one used by the CBiRRT planner, scripted Cartesian motion
+inherits the same smooth PD tracking that planned motion already has —
+without the per-segment jerkiness that a reactive Cartesian controller can
+introduce in physics mode.
+
+This is the **scripted** Cartesian primitive. For operator-driven reactive
+Cartesian control (teleop, force-guided motion), use
+:class:`~mj_manipulator.cartesian.CartesianController` instead.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from mj_manipulator.arm import Arm
+    from mj_manipulator.trajectory import Trajectory
+
+logger = logging.getLogger(__name__)
+
+
+def plan_cartesian_path(
+    arm: Arm,
+    waypoints: list[np.ndarray],
+    *,
+    q_start: np.ndarray | None = None,
+    control_dt: float = 0.008,
+    max_branch_jump: float | None = None,
+    partial_ok: bool = False,
+) -> Trajectory:
+    """Plan a joint-space trajectory that follows an SE(3) waypoint sequence.
+
+    Solves analytical IK at each waypoint via the arm's ``ik_solver``,
+    selects the solution closest in joint space to the previous
+    configuration (greedy nearest branch), then retimes the resulting
+    joint-space path with TOPP-RA using the arm's kinematic limits.
+
+    The returned trajectory can be executed via :meth:`SimContext.execute`.
+    TOPP-RA produces a smoothly varying position-velocity-acceleration
+    profile, so the PD controller receives continuous targets (unlike a
+    per-segment reactive loop, which introduces discrete jumps at segment
+    boundaries).
+
+    The IK selection is **local greedy**: at each waypoint we pick the
+    valid solution nearest to the previous commanded configuration. This
+    is robust for short monotonic paths (lift, approach, retreat) where
+    the IK branch does not change along the path. For long paths that
+    cross kinematic singularities or branch boundaries, this can fail
+    without backtracking — use ``max_branch_jump`` to catch the failure
+    early rather than silently producing a discontinuous path.
+
+    Args:
+        arm: Arm to plan for. Must have an IK solver attached.
+        waypoints: List of 4x4 SE(3) pose matrices in world frame. The
+            trajectory starts at the arm's current configuration (or
+            ``q_start``) and visits each waypoint in order.
+        q_start: Optional joint configuration to use as the starting
+            state. Defaults to ``arm.get_joint_positions()``. Useful
+            when chaining multiple paths without executing in between.
+        control_dt: Control timestep for trajectory sampling (seconds).
+            Must match the execution context's control rate.
+        max_branch_jump: Optional per-step joint-space distance threshold
+            (radians). If the nearest IK solution to the previous
+            configuration is farther than this, raise ``ValueError``
+            instead of silently jumping branches. ``None`` disables the
+            check. A reasonable value for manipulation-scale waypoint
+            spacing (5-10 mm) is ~0.5 rad (~30°).
+        partial_ok: If ``True``, return a trajectory for the longest
+            feasible prefix instead of raising when IK fails partway
+            through. Useful for collision-aware primitives like
+            :func:`safe_retract` that want "move as far as you can" semantics
+            when the requested distance exits the reachable workspace.
+            Still raises if the very first waypoint has no IK solution
+            (no feasible prefix exists). ``max_branch_jump`` failures
+            are treated the same as IK failures under ``partial_ok``.
+
+    Returns:
+        Time-parameterized :class:`~mj_manipulator.trajectory.Trajectory`
+        ready for :meth:`SimContext.execute`. Under ``partial_ok``, the
+        trajectory may cover fewer waypoints than were requested — check
+        the number of waypoints or the final EE pose if needed.
+
+    Raises:
+        RuntimeError: If the arm has no IK solver attached.
+        ValueError: If the waypoint list is empty, a waypoint has a bad
+            shape, no IK solution exists for a waypoint (unless
+            ``partial_ok=True``, in which case only the first waypoint
+            being infeasible raises), or the nearest-branch selection
+            exceeds ``max_branch_jump`` (same ``partial_ok`` semantics).
+    """
+    if arm.ik_solver is None:
+        raise RuntimeError(
+            f"plan_cartesian_path requires an arm with an IK solver; "
+            f"arm '{arm.config.name}' was created without one."
+        )
+
+    if not waypoints:
+        raise ValueError("plan_cartesian_path: waypoints must be non-empty")
+
+    q_current = (
+        arm.get_joint_positions().copy() if q_start is None else np.asarray(q_start, dtype=float).copy()
+    )
+
+    joint_path: list[np.ndarray] = [q_current]
+
+    for i, pose in enumerate(waypoints):
+        pose = np.asarray(pose, dtype=float)
+        if pose.shape != (4, 4):
+            raise ValueError(
+                f"plan_cartesian_path: waypoint {i} has shape {pose.shape}, expected (4, 4)"
+            )
+
+        solutions = arm.ik_solver.solve_valid(pose, q_init=q_current)
+        if not solutions:
+            if partial_ok and i > 0:
+                logger.info(
+                    "plan_cartesian_path: IK infeasible at waypoint %d/%d; "
+                    "returning partial trajectory for %d feasible waypoints",
+                    i,
+                    len(waypoints),
+                    i,
+                )
+                break
+            raise ValueError(
+                f"plan_cartesian_path: no valid IK solution at waypoint {i} "
+                f"(pose translation = {pose[:3, 3]})"
+            )
+
+        q_next = min(solutions, key=lambda q: float(np.linalg.norm(q - q_current)))
+
+        if max_branch_jump is not None:
+            jump = float(np.linalg.norm(q_next - q_current))
+            if jump > max_branch_jump:
+                if partial_ok and i > 0:
+                    logger.info(
+                        "plan_cartesian_path: IK branch jump at waypoint %d/%d "
+                        "(%.3f rad > %.3f); returning partial trajectory for %d "
+                        "feasible waypoints",
+                        i,
+                        len(waypoints),
+                        jump,
+                        max_branch_jump,
+                        i,
+                    )
+                    break
+                raise ValueError(
+                    f"plan_cartesian_path: IK branch jump at waypoint {i} "
+                    f"({jump:.3f} rad > max_branch_jump={max_branch_jump:.3f}). "
+                    "The nearest IK solution is far from the previous "
+                    "configuration — likely a singularity or branch boundary. "
+                    "Consider denser waypoints, a different path, or increasing "
+                    "max_branch_jump if the jump is intentional."
+                )
+
+        joint_path.append(q_next)
+        q_current = q_next
+
+    return arm.retime(joint_path, control_dt=control_dt)
+
+
+def translational_waypoints(
+    start_pose: np.ndarray,
+    direction: np.ndarray,
+    distance: float,
+    *,
+    segment_length: float = 0.005,
+) -> list[np.ndarray]:
+    """Generate SE(3) waypoints along a straight-line translation.
+
+    Produces waypoints at ``segment_length`` increments from ``start_pose``
+    in the given world-frame ``direction``, preserving orientation. The
+    final waypoint is exactly at ``start + direction * distance`` (possibly
+    closer than ``segment_length`` to the penultimate waypoint).
+
+    Useful for :func:`plan_cartesian_path` callers who want a simple
+    straight-line Cartesian motion (post-grasp lift, pre-grasp approach,
+    post-place retreat).
+
+    Args:
+        start_pose: 4x4 SE(3) starting pose in world frame.
+        direction: 3D direction vector. Will be normalized internally.
+        distance: Total translation distance along ``direction`` (meters).
+        segment_length: Spacing between consecutive waypoints (meters).
+            Smaller = more IK solves but smoother path reconstruction.
+            5 mm is a good default for manipulation-scale motions.
+
+    Returns:
+        List of 4x4 SE(3) waypoint poses.
+    """
+    direction = np.asarray(direction, dtype=float)
+    norm = float(np.linalg.norm(direction))
+    if norm < 1e-9:
+        return []
+    unit = direction / norm
+
+    start_rot = np.asarray(start_pose[:3, :3], dtype=float)
+    start_trans = np.asarray(start_pose[:3, 3], dtype=float)
+
+    n_segments = max(1, int(np.ceil(distance / segment_length)))
+    waypoints: list[np.ndarray] = []
+    for i in range(1, n_segments + 1):
+        step = min(i * segment_length, distance)
+        pose = np.eye(4)
+        pose[:3, :3] = start_rot
+        pose[:3, 3] = start_trans + unit * step
+        waypoints.append(pose)
+    return waypoints

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -189,6 +189,7 @@ def _setup_franka(objects):
     from mj_manipulator.arms.franka import (
         FRANKA_HOME,
         add_franka_ee_site,
+        add_franka_gravcomp,
         create_franka_arm,
         fix_franka_grip_force,
     )
@@ -206,6 +207,7 @@ def _setup_franka(objects):
     # which handles objects + registry with native path resolution.
     spec = mujoco.MjSpec.from_file(str(scene_path))
     add_franka_ee_site(spec)
+    add_franka_gravcomp(spec)
 
     if objects:
         from prl_assets import OBJECTS_DIR

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -210,19 +210,23 @@ def _setup_franka(objects):
     if objects:
         from prl_assets import OBJECTS_DIR
 
-        # Flat plate on the ground in front of the robot for objects
-        plate = spec.worldbody.add_body()
-        plate.name = "plate"
-        plate.pos = [0.5, 0.0, 0.005]
-        g = plate.add_geom()
+        # Low table in front of the robot for objects.
+        # Height tuned so the grasp is in the middle of the Franka's
+        # workspace — low enough to reach, high enough to lift without
+        # link6 colliding with the world after grasping.
+        TABLE_HEIGHT = 0.20
+        table = spec.worldbody.add_body()
+        table.name = "table"
+        table.pos = [0.5, 0.0, TABLE_HEIGHT / 2]
+        g = table.add_geom()
         g.type = mujoco.mjtGeom.mjGEOM_BOX
-        g.size = [0.30, 0.30, 0.005]
-        g.rgba = [0.6, 0.6, 0.6, 1.0]
-        # Worktop site on plate surface — enables robot.place("worktop")
-        s = plate.add_site()
+        g.size = [0.25, 0.25, TABLE_HEIGHT / 2]
+        g.rgba = [0.4, 0.3, 0.2, 1.0]
+        # Worktop site on table surface — enables robot.place("worktop")
+        s = table.add_site()
         s.name = "worktop"
-        s.pos = [0, 0, 0.005]
-        s.size = [0.25, 0.25, 0.001]
+        s.pos = [0, 0, TABLE_HEIGHT / 2]
+        s.size = [0.20, 0.20, 0.001]
         s.type = mujoco.mjtGeom.mjGEOM_BOX
         s.rgba = [0, 0, 0, 0]
 

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -210,23 +210,19 @@ def _setup_franka(objects):
     if objects:
         from prl_assets import OBJECTS_DIR
 
-        # Low table in front of the robot for objects.
-        # Height tuned so the grasp is in the middle of the Franka's
-        # workspace — low enough to reach, high enough to lift without
-        # link6 colliding with the world after grasping.
-        TABLE_HEIGHT = 0.20
-        table = spec.worldbody.add_body()
-        table.name = "table"
-        table.pos = [0.5, 0.0, TABLE_HEIGHT / 2]
-        g = table.add_geom()
+        # Flat plate on the ground in front of the robot for objects
+        plate = spec.worldbody.add_body()
+        plate.name = "plate"
+        plate.pos = [0.5, 0.0, 0.005]
+        g = plate.add_geom()
         g.type = mujoco.mjtGeom.mjGEOM_BOX
-        g.size = [0.25, 0.25, TABLE_HEIGHT / 2]
-        g.rgba = [0.4, 0.3, 0.2, 1.0]
-        # Worktop site on table surface — enables robot.place("worktop")
-        s = table.add_site()
+        g.size = [0.30, 0.30, 0.005]
+        g.rgba = [0.6, 0.6, 0.6, 1.0]
+        # Worktop site on plate surface — enables robot.place("worktop")
+        s = plate.add_site()
         s.name = "worktop"
-        s.pos = [0, 0, TABLE_HEIGHT / 2]
-        s.size = [0.20, 0.20, 0.001]
+        s.pos = [0, 0, 0.005]
+        s.size = [0.25, 0.25, 0.001]
         s.type = mujoco.mjtGeom.mjGEOM_BOX
         s.rgba = [0, 0, 0, 0]
 

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -186,7 +186,12 @@ def _setup_franka(objects):
     import mujoco
     from mj_environment import Environment
 
-    from mj_manipulator.arms.franka import FRANKA_HOME, add_franka_ee_site, create_franka_arm
+    from mj_manipulator.arms.franka import (
+        FRANKA_HOME,
+        add_franka_ee_site,
+        create_franka_arm,
+        fix_franka_grip_force,
+    )
     from mj_manipulator.grasp_manager import GraspManager
     from mj_manipulator.grippers.franka import FrankaGripper
     from mj_manipulator.menagerie import menagerie_scene
@@ -229,6 +234,9 @@ def _setup_franka(objects):
     else:
         model = spec.compile()
         env = Environment.from_model(model)
+
+    # Fix menagerie Franka's under-powered grip (140N target from datasheet)
+    fix_franka_grip_force(env.model)
 
     gm = GraspManager(env.model, env.data)
     gripper = FrankaGripper(env.model, env.data, "franka", grasp_manager=gm)

--- a/src/mj_manipulator/cli.py
+++ b/src/mj_manipulator/cli.py
@@ -190,6 +190,7 @@ def _setup_franka(objects):
         FRANKA_HOME,
         add_franka_ee_site,
         add_franka_gravcomp,
+        add_franka_pad_friction,
         create_franka_arm,
         fix_franka_grip_force,
     )
@@ -208,22 +209,25 @@ def _setup_franka(objects):
     spec = mujoco.MjSpec.from_file(str(scene_path))
     add_franka_ee_site(spec)
     add_franka_gravcomp(spec)
+    add_franka_pad_friction(spec)
 
     if objects:
         from prl_assets import OBJECTS_DIR
 
-        # Flat plate on the ground in front of the robot for objects
+        # Raised plate in front of the robot for objects (5cm tall so the
+        # Franka isn't reaching into a near-singular configuration and link6
+        # has clearance from the plate surface during cartesian lift).
         plate = spec.worldbody.add_body()
         plate.name = "plate"
-        plate.pos = [0.5, 0.0, 0.005]
+        plate.pos = [0.5, 0.0, 0.025]
         g = plate.add_geom()
         g.type = mujoco.mjtGeom.mjGEOM_BOX
-        g.size = [0.30, 0.30, 0.005]
+        g.size = [0.30, 0.30, 0.025]
         g.rgba = [0.6, 0.6, 0.6, 1.0]
         # Worktop site on plate surface — enables robot.place("worktop")
         s = plate.add_site()
         s.name = "worktop"
-        s.pos = [0, 0, 0.005]
+        s.pos = [0, 0, 0.025]
         s.size = [0.25, 0.25, 0.001]
         s.type = mujoco.mjtGeom.mjGEOM_BOX
         s.rgba = [0, 0, 0, 0]
@@ -273,9 +277,9 @@ def _scatter_objects(env, objects: dict):
 
     assets = AssetManager(str(OBJECTS_DIR))
 
-    # Plate surface: ground level in front of robot
+    # Plate surface: top of raised plate in front of robot (see _setup_franka)
     plate_surface = np.eye(4)
-    plate_surface[:3, 3] = [0.5, 0.0, 0.01]
+    plate_surface[:3, 3] = [0.5, 0.0, 0.05]
     placer = StablePlacer(0.25, 0.25)
 
     placed_positions = []

--- a/src/mj_manipulator/grasp_manager.py
+++ b/src/mj_manipulator/grasp_manager.py
@@ -276,12 +276,9 @@ def detect_grasped_object(
     # Filter by bilateral contact requirement
     non_empty_groups = [g for g, ids in group_body_ids.items() if ids]
     if require_bilateral and len(non_empty_groups) < 2:
-        logger.warning(
-            "require_bilateral=True but only %d non-empty finger group(s) found "
-            "(body names may not match '/left_' or '/right_' convention); "
-            "falling back to any-contact detection",
-            len(non_empty_groups),
-        )
+        # Finger group inference failed — fall back to any-contact detection.
+        # TODO(#80): replace bilateral heuristic with physics/sensor-based verification.
+        pass
     if require_bilateral and len(non_empty_groups) >= 2:
         bilateral = {
             bid: info for bid, info in object_contacts.items() if all(info.get(g, False) for g in non_empty_groups)

--- a/src/mj_manipulator/grippers/_base.py
+++ b/src/mj_manipulator/grippers/_base.py
@@ -28,6 +28,11 @@ class _BaseGripper:
     ``get_actual_position``.
     """
 
+    # Does fully-closed mean "no object held"? True for grippers whose
+    # fingers physically touch (Franka). False for grippers with large
+    # finger travel where fully-closed is still a valid grasp (Robotiq).
+    empty_at_fully_closed: bool = False
+
     def __init__(
         self,
         model: mujoco.MjModel,

--- a/src/mj_manipulator/grippers/franka.py
+++ b/src/mj_manipulator/grippers/franka.py
@@ -74,6 +74,8 @@ class FrankaGripper(_BaseGripper):
     """
 
     hand_type: str = "franka"
+    # Franka fingers physically touch at fully-closed → can't hold anything
+    empty_at_fully_closed: bool = True
 
     def __init__(
         self,

--- a/src/mj_manipulator/grippers/robotiq.py
+++ b/src/mj_manipulator/grippers/robotiq.py
@@ -198,6 +198,8 @@ class RobotiqGripper(_BaseGripper):
     """
 
     hand_type: str = "robotiq"
+    # Robotiq 2F-140 has 14cm finger travel — fully-closed can still hold
+    empty_at_fully_closed: bool = False
 
     def __init__(
         self,

--- a/src/mj_manipulator/physics_controller.py
+++ b/src/mj_manipulator/physics_controller.py
@@ -696,10 +696,28 @@ class PhysicsController:
                     grasped,
                 )
 
-        # Warn if fully closed with no contacts (missed object)
-        if not grasped:
-            gripper_pos = gripper.get_actual_position()
-            if gripper_pos > cfg.fully_closed_threshold:
+        # Check fully-closed state: for grippers whose fingers physically
+        # touch at fully-closed (e.g. Franka), this means nothing is held.
+        # For grippers with finger travel (e.g. Robotiq 2F-140), fully-closed
+        # is still a valid grasp position.
+        gripper_pos = gripper.get_actual_position()
+        if gripper_pos > cfg.fully_closed_threshold:
+            if getattr(gripper, "empty_at_fully_closed", False):
+                if grasped:
+                    logger.info(
+                        "Gripper %s: fully closed (pos=%.3f) — grasp rejected (%s)",
+                        arm_name,
+                        gripper_pos,
+                        grasped,
+                    )
+                else:
+                    logger.info(
+                        "Gripper %s: fully closed (pos=%.3f) — no object grasped",
+                        arm_name,
+                        gripper_pos,
+                    )
+                return None
+            elif not grasped:
                 logger.warning(
                     "Gripper %s: fully closed (pos=%.3f) with no contacts",
                     arm_name,

--- a/src/mj_manipulator/safe_retract.py
+++ b/src/mj_manipulator/safe_retract.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Collision-aware directional motion.
+
+safe_retract() moves the arm along a twist until new collisions are
+introduced. Tracks the starting contact state as a baseline — any
+contacts present at the start are allowed to persist (e.g. held object
+touching source surface), but new contacts cause the motion to stop.
+
+Use for:
+- Post-grasp lift (start has held object touching source surface)
+- Recovery after failed grasp (start has arm touching bumped object)
+- Any directional motion that might hit something
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable
+
+import mujoco
+import numpy as np
+
+from mj_manipulator.cartesian import CartesianController
+from mj_manipulator.contacts import iter_contacts
+
+if TYPE_CHECKING:
+    from mj_manipulator.arm import Arm
+
+
+def _get_contact_pairs(model: mujoco.MjModel, data: mujoco.MjData) -> set[tuple[int, int]]:
+    """Get the set of unordered (body1, body2) pairs currently in contact."""
+    pairs = set()
+    for body1, body2, _ in iter_contacts(model, data):
+        if body1 == body2:
+            continue
+        pair = (min(body1, body2), max(body1, body2))
+        pairs.add(pair)
+    return pairs
+
+
+def safe_retract(
+    arm: Arm,
+    step_fn: Callable[[np.ndarray, np.ndarray], None],
+    twist: np.ndarray,
+    max_distance: float,
+    *,
+    dt: float = 0.008,
+    stop_condition: Callable[[], bool] | None = None,
+) -> float:
+    """Move along twist until NEW collisions appear. Returns distance moved.
+
+    Records the set of contacts at the start pose as a baseline. Moves
+    incrementally. If a new contact pair appears (not in the baseline),
+    stops immediately and holds position.
+
+    This handles the common cases where the start pose is in collision:
+    - Post-grasp lift: held object touching the source surface
+    - Recovery after failed grasp: arm bumped into an object
+    The baseline contacts are ignored; only new contacts stop the motion.
+
+    Args:
+        arm: Arm to move.
+        step_fn: Callback to apply joint targets (e.g. ctx.step_cartesian).
+        twist: 6D twist direction [vx, vy, vz, wx, wy, wz].
+        max_distance: Maximum distance to travel (meters).
+        dt: Control timestep for the cartesian controller.
+        stop_condition: Optional early-termination check.
+
+    Returns:
+        Distance moved before stopping (meters).
+    """
+    model = arm.env.model
+    data = arm.env.data
+
+    # Record baseline contacts — these are allowed to persist
+    mujoco.mj_forward(model, data)
+    baseline = _get_contact_pairs(model, data)
+
+    ctrl = CartesianController.from_arm(arm, step_fn=step_fn)
+    ctrl.reset()
+
+    total_distance = 0.0
+    last_pos = data.site_xpos[arm.ee_site_id].copy()
+
+    while total_distance < max_distance:
+        if stop_condition is not None and stop_condition():
+            break
+
+        result = ctrl.step(twist, dt)
+
+        current_pos = data.site_xpos[arm.ee_site_id].copy()
+        total_distance += float(np.linalg.norm(current_pos - last_pos))
+        last_pos = current_pos
+
+        if result.achieved_fraction < 0.1:
+            break
+
+        # Check for new collisions (not in baseline)
+        current_contacts = _get_contact_pairs(model, data)
+        new_contacts = current_contacts - baseline
+        if new_contacts:
+            # New collision — stop here and hold position
+            hold_q = arm.get_joint_positions()
+            step_fn(hold_q, np.zeros_like(hold_q))
+            break
+
+    return total_distance

--- a/src/mj_manipulator/safe_retract.py
+++ b/src/mj_manipulator/safe_retract.py
@@ -16,6 +16,7 @@ Use for:
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Callable
 
 import mujoco
@@ -26,6 +27,8 @@ from mj_manipulator.contacts import iter_contacts
 
 if TYPE_CHECKING:
     from mj_manipulator.arm import Arm
+
+logger = logging.getLogger(__name__)
 
 
 def _get_contact_pairs(model: mujoco.MjModel, data: mujoco.MjData) -> set[tuple[int, int]]:
@@ -76,6 +79,7 @@ def safe_retract(
     # Record baseline contacts — these are allowed to persist
     mujoco.mj_forward(model, data)
     baseline = _get_contact_pairs(model, data)
+    logger.info("safe_retract: baseline has %d contacts", len(baseline))
 
     ctrl = CartesianController.from_arm(arm, step_fn=step_fn)
     ctrl.reset()
@@ -100,9 +104,20 @@ def safe_retract(
         current_contacts = _get_contact_pairs(model, data)
         new_contacts = current_contacts - baseline
         if new_contacts:
-            # New collision — stop here and hold position
+            # Translate body IDs to names for diagnostic
+            names = []
+            for b1, b2 in new_contacts:
+                n1 = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b1) or f"body_{b1}"
+                n2 = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b2) or f"body_{b2}"
+                names.append(f"{n1}<->{n2}")
+            logger.info(
+                "safe_retract: stopping at %.3fm (new contacts: %s)",
+                total_distance,
+                ", ".join(names),
+            )
             hold_q = arm.get_joint_positions()
             step_fn(hold_q, np.zeros_like(hold_q))
             break
 
+    logger.info("safe_retract: moved %.3fm", total_distance)
     return total_distance

--- a/src/mj_manipulator/safe_retract.py
+++ b/src/mj_manipulator/safe_retract.py
@@ -103,8 +103,7 @@ def safe_retract(
     """
     if not np.allclose(twist[3:], 0.0):
         raise NotImplementedError(
-            "safe_retract currently handles translational twists only; "
-            f"got angular components {twist[3:]}"
+            f"safe_retract currently handles translational twists only; got angular components {twist[3:]}"
         )
 
     linear = np.asarray(twist[:3], dtype=float)

--- a/src/mj_manipulator/safe_retract.py
+++ b/src/mj_manipulator/safe_retract.py
@@ -1,17 +1,35 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Siddhartha Srinivasa
 
-"""Collision-aware directional motion.
+"""Collision-aware directional motion via a planned Cartesian path.
 
-safe_retract() moves the arm along a twist until new collisions are
-introduced. Tracks the starting contact state as a baseline — any
-contacts present at the start are allowed to persist (e.g. held object
-touching source surface), but new contacts cause the motion to stop.
+``safe_retract()`` moves the arm's end-effector along a straight-line
+direction (currently translation only) until new collisions appear or the
+target distance is reached. It tracks the starting contact state as a
+**baseline** — contacts present at the start are allowed to persist
+(e.g. a held object touching its source surface), but new contacts cause
+the motion to stop immediately.
+
+Internally this builds a Cartesian SE(3) waypoint sequence via
+:func:`~mj_manipulator.cartesian_path.translational_waypoints`, plans a
+joint-space trajectory with
+:func:`~mj_manipulator.cartesian_path.plan_cartesian_path` (analytical IK
+per waypoint + TOPP-RA retiming respecting the arm's velocity and
+acceleration limits), and executes it via :meth:`SimContext.execute` with
+a baseline-contact abort predicate. Because TOPP-RA produces a smoothly
+varying target profile and the execution path is the standard trajectory
+runner, the gripper experiences no per-segment jerks and the held object
+stays pinched throughout the lift.
 
 Use for:
+
 - Post-grasp lift (start has held object touching source surface)
 - Recovery after failed grasp (start has arm touching bumped object)
 - Any directional motion that might hit something
+
+See also :func:`~mj_manipulator.cartesian_path.plan_cartesian_path` for
+the general-purpose scripted-Cartesian primitive; this function is a
+collision-aware wrapper around it for post-grasp motion.
 """
 
 from __future__ import annotations
@@ -22,11 +40,12 @@ from typing import TYPE_CHECKING, Callable
 import mujoco
 import numpy as np
 
-from mj_manipulator.cartesian import CartesianController
+from mj_manipulator.cartesian_path import plan_cartesian_path, translational_waypoints
 from mj_manipulator.contacts import iter_contacts
 
 if TYPE_CHECKING:
     from mj_manipulator.arm import Arm
+    from mj_manipulator.protocols import ExecutionContext
 
 logger = logging.getLogger(__name__)
 
@@ -44,80 +63,117 @@ def _get_contact_pairs(model: mujoco.MjModel, data: mujoco.MjData) -> set[tuple[
 
 def safe_retract(
     arm: Arm,
-    step_fn: Callable[[np.ndarray, np.ndarray], None],
+    ctx: ExecutionContext,
     twist: np.ndarray,
     max_distance: float,
     *,
-    dt: float = 0.008,
+    segment_length: float = 0.005,
     stop_condition: Callable[[], bool] | None = None,
 ) -> float:
-    """Move along twist until NEW collisions appear. Returns distance moved.
+    """Move the EE along ``twist`` until new collisions appear.
 
-    Records the set of contacts at the start pose as a baseline. Moves
-    incrementally. If a new contact pair appears (not in the baseline),
-    stops immediately and holds position.
+    Plans a Cartesian trajectory along the twist direction and executes
+    it via ``ctx.execute`` with a baseline-contact abort predicate. If a
+    new contact pair appears during execution (one not present at the
+    start pose), the trajectory runner halts at the next control cycle
+    and the arm holds its current position.
 
-    This handles the common cases where the start pose is in collision:
-    - Post-grasp lift: held object touching the source surface
-    - Recovery after failed grasp: arm bumped into an object
-    The baseline contacts are ignored; only new contacts stop the motion.
+    Currently handles translational twists only (angular components
+    ``twist[3:]`` must be zero). Rotational lifts are unusual for
+    post-grasp retraction and can be added when needed.
 
     Args:
-        arm: Arm to move.
-        step_fn: Callback to apply joint targets (e.g. ctx.step_cartesian).
-        twist: 6D twist direction [vx, vy, vz, wx, wy, wz].
-        max_distance: Maximum distance to travel (meters).
-        dt: Control timestep for the cartesian controller.
-        stop_condition: Optional early-termination check.
+        arm: Arm to move. Must have an IK solver attached.
+        ctx: Execution context (e.g. ``SimContext`` or a hardware
+            context implementing ``ExecutionContext``).
+        twist: 6D twist [vx, vy, vz, wx, wy, wz]. Only the translational
+            part is used; angular components must be zero.
+        max_distance: Maximum distance to travel along the twist (meters).
+        segment_length: Cartesian spacing between IK waypoints (meters).
+            Smaller = more IK solves, denser waypoint reconstruction,
+            slower planning. 5 mm is a good default for manipulation.
+        stop_condition: Optional additional early-termination predicate.
+            Checked alongside the baseline-contact check each control
+            cycle.
 
     Returns:
-        Distance moved before stopping (meters).
+        Signed projected distance traveled along the twist direction
+        (meters). Equal to ``max_distance`` on clean completion, less
+        on collision stop, possibly less on IK failure during planning.
     """
+    if not np.allclose(twist[3:], 0.0):
+        raise NotImplementedError(
+            "safe_retract currently handles translational twists only; "
+            f"got angular components {twist[3:]}"
+        )
+
+    linear = np.asarray(twist[:3], dtype=float)
+    linear_norm = float(np.linalg.norm(linear))
+    if linear_norm < 1e-9:
+        logger.warning("safe_retract: twist has zero magnitude; nothing to do")
+        return 0.0
+
+    direction = linear / linear_norm
+
     model = arm.env.model
     data = arm.env.data
 
-    # Record baseline contacts — these are allowed to persist
+    # Baseline contacts at the start pose — these are allowed to persist.
+    # Must be captured AFTER mj_forward to reflect the current kinematic
+    # state, not any stale contact data.
     mujoco.mj_forward(model, data)
     baseline = _get_contact_pairs(model, data)
-    logger.warning("safe_retract: baseline has %d contacts", len(baseline))
+    logger.info("safe_retract: baseline has %d contacts", len(baseline))
 
-    ctrl = CartesianController.from_arm(arm, step_fn=step_fn)
-    ctrl.reset()
+    start_pose = arm.get_ee_pose()
+    start_pos = start_pose[:3, 3].copy()
 
-    total_distance = 0.0
-    last_pos = data.site_xpos[arm.ee_site_id].copy()
+    # Build the Cartesian path and plan a joint-space trajectory for the
+    # longest feasible prefix. If the requested distance exits the
+    # reachable workspace partway through, ``partial_ok=True`` gives us
+    # back whatever prefix IS feasible rather than refusing to move.
+    waypoints = translational_waypoints(
+        start_pose,
+        direction,
+        max_distance,
+        segment_length=segment_length,
+    )
+    try:
+        trajectory = plan_cartesian_path(arm, waypoints, partial_ok=True)
+    except ValueError as exc:
+        # Even the first waypoint is infeasible — nothing reachable
+        # from the current pose along the twist direction.
+        logger.warning("safe_retract: no feasible prefix (%s); not moving", exc)
+        return 0.0
 
-    while total_distance < max_distance:
+    # Abort predicate: stop the trajectory the instant we see a contact
+    # pair that was not present at the baseline. Runs once per control
+    # cycle (every 8 ms at 125 Hz).
+    stopped_due_to_contact = {"flag": False}
+
+    def _abort() -> bool:
         if stop_condition is not None and stop_condition():
-            break
-
-        result = ctrl.step(twist, dt)
-
-        current_pos = data.site_xpos[arm.ee_site_id].copy()
-        total_distance += float(np.linalg.norm(current_pos - last_pos))
-        last_pos = current_pos
-
-        if result.achieved_fraction < 0.1:
-            break
-
-        # Check for new collisions (not in baseline)
-        current_contacts = _get_contact_pairs(model, data)
-        new_contacts = current_contacts - baseline
+            return True
+        current = _get_contact_pairs(model, data)
+        new_contacts = current - baseline
         if new_contacts:
-            # Translate body IDs to names for diagnostic
-            names = []
-            for b1, b2 in new_contacts:
-                n1 = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b1) or f"body_{b1}"
-                n2 = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b2) or f"body_{b2}"
-                names.append(f"{n1}<->{n2}")
-            logger.warning(
-                "safe_retract: stopping at %.3fm (new contacts: %s)",
-                total_distance,
-                ", ".join(names),
-            )
-            hold_q = arm.get_joint_positions()
-            step_fn(hold_q, np.zeros_like(hold_q))
-            break
+            if not stopped_due_to_contact["flag"]:
+                stopped_due_to_contact["flag"] = True
+                names = []
+                for b1, b2 in new_contacts:
+                    n1 = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b1) or f"body_{b1}"
+                    n2 = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b2) or f"body_{b2}"
+                    names.append(f"{n1}<->{n2}")
+                logger.info(
+                    "safe_retract: new contact detected: %s",
+                    ", ".join(names),
+                )
+            return True
+        return False
 
-    logger.warning("safe_retract: moved %.3fm", total_distance)
-    return total_distance
+    ctx.execute(trajectory, abort_fn=_abort)
+
+    end_pos = data.site_xpos[arm.ee_site_id].copy()
+    distance_traveled = float(np.dot(end_pos - start_pos, direction))
+    logger.info("safe_retract: moved %.3fm along twist", distance_traveled)
+    return distance_traveled

--- a/src/mj_manipulator/safe_retract.py
+++ b/src/mj_manipulator/safe_retract.py
@@ -79,7 +79,7 @@ def safe_retract(
     # Record baseline contacts — these are allowed to persist
     mujoco.mj_forward(model, data)
     baseline = _get_contact_pairs(model, data)
-    logger.info("safe_retract: baseline has %d contacts", len(baseline))
+    logger.warning("safe_retract: baseline has %d contacts", len(baseline))
 
     ctrl = CartesianController.from_arm(arm, step_fn=step_fn)
     ctrl.reset()
@@ -110,7 +110,7 @@ def safe_retract(
                 n1 = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b1) or f"body_{b1}"
                 n2 = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b2) or f"body_{b2}"
                 names.append(f"{n1}<->{n2}")
-            logger.info(
+            logger.warning(
                 "safe_retract: stopping at %.3fm (new contacts: %s)",
                 total_distance,
                 ", ".join(names),
@@ -119,5 +119,5 @@ def safe_retract(
             step_fn(hold_q, np.zeros_like(hold_q))
             break
 
-    logger.info("safe_retract: moved %.3fm", total_distance)
+    logger.warning("safe_retract: moved %.3fm", total_distance)
     return total_distance

--- a/src/mj_manipulator/sim_context.py
+++ b/src/mj_manipulator/sim_context.py
@@ -342,9 +342,7 @@ class SimContext:
         if self._event_loop is not None:
             # Kinematic with event loop: legacy blocking dispatch
             self._event_loop._deactivate_all_teleop()
-            return self._event_loop.run_on_physics_thread(
-                lambda: self._execute_impl(item, abort_fn=abort_fn)
-            )
+            return self._event_loop.run_on_physics_thread(lambda: self._execute_impl(item, abort_fn=abort_fn))
 
         return self._execute_impl(item, abort_fn=abort_fn)
 
@@ -427,6 +425,7 @@ class SimContext:
                 # No ownership registry — still compose context + caller
                 ctx_abort = self._abort_fn
                 if caller_abort is not None or ctx_abort is not None:
+
                     def _abort(ca=caller_abort, cx=ctx_abort) -> bool:
                         if cx is not None and cx():
                             return True

--- a/src/mj_manipulator/sim_context.py
+++ b/src/mj_manipulator/sim_context.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
+from collections.abc import Callable
 from concurrent.futures import Future
 from typing import TYPE_CHECKING
 
@@ -304,7 +305,12 @@ class SimContext:
 
     # -- ExecutionContext protocol -------------------------------------------
 
-    def execute(self, item: object) -> bool:
+    def execute(
+        self,
+        item: object,
+        *,
+        abort_fn: Callable[[], bool] | None = None,
+    ) -> bool:
         """Execute a trajectory or plan result.
 
         In tick-driven mode (event loop + controller), trajectories run
@@ -320,21 +326,34 @@ class SimContext:
 
         Args:
             item: Trajectory or PlanResult to execute.
+            abort_fn: Optional per-call abort predicate. Runner stops the
+                next control cycle after this returns True. Used by
+                collision-aware primitives (e.g. safe_retract) to halt
+                mid-trajectory when a new contact appears. Composes with
+                (does not replace) the ownership-registry abort: either
+                one returning True stops the trajectory.
 
         Returns:
             True if execution completed successfully.
         """
         if self._event_loop is not None and self._controller is not None:
-            return self._execute_tick_driven(item)
+            return self._execute_tick_driven(item, abort_fn=abort_fn)
 
         if self._event_loop is not None:
             # Kinematic with event loop: legacy blocking dispatch
             self._event_loop._deactivate_all_teleop()
-            return self._event_loop.run_on_physics_thread(lambda: self._execute_impl(item))
+            return self._event_loop.run_on_physics_thread(
+                lambda: self._execute_impl(item, abort_fn=abort_fn)
+            )
 
-        return self._execute_impl(item)
+        return self._execute_impl(item, abort_fn=abort_fn)
 
-    def _execute_tick_driven(self, item: object) -> bool:
+    def _execute_tick_driven(
+        self,
+        item: object,
+        *,
+        abort_fn: Callable[[], bool] | None = None,
+    ) -> bool:
         """Execute via non-blocking trajectory runners.
 
         Two modes depending on which thread calls:
@@ -363,8 +382,14 @@ class SimContext:
             if entity is None:
                 raise ValueError("Trajectory has no entity set")
 
-            # Acquire ownership and build per-arm/entity abort function
-            abort_fn = None
+            # Build per-arm/entity abort function.
+            # The caller-supplied ``abort_fn`` composes with (does not
+            # replace) the ownership abort and the context-level abort:
+            # any of the three returning True halts the trajectory at
+            # the next control cycle.
+            caller_abort = abort_fn  # shadow the outer parameter into closure
+            runner_abort_fn: Callable[[], bool] | None = None
+
             if self._ownership is not None:
                 from mj_manipulator.ownership import OwnerKind
 
@@ -382,17 +407,39 @@ class SimContext:
                     return False
                 self._ownership.acquire(entity, OwnerKind.TRAJECTORY, traj)
 
-                def _make_abort_fn(e=entity):
-                    return self._ownership.is_aborted(e)
+                def _make_abort_fn(e=entity, ca=caller_abort):
+                    reg = self._ownership
+                    ctx_abort = self._abort_fn
 
-                abort_fn = _make_abort_fn
-            elif self._abort_fn is not None:
-                abort_fn = self._abort_fn
+                    def _abort() -> bool:
+                        if reg is not None and reg.is_aborted(e):
+                            return True
+                        if ctx_abort is not None and ctx_abort():
+                            return True
+                        if ca is not None and ca():
+                            return True
+                        return False
+
+                    return _abort
+
+                runner_abort_fn = _make_abort_fn()
+            else:
+                # No ownership registry — still compose context + caller
+                ctx_abort = self._abort_fn
+                if caller_abort is not None or ctx_abort is not None:
+                    def _abort(ca=caller_abort, cx=ctx_abort) -> bool:
+                        if cx is not None and cx():
+                            return True
+                        if ca is not None and ca():
+                            return True
+                        return False
+
+                    runner_abort_fn = _abort
 
             try:
                 if on_owner_thread:
                     # We ARE the tick pump — start runner and drive tick() directly
-                    future = self._controller.start_trajectory(entity, traj, abort_fn)
+                    future = self._controller.start_trajectory(entity, traj, runner_abort_fn)
                     control_dt = self._controller.control_dt
                     realtime = self._controller.viewer is not None
                     t_next = time.monotonic() + control_dt
@@ -410,7 +457,7 @@ class SimContext:
                     # the inputhook pumps tick() on the owner thread
                     runner_future: Future[bool] = Future()
 
-                    def _start(t=traj, af=abort_fn, rf=runner_future):
+                    def _start(t=traj, af=runner_abort_fn, rf=runner_future):
                         try:
                             f = self._controller.start_trajectory(t.entity, t, af)
                             f.add_done_callback(lambda done_f: rf.set_result(done_f.result()))
@@ -429,19 +476,37 @@ class SimContext:
 
         return True
 
-    def _execute_impl(self, item: object) -> bool:
+    def _execute_impl(
+        self,
+        item: object,
+        *,
+        abort_fn: Callable[[], bool] | None = None,
+    ) -> bool:
         """Execute implementation — synchronous, always runs on the physics thread."""
         from mj_manipulator.planning import PlanResult
         from mj_manipulator.trajectory import Trajectory
 
+        # In the kinematic/legacy path, abort checks happen between
+        # trajectories only (not between waypoints). That's acceptable
+        # because kinematic mode is fast and primarily used for planning/
+        # testing; the tick-driven physics path does per-waypoint checks.
+        def _should_abort() -> bool:
+            if self._abort_fn is not None and self._abort_fn():
+                return True
+            if abort_fn is not None and abort_fn():
+                return True
+            return False
+
         if isinstance(item, PlanResult):
             for traj in item.trajectories:
-                if self._abort_fn is not None and self._abort_fn():
+                if _should_abort():
                     return False
                 if not self._execute_trajectory(traj):
                     return False
             return True
         elif isinstance(item, Trajectory):
+            if _should_abort():
+                return False
             return self._execute_trajectory(item)
         else:
             raise TypeError(f"Cannot execute {type(item)}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,48 @@ def mock_arm(model_and_data):
 
 
 @pytest.fixture
+def franka_env_with_gravcomp():
+    """Build a Franka ``Environment`` with the EE site and gravcomp enabled.
+
+    Skips the test if the menagerie is not available. Used by tests that
+    need a real arm with an IK solver and physics-mode behavior (e.g.
+    safe_retract, plan_cartesian_path integration tests).
+    """
+    try:
+        from mj_environment import Environment
+
+        from mj_manipulator.arms.franka import add_franka_ee_site, add_franka_gravcomp
+        from mj_manipulator.menagerie import menagerie_scene
+    except (ImportError, FileNotFoundError):
+        pytest.skip("mujoco_menagerie or mj_environment not available")
+
+    try:
+        scene = menagerie_scene("franka_emika_panda")
+    except FileNotFoundError:
+        pytest.skip("mujoco_menagerie not found")
+
+    spec = mujoco.MjSpec.from_file(str(scene))
+    add_franka_ee_site(spec)
+    add_franka_gravcomp(spec)
+    return Environment.from_model(spec.compile())
+
+
+@pytest.fixture
+def franka_arm_at_home(franka_env_with_gravcomp):
+    """Franka arm constructed at FRANKA_HOME, ready for physics tests."""
+    from mj_manipulator.arms.franka import FRANKA_HOME, create_franka_arm
+
+    env = franka_env_with_gravcomp
+    arm = create_franka_arm(env)
+    for i, idx in enumerate(arm.joint_qpos_indices):
+        env.data.qpos[idx] = FRANKA_HOME[i]
+    for idx in arm.joint_qvel_indices:
+        env.data.qvel[idx] = 0.0
+    mujoco.mj_forward(env.model, env.data)
+    return arm
+
+
+@pytest.fixture
 def joint_qpos_indices(model_and_data):
     model, _ = model_and_data
     return [model.jnt_qposadr[mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)] for name in JOINT_NAMES]

--- a/tests/test_cartesian_path.py
+++ b/tests/test_cartesian_path.py
@@ -32,17 +32,13 @@ class TestTranslationalWaypoints:
     def test_basic_lift_generates_expected_count(self):
         """15 cm lift with 5 mm spacing → 30 waypoints."""
         start = np.eye(4)
-        wps = translational_waypoints(
-            start, np.array([0.0, 0.0, 1.0]), distance=0.15, segment_length=0.005
-        )
+        wps = translational_waypoints(start, np.array([0.0, 0.0, 1.0]), distance=0.15, segment_length=0.005)
         assert len(wps) == 30
 
     def test_final_waypoint_at_exact_distance(self):
         """Last waypoint is exactly at start + direction * distance."""
         start = np.eye(4)
-        wps = translational_waypoints(
-            start, np.array([0.0, 0.0, 1.0]), distance=0.15, segment_length=0.005
-        )
+        wps = translational_waypoints(start, np.array([0.0, 0.0, 1.0]), distance=0.15, segment_length=0.005)
         np.testing.assert_allclose(wps[-1][:3, 3], [0.0, 0.0, 0.15], atol=1e-12)
 
     def test_waypoints_preserve_orientation(self):
@@ -57,9 +53,7 @@ class TestTranslationalWaypoints:
                 [-np.sin(theta), 0, np.cos(theta)],
             ]
         )
-        wps = translational_waypoints(
-            start, np.array([0.0, 0.0, 1.0]), distance=0.1, segment_length=0.01
-        )
+        wps = translational_waypoints(start, np.array([0.0, 0.0, 1.0]), distance=0.1, segment_length=0.01)
         for w in wps:
             np.testing.assert_allclose(w[:3, :3], start[:3, :3], atol=1e-12)
 
@@ -67,9 +61,7 @@ class TestTranslationalWaypoints:
         """Passing a non-unit direction vector still produces correct geometry."""
         start = np.eye(4)
         # Direction magnitude = 2, but distance is still 0.15 m
-        wps = translational_waypoints(
-            start, np.array([0.0, 0.0, 2.0]), distance=0.15, segment_length=0.005
-        )
+        wps = translational_waypoints(start, np.array([0.0, 0.0, 2.0]), distance=0.15, segment_length=0.005)
         np.testing.assert_allclose(wps[-1][:3, 3], [0.0, 0.0, 0.15], atol=1e-12)
 
     def test_arbitrary_direction(self):
@@ -83,27 +75,21 @@ class TestTranslationalWaypoints:
     def test_short_distance_produces_one_waypoint(self):
         """distance < segment_length → exactly one waypoint at the full distance."""
         start = np.eye(4)
-        wps = translational_waypoints(
-            start, np.array([0.0, 0.0, 1.0]), distance=0.002, segment_length=0.005
-        )
+        wps = translational_waypoints(start, np.array([0.0, 0.0, 1.0]), distance=0.002, segment_length=0.005)
         assert len(wps) == 1
         np.testing.assert_allclose(wps[0][:3, 3], [0.0, 0.0, 0.002], atol=1e-12)
 
     def test_zero_direction_returns_empty(self):
         """Zero-magnitude direction vector → empty waypoint list."""
         start = np.eye(4)
-        wps = translational_waypoints(
-            start, np.zeros(3), distance=0.15, segment_length=0.005
-        )
+        wps = translational_waypoints(start, np.zeros(3), distance=0.15, segment_length=0.005)
         assert wps == []
 
     def test_start_pose_translation_preserved(self):
         """Waypoints are offset from the start pose's translation, not origin."""
         start = np.eye(4)
         start[:3, 3] = [0.5, -0.2, 0.3]
-        wps = translational_waypoints(
-            start, np.array([0.0, 0.0, 1.0]), distance=0.1, segment_length=0.05
-        )
+        wps = translational_waypoints(start, np.array([0.0, 0.0, 1.0]), distance=0.1, segment_length=0.05)
         np.testing.assert_allclose(wps[-1][:3, 3], [0.5, -0.2, 0.4], atol=1e-12)
 
 
@@ -163,9 +149,7 @@ class TestPlanCartesianPathHappy:
         """A 10 cm +Z lift from home yields a valid, non-empty trajectory."""
         arm = franka_arm_at_home
         start = arm.get_ee_pose()
-        wps = translational_waypoints(
-            start, np.array([0.0, 0.0, 1.0]), distance=0.1, segment_length=0.005
-        )
+        wps = translational_waypoints(start, np.array([0.0, 0.0, 1.0]), distance=0.1, segment_length=0.005)
         traj = plan_cartesian_path(arm, wps)
 
         assert traj.dof == 7
@@ -178,9 +162,7 @@ class TestPlanCartesianPathHappy:
         arm = franka_arm_at_home
         start = arm.get_ee_pose()
         target_z = start[2, 3] + 0.1
-        wps = translational_waypoints(
-            start, np.array([0.0, 0.0, 1.0]), distance=0.1, segment_length=0.005
-        )
+        wps = translational_waypoints(start, np.array([0.0, 0.0, 1.0]), distance=0.1, segment_length=0.005)
         traj = plan_cartesian_path(arm, wps)
 
         # Forward-kinematics the last waypoint and check the EE z.
@@ -202,9 +184,7 @@ class TestPlanCartesianPathHappy:
         """
         arm = franka_arm_at_home
         start = arm.get_ee_pose()
-        wps = translational_waypoints(
-            start, np.array([0.0, 0.0, 1.0]), distance=0.1, segment_length=0.005
-        )
+        wps = translational_waypoints(start, np.array([0.0, 0.0, 1.0]), distance=0.1, segment_length=0.005)
         traj = plan_cartesian_path(arm, wps)
 
         # Check first, middle, and last waypoint
@@ -226,9 +206,7 @@ class TestPlanCartesianPathHappy:
         start = arm.get_ee_pose()
         # 80 cm lift — Franka reach is ~85 cm, so the very top will be
         # unreachable but the first ~30 cm should plan fine.
-        wps = translational_waypoints(
-            start, np.array([0.0, 0.0, 1.0]), distance=0.8, segment_length=0.01
-        )
+        wps = translational_waypoints(start, np.array([0.0, 0.0, 1.0]), distance=0.8, segment_length=0.01)
 
         # Without partial_ok, should raise.
         with pytest.raises(ValueError, match="no valid IK solution"):
@@ -246,8 +224,7 @@ class TestPlanCartesianPathHappy:
         final_pose = arm.forward_kinematics(final_q)
         lifted = final_pose[2, 3] - start[2, 3]
         assert 0.05 < lifted < 0.8, (
-            f"Partial lift should be a positive fraction of the commanded "
-            f"distance, got {lifted * 1000:.1f} mm"
+            f"Partial lift should be a positive fraction of the commanded distance, got {lifted * 1000:.1f} mm"
         )
 
     def test_partial_ok_first_waypoint_infeasible_raises(self, franka_arm_at_home):
@@ -278,9 +255,7 @@ class TestPlanCartesianPathHappy:
 
         # FK from FRANKA_HOME — not the current (perturbed) pose
         start_pose_at_home = arm.forward_kinematics(FRANKA_HOME)
-        wps = translational_waypoints(
-            start_pose_at_home, np.array([0.0, 0.0, 1.0]), 0.05, segment_length=0.005
-        )
+        wps = translational_waypoints(start_pose_at_home, np.array([0.0, 0.0, 1.0]), 0.05, segment_length=0.005)
         traj = plan_cartesian_path(arm, wps, q_start=FRANKA_HOME)
 
         # First trajectory waypoint should be FRANKA_HOME (the retimer seeds

--- a/tests/test_cartesian_path.py
+++ b/tests/test_cartesian_path.py
@@ -1,0 +1,288 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Tests for :mod:`mj_manipulator.cartesian_path`.
+
+Covers:
+- ``translational_waypoints`` edge cases (zero/short/long distances,
+  non-unit direction, orientation preservation)
+- ``plan_cartesian_path`` happy path and error handling (empty list,
+  bad shape, no-IK-solution, branch-jump detection)
+
+The integration tests require the Franka + menagerie; they skip
+automatically if either is missing. Pure-logic tests (waypoint
+generation, input validation) do not need menagerie.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mj_manipulator.cartesian_path import plan_cartesian_path, translational_waypoints
+
+# ---------------------------------------------------------------------------
+# translational_waypoints — pure logic, no menagerie
+# ---------------------------------------------------------------------------
+
+
+class TestTranslationalWaypoints:
+    """Unit tests for the SE(3) waypoint generator."""
+
+    def test_basic_lift_generates_expected_count(self):
+        """15 cm lift with 5 mm spacing → 30 waypoints."""
+        start = np.eye(4)
+        wps = translational_waypoints(
+            start, np.array([0.0, 0.0, 1.0]), distance=0.15, segment_length=0.005
+        )
+        assert len(wps) == 30
+
+    def test_final_waypoint_at_exact_distance(self):
+        """Last waypoint is exactly at start + direction * distance."""
+        start = np.eye(4)
+        wps = translational_waypoints(
+            start, np.array([0.0, 0.0, 1.0]), distance=0.15, segment_length=0.005
+        )
+        np.testing.assert_allclose(wps[-1][:3, 3], [0.0, 0.0, 0.15], atol=1e-12)
+
+    def test_waypoints_preserve_orientation(self):
+        """Every waypoint has the same rotation as the start pose."""
+        start = np.eye(4)
+        # 45° rotation about Y
+        theta = np.pi / 4
+        start[:3, :3] = np.array(
+            [
+                [np.cos(theta), 0, np.sin(theta)],
+                [0, 1, 0],
+                [-np.sin(theta), 0, np.cos(theta)],
+            ]
+        )
+        wps = translational_waypoints(
+            start, np.array([0.0, 0.0, 1.0]), distance=0.1, segment_length=0.01
+        )
+        for w in wps:
+            np.testing.assert_allclose(w[:3, :3], start[:3, :3], atol=1e-12)
+
+    def test_non_unit_direction_is_normalized(self):
+        """Passing a non-unit direction vector still produces correct geometry."""
+        start = np.eye(4)
+        # Direction magnitude = 2, but distance is still 0.15 m
+        wps = translational_waypoints(
+            start, np.array([0.0, 0.0, 2.0]), distance=0.15, segment_length=0.005
+        )
+        np.testing.assert_allclose(wps[-1][:3, 3], [0.0, 0.0, 0.15], atol=1e-12)
+
+    def test_arbitrary_direction(self):
+        """Diagonal direction places the final waypoint at the right spot."""
+        start = np.eye(4)
+        direction = np.array([1.0, 1.0, 1.0])  # unit = 1/sqrt(3) * [1,1,1]
+        wps = translational_waypoints(start, direction, distance=0.3, segment_length=0.05)
+        expected = (direction / np.linalg.norm(direction)) * 0.3
+        np.testing.assert_allclose(wps[-1][:3, 3], expected, atol=1e-12)
+
+    def test_short_distance_produces_one_waypoint(self):
+        """distance < segment_length → exactly one waypoint at the full distance."""
+        start = np.eye(4)
+        wps = translational_waypoints(
+            start, np.array([0.0, 0.0, 1.0]), distance=0.002, segment_length=0.005
+        )
+        assert len(wps) == 1
+        np.testing.assert_allclose(wps[0][:3, 3], [0.0, 0.0, 0.002], atol=1e-12)
+
+    def test_zero_direction_returns_empty(self):
+        """Zero-magnitude direction vector → empty waypoint list."""
+        start = np.eye(4)
+        wps = translational_waypoints(
+            start, np.zeros(3), distance=0.15, segment_length=0.005
+        )
+        assert wps == []
+
+    def test_start_pose_translation_preserved(self):
+        """Waypoints are offset from the start pose's translation, not origin."""
+        start = np.eye(4)
+        start[:3, 3] = [0.5, -0.2, 0.3]
+        wps = translational_waypoints(
+            start, np.array([0.0, 0.0, 1.0]), distance=0.1, segment_length=0.05
+        )
+        np.testing.assert_allclose(wps[-1][:3, 3], [0.5, -0.2, 0.4], atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# plan_cartesian_path — input validation (no menagerie needed for most)
+# ---------------------------------------------------------------------------
+
+
+class TestPlanCartesianPathValidation:
+    """Tests that exercise plan_cartesian_path's error-handling paths."""
+
+    def test_empty_waypoints_raises(self, franka_arm_at_home):
+        with pytest.raises(ValueError, match="waypoints must be non-empty"):
+            plan_cartesian_path(franka_arm_at_home, [])
+
+    def test_bad_shape_raises(self, franka_arm_at_home):
+        bad = np.zeros((3, 4))  # not 4x4
+        with pytest.raises(ValueError, match=r"shape \(3, 4\)"):
+            plan_cartesian_path(franka_arm_at_home, [bad])
+
+    def test_no_arm_ik_solver_raises(self, franka_env_with_gravcomp):
+        """Arm built without an IK solver should refuse Cartesian planning."""
+        from mj_manipulator.arms.franka import FRANKA_HOME, create_franka_arm
+
+        env = franka_env_with_gravcomp
+        arm = create_franka_arm(env, with_ik=False)
+        for i, idx in enumerate(arm.joint_qpos_indices):
+            env.data.qpos[idx] = FRANKA_HOME[i]
+        import mujoco
+
+        mujoco.mj_forward(env.model, env.data)
+
+        # One valid waypoint; should still raise because of missing solver
+        wp = arm.get_ee_pose()
+        wp[2, 3] += 0.05
+        with pytest.raises(RuntimeError, match="requires an arm with an IK solver"):
+            plan_cartesian_path(arm, [wp])
+
+    def test_unreachable_pose_raises(self, franka_arm_at_home):
+        """A pose far outside the reachable workspace raises ValueError."""
+        # 5 meters above the base — way outside Franka's ~0.855 m reach.
+        wp = np.eye(4)
+        wp[:3, 3] = [0.0, 0.0, 5.0]
+        with pytest.raises(ValueError, match="no valid IK solution"):
+            plan_cartesian_path(franka_arm_at_home, [wp])
+
+
+# ---------------------------------------------------------------------------
+# plan_cartesian_path — happy-path integration
+# ---------------------------------------------------------------------------
+
+
+class TestPlanCartesianPathHappy:
+    """Integration tests that actually plan a trajectory."""
+
+    def test_lift_produces_executable_trajectory(self, franka_arm_at_home):
+        """A 10 cm +Z lift from home yields a valid, non-empty trajectory."""
+        arm = franka_arm_at_home
+        start = arm.get_ee_pose()
+        wps = translational_waypoints(
+            start, np.array([0.0, 0.0, 1.0]), distance=0.1, segment_length=0.005
+        )
+        traj = plan_cartesian_path(arm, wps)
+
+        assert traj.dof == 7
+        assert traj.num_waypoints > 0
+        assert traj.duration > 0.0
+        assert traj.entity == arm.config.name
+
+    def test_trajectory_reaches_target_kinematically(self, franka_arm_at_home):
+        """Final joint config in the trajectory produces the target EE z."""
+        arm = franka_arm_at_home
+        start = arm.get_ee_pose()
+        target_z = start[2, 3] + 0.1
+        wps = translational_waypoints(
+            start, np.array([0.0, 0.0, 1.0]), distance=0.1, segment_length=0.005
+        )
+        traj = plan_cartesian_path(arm, wps)
+
+        # Forward-kinematics the last waypoint and check the EE z.
+        final_q = traj.positions[-1]
+        pose = arm.forward_kinematics(final_q)
+        assert abs(pose[2, 3] - target_z) < 1e-3
+        # Translation in x/y should be tiny (straight-line lift).
+        np.testing.assert_allclose(pose[:2, 3], start[:2, 3], atol=1e-3)
+
+    def test_trajectory_preserves_orientation(self, franka_arm_at_home):
+        """Waypoints in the planned trajectory approximately preserve EE orientation.
+
+        Exact orientation is only guaranteed at the IK anchor waypoints. TOPP-RA
+        densifies the joint-space path with linear interpolation between anchors,
+        which introduces mild (~1-2°) rotation drift at interior samples — bounded
+        by the curvature of the orientation manifold along a joint-space straight
+        line. 0.05 (~3°) is the tolerance that catches actual bugs without
+        flagging this expected interpolation error.
+        """
+        arm = franka_arm_at_home
+        start = arm.get_ee_pose()
+        wps = translational_waypoints(
+            start, np.array([0.0, 0.0, 1.0]), distance=0.1, segment_length=0.005
+        )
+        traj = plan_cartesian_path(arm, wps)
+
+        # Check first, middle, and last waypoint
+        for idx in [0, traj.num_waypoints // 2, traj.num_waypoints - 1]:
+            q = traj.positions[idx]
+            pose = arm.forward_kinematics(q)
+            rot_err = np.linalg.norm(pose[:3, :3] @ start[:3, :3].T - np.eye(3), ord="fro")
+            assert rot_err < 0.05, f"Waypoint {idx} rotation drift: {rot_err}"
+
+    def test_partial_ok_returns_feasible_prefix(self, franka_arm_at_home):
+        """partial_ok=True returns a trajectory for the longest feasible prefix.
+
+        Build a lift from home that starts feasibly but extends far enough
+        above the workspace that IK fails at some mid-path waypoint. With
+        partial_ok, we get back a shorter trajectory covering only the
+        feasible portion — not a raise, and not an empty plan.
+        """
+        arm = franka_arm_at_home
+        start = arm.get_ee_pose()
+        # 80 cm lift — Franka reach is ~85 cm, so the very top will be
+        # unreachable but the first ~30 cm should plan fine.
+        wps = translational_waypoints(
+            start, np.array([0.0, 0.0, 1.0]), distance=0.8, segment_length=0.01
+        )
+
+        # Without partial_ok, should raise.
+        with pytest.raises(ValueError, match="no valid IK solution"):
+            plan_cartesian_path(arm, wps)
+
+        # With partial_ok, returns a non-empty partial trajectory.
+        traj = plan_cartesian_path(arm, wps, partial_ok=True)
+        assert traj.dof == 7
+        assert traj.num_waypoints > 0
+        assert traj.duration > 0.0
+
+        # Final EE z of the partial trajectory should be somewhere between
+        # the start and the commanded endpoint (not all 80 cm, not zero).
+        final_q = traj.positions[-1]
+        final_pose = arm.forward_kinematics(final_q)
+        lifted = final_pose[2, 3] - start[2, 3]
+        assert 0.05 < lifted < 0.8, (
+            f"Partial lift should be a positive fraction of the commanded "
+            f"distance, got {lifted * 1000:.1f} mm"
+        )
+
+    def test_partial_ok_first_waypoint_infeasible_raises(self, franka_arm_at_home):
+        """partial_ok only rescues mid-path failures, not first-waypoint ones.
+
+        If the very first waypoint has no IK solution, there's no feasible
+        prefix at all and we still raise — partial_ok doesn't silently
+        hide "nothing is reachable" failures.
+        """
+        arm = franka_arm_at_home
+        # Single unreachable waypoint
+        unreachable = np.eye(4)
+        unreachable[:3, 3] = [0.0, 0.0, 5.0]
+        with pytest.raises(ValueError, match="no valid IK solution"):
+            plan_cartesian_path(arm, [unreachable], partial_ok=True)
+
+    def test_q_start_override(self, franka_arm_at_home):
+        """Passing q_start uses it as the initial configuration, not qpos."""
+        from mj_manipulator.arms.franka import FRANKA_HOME
+
+        arm = franka_arm_at_home
+        # Move the arm physically to a different pose, but plan from FRANKA_HOME
+        import mujoco
+
+        for i, idx in enumerate(arm.joint_qpos_indices):
+            arm.env.data.qpos[idx] = FRANKA_HOME[i] + 0.1
+        mujoco.mj_forward(arm.env.model, arm.env.data)
+
+        # FK from FRANKA_HOME — not the current (perturbed) pose
+        start_pose_at_home = arm.forward_kinematics(FRANKA_HOME)
+        wps = translational_waypoints(
+            start_pose_at_home, np.array([0.0, 0.0, 1.0]), 0.05, segment_length=0.005
+        )
+        traj = plan_cartesian_path(arm, wps, q_start=FRANKA_HOME)
+
+        # First trajectory waypoint should be FRANKA_HOME (the retimer seeds
+        # the path at q_start), not the perturbed current qpos.
+        np.testing.assert_allclose(traj.positions[0], FRANKA_HOME, atol=1e-6)

--- a/tests/test_grippers.py
+++ b/tests/test_grippers.py
@@ -11,7 +11,6 @@ Uses real menagerie/geodude_assets robot models to verify:
 - Integration with arm factories
 """
 
-import geodude_assets
 import mujoco
 import pytest
 from mj_environment import Environment
@@ -20,6 +19,14 @@ from mj_manipulator.grasp_manager import GraspManager
 from mj_manipulator.grippers.franka import FrankaGripper
 from mj_manipulator.grippers.robotiq import RobotiqGripper
 from mj_manipulator.protocols import Gripper
+
+# Robotiq tests require ``geodude_assets`` for the 2F140 scene XML, but
+# geodude_assets is not a declared dependency of mj_manipulator (it's a
+# downstream consumer's package). Skip the whole test module when it's
+# not importable so CI collection doesn't error out before any tests
+# run. The proper architectural fix — moving Robotiq tests into
+# geodude/tests/ — is tracked in #87.
+geodude_assets = pytest.importorskip("geodude_assets")
 
 # ---------------------------------------------------------------------------
 # Paths

--- a/tests/test_safe_retract.py
+++ b/tests/test_safe_retract.py
@@ -251,9 +251,7 @@ class TestSafeRetractCollision:
         z_travel = end_pos[2] - start_pos[2]
 
         # Expect to stop well before 15 cm — somewhere in (1 cm, 10 cm).
-        assert 0.01 < z_travel < 0.10, (
-            f"Expected early stop, got z_travel={z_travel * 1000:.1f}mm"
-        )
+        assert 0.01 < z_travel < 0.10, f"Expected early stop, got z_travel={z_travel * 1000:.1f}mm"
 
     def test_tolerates_baseline_contact(self, franka_arm_at_home):
         """An object already in contact at t=0 does not abort the lift.

--- a/tests/test_safe_retract.py
+++ b/tests/test_safe_retract.py
@@ -20,7 +20,7 @@ import numpy as np
 import pytest
 from mj_environment import Environment
 
-from mj_manipulator.arms.franka import FRANKA_HOME, create_franka_arm
+from mj_manipulator.arms.franka import FRANKA_HOME
 from mj_manipulator.safe_retract import safe_retract
 
 # ---------------------------------------------------------------------------
@@ -262,8 +262,6 @@ class TestSafeRetractCollision:
         with a surface when the lift starts. safe_retract records this as
         a baseline and only aborts on *new* pairs.
         """
-        import mujoco
-
         from mj_manipulator.sim_context import SimContext
 
         arm = franka_arm_at_home

--- a/tests/test_safe_retract.py
+++ b/tests/test_safe_retract.py
@@ -1,0 +1,302 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Tests for :func:`mj_manipulator.safe_retract.safe_retract`.
+
+Covers:
+- Kinematic and physics-mode reachability (home + low reach-down pose)
+- Input validation (angular twist raises, zero twist no-ops)
+- Baseline-contact awareness (starting with a contact is tolerated)
+- New-contact abort (collision mid-trajectory stops the motion)
+
+All physics-mode tests require the Franka menagerie. They skip
+automatically if the menagerie isn't available (via
+``franka_env_with_gravcomp`` in conftest.py).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from mj_environment import Environment
+
+from mj_manipulator.arms.franka import FRANKA_HOME, create_franka_arm
+from mj_manipulator.safe_retract import safe_retract
+
+# ---------------------------------------------------------------------------
+# Input validation — no physics needed
+# ---------------------------------------------------------------------------
+
+
+class TestSafeRetractValidation:
+    """Tests that exercise safe_retract's input validation."""
+
+    def test_angular_twist_raises(self, franka_arm_at_home):
+        """A twist with non-zero angular components is not supported."""
+        from mj_manipulator.sim_context import SimContext
+
+        arm = franka_arm_at_home
+        with SimContext(
+            arm.env.model,
+            arm.env.data,
+            {arm.config.name: arm},
+            physics=False,
+            headless=True,
+        ) as ctx:
+            twist = np.array([0.0, 0.0, 0.1, 0.0, 0.0, 0.1])
+            with pytest.raises(NotImplementedError, match="translational"):
+                safe_retract(arm, ctx, twist=twist, max_distance=0.1)
+
+    def test_zero_twist_returns_zero(self, franka_arm_at_home):
+        """A zero twist is a no-op, not an error."""
+        from mj_manipulator.sim_context import SimContext
+
+        arm = franka_arm_at_home
+        with SimContext(
+            arm.env.model,
+            arm.env.data,
+            {arm.config.name: arm},
+            physics=False,
+            headless=True,
+        ) as ctx:
+            twist = np.zeros(6)
+            distance = safe_retract(arm, ctx, twist=twist, max_distance=0.1)
+            assert distance == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Reachability — kinematic and physics
+# ---------------------------------------------------------------------------
+
+
+# A "reach down" configuration — same one used by verify_cartesian_lift.py
+FRANKA_REACH_DOWN = np.array([0.0, 0.6, 0.0, -2.0, 0.0, 2.6, -0.7853], dtype=float)
+
+
+class TestSafeRetractReachability:
+    """safe_retract moves the EE along the commanded twist in clean scenes."""
+
+    def _run(self, franka_arm_at_home, home_q, physics: bool, distance: float = 0.15):
+        """Shared setup: move arm to home_q, run safe_retract, return deltas."""
+        import mujoco
+
+        from mj_manipulator.sim_context import SimContext
+
+        arm = franka_arm_at_home
+        env = arm.env
+
+        # Override the fixture's home with the requested config
+        for i, idx in enumerate(arm.joint_qpos_indices):
+            env.data.qpos[idx] = home_q[i]
+        for idx in arm.joint_qvel_indices:
+            env.data.qvel[idx] = 0.0
+        mujoco.mj_forward(env.model, env.data)
+
+        with SimContext(
+            env.model,
+            env.data,
+            {arm.config.name: arm},
+            physics=physics,
+            headless=True,
+        ) as ctx:
+            ee_id = arm.ee_site_id
+            start_pos = env.data.site_xpos[ee_id].copy()
+            start_rot = env.data.site_xmat[ee_id].reshape(3, 3).copy()
+
+            twist = np.array([0.0, 0.0, 0.1, 0.0, 0.0, 0.0])
+            reported = safe_retract(arm, ctx, twist=twist, max_distance=distance)
+
+            end_pos = env.data.site_xpos[ee_id].copy()
+            end_rot = env.data.site_xmat[ee_id].reshape(3, 3).copy()
+
+        delta = end_pos - start_pos
+        rot_err = float(np.linalg.norm(end_rot @ start_rot.T - np.eye(3), ord="fro"))
+        return {
+            "reported": reported,
+            "x_drift": float(delta[0]),
+            "y_drift": float(delta[1]),
+            "z_travel": float(delta[2]),
+            "rot_err": rot_err,
+        }
+
+    def test_kinematic_home_reaches_target(self, franka_arm_at_home):
+        """Kinematic mode from home reaches the commanded 15 cm lift."""
+        m = self._run(franka_arm_at_home, FRANKA_HOME, physics=False)
+        assert abs(m["z_travel"] - 0.15) < 0.005  # within 5 mm
+        assert abs(m["x_drift"]) < 0.002
+        assert abs(m["y_drift"]) < 0.002
+        assert m["rot_err"] < 0.02
+        assert abs(m["reported"] - m["z_travel"]) < 0.005
+
+    def test_physics_home_reaches_target(self, franka_arm_at_home):
+        """Physics mode from home reaches the commanded 15 cm lift within tolerance."""
+        m = self._run(franka_arm_at_home, FRANKA_HOME, physics=True)
+        assert abs(m["z_travel"] - 0.15) < 0.005
+        assert abs(m["x_drift"]) < 0.002
+        assert abs(m["y_drift"]) < 0.002
+        assert m["rot_err"] < 0.02
+
+    def test_physics_low_pose_reaches_target(self, franka_arm_at_home):
+        """Physics mode from a reach-down pose reaches the commanded lift.
+
+        This is the demo's actual failure case before the fix: the arm was
+        drifting sideways ~35 mm instead of lifting straight up.
+        """
+        m = self._run(franka_arm_at_home, FRANKA_REACH_DOWN, physics=True)
+        assert abs(m["z_travel"] - 0.15) < 0.005
+        assert abs(m["x_drift"]) < 0.002
+        assert abs(m["y_drift"]) < 0.002
+        assert m["rot_err"] < 0.02
+
+
+# ---------------------------------------------------------------------------
+# Collision-aware abort
+# ---------------------------------------------------------------------------
+
+
+# Franka scene with a ceiling box 8 cm above the EE at home. The lift
+# should reach the ceiling after ~5 cm (ceiling at ~62 cm, EE starts at
+# ~57 cm, ~3 cm of clearance before fingertip/hand contacts the box).
+_CEILING_SCENE = """
+<mujoco>
+  <worldbody>
+    <body name="ceiling" pos="0.555 0 0.64">
+      <geom type="box" size="0.3 0.3 0.01" rgba="0.4 0.4 0.4 1"/>
+    </body>
+  </worldbody>
+</mujoco>
+"""
+
+
+@pytest.fixture
+def franka_with_ceiling():
+    """Franka + a ceiling box 8 cm above the home EE pose.
+
+    The ceiling is thin and positioned so the Franka hand will contact it
+    after a few cm of upward lift. Used to test that safe_retract stops on
+    new contact rather than pushing through.
+    """
+    try:
+        import mujoco
+
+        from mj_manipulator.arms.franka import (
+            add_franka_ee_site,
+            add_franka_gravcomp,
+            create_franka_arm,
+        )
+        from mj_manipulator.menagerie import menagerie_scene
+    except (ImportError, FileNotFoundError):
+        pytest.skip("mujoco_menagerie or mj_environment not available")
+
+    try:
+        scene = menagerie_scene("franka_emika_panda")
+    except FileNotFoundError:
+        pytest.skip("mujoco_menagerie not found")
+
+    spec = mujoco.MjSpec.from_file(str(scene))
+    add_franka_ee_site(spec)
+    add_franka_gravcomp(spec)
+
+    # Add a ceiling box directly to the spec so its mesh paths resolve
+    ceiling = spec.worldbody.add_body()
+    ceiling.name = "ceiling"
+    ceiling.pos = [0.555, 0.0, 0.64]  # ~8 cm above FRANKA_HOME EE z=0.566
+    g = ceiling.add_geom()
+    g.type = mujoco.mjtGeom.mjGEOM_BOX
+    g.size = [0.3, 0.3, 0.01]
+    g.rgba = [0.4, 0.4, 0.4, 1.0]
+
+    env = Environment.from_model(spec.compile())
+    arm = create_franka_arm(env)
+    for i, idx in enumerate(arm.joint_qpos_indices):
+        env.data.qpos[idx] = FRANKA_HOME[i]
+    for idx in arm.joint_qvel_indices:
+        env.data.qvel[idx] = 0.0
+    mujoco.mj_forward(env.model, env.data)
+    return arm
+
+
+class TestSafeRetractCollision:
+    """Tests for the baseline-contact / new-contact abort logic."""
+
+    def test_stops_on_new_contact(self, franka_with_ceiling):
+        """Lift command of 15 cm stops early when hitting a ceiling ~8 cm up.
+
+        The ceiling is a thin box at z=0.64, ~8 cm above the home EE pose
+        at z=0.566. The Franka hand is longer than just the EE site, so
+        contact happens somewhere before the EE itself reaches the ceiling
+        — expect motion to halt between 1 cm and 10 cm of z travel.
+        """
+        import mujoco
+
+        from mj_manipulator.sim_context import SimContext
+
+        arm = franka_with_ceiling
+        env = arm.env
+
+        mujoco.mj_forward(env.model, env.data)
+        start_pos = env.data.site_xpos[arm.ee_site_id].copy()
+
+        with SimContext(
+            env.model,
+            env.data,
+            {arm.config.name: arm},
+            physics=True,
+            headless=True,
+        ) as ctx:
+            twist = np.array([0.0, 0.0, 0.1, 0.0, 0.0, 0.0])
+            safe_retract(arm, ctx, twist=twist, max_distance=0.15)
+
+        end_pos = env.data.site_xpos[arm.ee_site_id].copy()
+        z_travel = end_pos[2] - start_pos[2]
+
+        # Expect to stop well before 15 cm — somewhere in (1 cm, 10 cm).
+        assert 0.01 < z_travel < 0.10, (
+            f"Expected early stop, got z_travel={z_travel * 1000:.1f}mm"
+        )
+
+    def test_tolerates_baseline_contact(self, franka_arm_at_home):
+        """An object already in contact at t=0 does not abort the lift.
+
+        Approximates the post-grasp case: the held object is in contact
+        with a surface when the lift starts. safe_retract records this as
+        a baseline and only aborts on *new* pairs.
+        """
+        import mujoco
+
+        from mj_manipulator.sim_context import SimContext
+
+        arm = franka_arm_at_home
+        env = arm.env
+
+        # We simulate this by monkey-patching the baseline detection to
+        # report an extra pair. This is less invasive than adding a whole
+        # new spec with a touching body, and verifies the same logic: a
+        # contact present at the start is ignored, new ones are not.
+        from mj_manipulator import safe_retract as safe_retract_mod
+
+        real_get_pairs = safe_retract_mod._get_contact_pairs
+        fake_pair = (999, 1000)  # synthetic "already in contact at t=0"
+
+        def mock_get_pairs(model, data):
+            real = real_get_pairs(model, data)
+            return real | {fake_pair}
+
+        safe_retract_mod._get_contact_pairs = mock_get_pairs
+        try:
+            with SimContext(
+                env.model,
+                env.data,
+                {arm.config.name: arm},
+                physics=True,
+                headless=True,
+            ) as ctx:
+                twist = np.array([0.0, 0.0, 0.1, 0.0, 0.0, 0.0])
+                distance = safe_retract(arm, ctx, twist=twist, max_distance=0.1)
+
+            # Baseline includes the fake pair, but it's also present the
+            # whole time, so it never appears as "new" and execution runs
+            # to completion.
+            assert abs(distance - 0.1) < 0.005
+        finally:
+            safe_retract_mod._get_contact_pairs = real_get_pairs

--- a/tests/test_sim_context.py
+++ b/tests/test_sim_context.py
@@ -201,9 +201,7 @@ class TestSimContextExecution:
     # with (does not replace) the ownership-registry abort and the
     # context-level abort: any of the three returning True stops execution.
 
-    def test_execute_accepts_abort_fn_none_backwards_compat(
-        self, model_and_data, mock_arm
-    ):
+    def test_execute_accepts_abort_fn_none_backwards_compat(self, model_and_data, mock_arm):
         """Calling ctx.execute(traj) without abort_fn still works (default=None)."""
         model, data = model_and_data
         with SimContext(
@@ -220,9 +218,7 @@ class TestSimContextExecution:
             # No abort_fn passed — should run to completion.
             assert ctx.execute(traj) is True
 
-    def test_execute_caller_abort_fn_runs_to_completion_when_false(
-        self, model_and_data, mock_arm
-    ):
+    def test_execute_caller_abort_fn_runs_to_completion_when_false(self, model_and_data, mock_arm):
         """A caller abort_fn that always returns False doesn't interfere."""
         model, data = model_and_data
         with SimContext(
@@ -247,9 +243,7 @@ class TestSimContextExecution:
             # kinematic mode) — proves the parameter was plumbed through.
             assert call_count["n"] >= 1
 
-    def test_execute_caller_abort_fn_short_circuits_when_true(
-        self, model_and_data, mock_arm
-    ):
+    def test_execute_caller_abort_fn_short_circuits_when_true(self, model_and_data, mock_arm):
         """A caller abort_fn that returns True halts execution."""
         model, data = model_and_data
         with SimContext(
@@ -271,9 +265,7 @@ class TestSimContextExecution:
             for idx in mock_arm.joint_qpos_indices:
                 assert abs(data.qpos[idx]) < 1e-6
 
-    def test_execute_context_abort_fn_still_composes(
-        self, model_and_data, mock_arm
-    ):
+    def test_execute_context_abort_fn_still_composes(self, model_and_data, mock_arm):
         """The context-level abort_fn (set at construction) still fires
         alongside the caller-provided abort_fn."""
         model, data = model_and_data

--- a/tests/test_sim_context.py
+++ b/tests/test_sim_context.py
@@ -195,6 +195,104 @@ class TestSimContextExecution:
             with pytest.raises(ValueError, match="No executor"):
                 ctx.execute(traj)
 
+    # --- abort_fn parameter ------------------------------------------------
+    # The abort_fn parameter lets callers halt a trajectory mid-execution
+    # based on real-time signals (e.g. a new collision contact). It composes
+    # with (does not replace) the ownership-registry abort and the
+    # context-level abort: any of the three returning True stops execution.
+
+    def test_execute_accepts_abort_fn_none_backwards_compat(
+        self, model_and_data, mock_arm
+    ):
+        """Calling ctx.execute(traj) without abort_fn still works (default=None)."""
+        model, data = model_and_data
+        with SimContext(
+            model,
+            data,
+            {"test_arm": mock_arm},
+            physics=False,
+            headless=True,
+        ) as ctx:
+            traj = make_trajectory(
+                np.array([[0.0, 0.0], [0.1, 0.1], [0.2, 0.2]]),
+                entity="test_arm",
+            )
+            # No abort_fn passed — should run to completion.
+            assert ctx.execute(traj) is True
+
+    def test_execute_caller_abort_fn_runs_to_completion_when_false(
+        self, model_and_data, mock_arm
+    ):
+        """A caller abort_fn that always returns False doesn't interfere."""
+        model, data = model_and_data
+        with SimContext(
+            model,
+            data,
+            {"test_arm": mock_arm},
+            physics=False,
+            headless=True,
+        ) as ctx:
+            traj = make_trajectory(
+                np.array([[0.0, 0.0], [0.1, 0.1], [0.2, 0.2]]),
+                entity="test_arm",
+            )
+            call_count = {"n": 0}
+
+            def never_abort():
+                call_count["n"] += 1
+                return False
+
+            assert ctx.execute(traj, abort_fn=never_abort) is True
+            # abort_fn was invoked at least once (pre-flight check in
+            # kinematic mode) — proves the parameter was plumbed through.
+            assert call_count["n"] >= 1
+
+    def test_execute_caller_abort_fn_short_circuits_when_true(
+        self, model_and_data, mock_arm
+    ):
+        """A caller abort_fn that returns True halts execution."""
+        model, data = model_and_data
+        with SimContext(
+            model,
+            data,
+            {"test_arm": mock_arm},
+            physics=False,
+            headless=True,
+        ) as ctx:
+            traj = make_trajectory(
+                np.array([[0.0, 0.0], [0.1, 0.1], [0.2, 0.2]]),
+                entity="test_arm",
+            )
+            # abort_fn fires immediately — the kinematic path should
+            # short-circuit before running the trajectory at all.
+            assert ctx.execute(traj, abort_fn=lambda: True) is False
+            # And qpos should still be at the starting zero, not the
+            # final [0.2, 0.2].
+            for idx in mock_arm.joint_qpos_indices:
+                assert abs(data.qpos[idx]) < 1e-6
+
+    def test_execute_context_abort_fn_still_composes(
+        self, model_and_data, mock_arm
+    ):
+        """The context-level abort_fn (set at construction) still fires
+        alongside the caller-provided abort_fn."""
+        model, data = model_and_data
+        with SimContext(
+            model,
+            data,
+            {"test_arm": mock_arm},
+            physics=False,
+            headless=True,
+            abort_fn=lambda: True,  # always-abort context-level
+        ) as ctx:
+            traj = make_trajectory(
+                np.array([[0.0, 0.0], [0.1, 0.1], [0.2, 0.2]]),
+                entity="test_arm",
+            )
+            # Caller says "never abort", but context says "always abort"
+            # — the OR should fire, execution halts.
+            assert ctx.execute(traj, abort_fn=lambda: False) is False
+
 
 class TestSimContextStep:
     def test_step_physics_with_targets(self, model_and_data, mock_arm):


### PR DESCRIPTION
Fixes #68.

Polishes the Franka Panda demo in the CLI so `robot.pickup()` reliably grasps, lifts, and places cans. Four logical commits:

1. **Gravity compensation** — `add_franka_gravcomp(spec)` MjSpec helper, wired into the Franka CLI setup. Enables MuJoCo's per-body gravcomp pathway before compile, matching real Franka FCI behavior. Without it, the position-servo PD loop fights gravity via steady-state error, producing visible sag at rest and lag during motion. Also adds a warning in `Arm.__init__` that fires if the kinematic subtree has no gravcomp active, so forgetting the helper is loud instead of silent.

2. **Fingertip pad grip** — `add_franka_pad_friction(spec)` boosts the menagerie fingertip pads to mimic compliant silicone contact: `friction=(1.5, 0.05, 0.0002)` with `priority=1`, and soft `solref`/`solimp` producing ~1 mm constraint penetration. Compensates for the lack of compliant-contact primitives in MuJoCo without changing the pad geometry. Also raises the demo plate from 1 cm to 5 cm tall so the Franka reaches a less singular configuration for the grasp and link6 has clearance during the lift.

3. **`plan_cartesian_path` + `ctx.execute` abort_fn** — new `mj_manipulator.cartesian_path` module with a generic scripted-Cartesian primitive (greedy-nearest analytical IK per SE(3) waypoint, then TOPP-RA retime via `arm.retime`) and a `translational_waypoints` helper. `ctx.execute` gains an optional `abort_fn` parameter that composes with the ownership and context-level aborts. Reusable for post-grasp lift, pre-grasp approach, post-place retreat, tool-frame probes.

4. **`safe_retract` rewrite** — drops the buggy Jacobian + per-segment reactive loop in favor of `plan_cartesian_path(partial_ok=True)` + `ctx.execute(abort_fn=...)`. TOPP-RA enforces smooth velocity/acceleration profiles end-to-end, so the commanded targets are smooth (no per-segment jumps), the held object stays pinched through the lift, and the baseline-contact abort stops the motion the instant any new contact appears. `partial_ok` handles workspace-edge cases gracefully.

## What doesn't land here

Several follow-ups were discovered during the investigation and filed as their own issues rather than bundled in:

- #83 — Remove fake grasp detection; add execution monitors for real failure detection. The reason `pickup()` still returns True even when the grasp drops mid-lift. Consolidates the old geodude#113 proposal.
- #84 — `CartesianController` closed-loop-in-physics bug. Sidestepped by routing scripted Cartesian motion through `plan_cartesian_path` entirely. `CartesianController` still used by teleop where it works.
- #85 — Systematic gravcomp rollout to the UR5e helper and the rest of the demos. Partially sketched in a `git stash` with the pattern to follow.
- personalrobotics/geodude_assets#12 — Retune the geodude UR5e PD gains now that gravcomp is active. The source XML edits for gravcomp on the geodude UR5e + Robotiq are already landed on `geodude_assets/main`; the tuning is the next step.

## Test plan

- [x] `uv run pytest tests/` — 335 passed (up from 306, 29 new tests across `test_cartesian_path.py`, `test_safe_retract.py`, `test_sim_context.py`)
- [x] `uv run python demos/verify_cartesian_lift.py` — all three scenarios PASS (kinematic/home, physics/home, physics/low)
- [x] Franka demo CLI: `robot.pickup()` reliably grasps and lifts cans in the scattered scene
- [x] Geodude recycling demo: unchanged behavior, no regressions (`with_lift=False` preserves the Vention-driven lift path)