### PR TITLE
Systematic gravcomp rollout: UR5e helper + every MjSpec-loading demo

### DIFF
--- a/demos/_debug_franka_grasp.py
+++ b/demos/_debug_franka_grasp.py
@@ -14,7 +14,12 @@ from mj_environment import Environment
 from prl_assets import OBJECTS_DIR
 from tsr.hands import FrankaHand
 
-from mj_manipulator.arms.franka import FRANKA_HOME, add_franka_ee_site, create_franka_arm
+from mj_manipulator.arms.franka import (
+    FRANKA_HOME,
+    add_franka_ee_site,
+    add_franka_gravcomp,
+    create_franka_arm,
+)
 from mj_manipulator.grasp_manager import GraspManager
 from mj_manipulator.grippers.franka import FrankaGripper
 from mj_manipulator.sim_context import SimContext
@@ -28,6 +33,7 @@ spec = mujoco.MjSpec.from_file(
     str(__import__("mj_manipulator.menagerie", fromlist=["menagerie_scene"]).menagerie_scene("franka_emika_panda"))
 )
 add_franka_ee_site(spec)
+add_franka_gravcomp(spec)
 
 table = spec.worldbody.add_body()
 table.name = "table"

--- a/demos/arm_planning.py
+++ b/demos/arm_planning.py
@@ -20,9 +20,10 @@ from mj_environment import Environment
 from mj_manipulator.arms.franka import (
     FRANKA_HOME,
     add_franka_ee_site,
+    add_franka_gravcomp,
     create_franka_arm,
 )
-from mj_manipulator.arms.ur5e import UR5E_HOME, create_ur5e_arm
+from mj_manipulator.arms.ur5e import UR5E_HOME, add_ur5e_gravcomp, create_ur5e_arm
 from mj_manipulator.menagerie import menagerie_scene
 
 # ---------------------------------------------------------------------------
@@ -125,7 +126,9 @@ def demo_plan_to_pose(arm, label):
 # ---------------------------------------------------------------------------
 def main():
     # --- UR5e ---
-    ur5e_env = Environment(str(UR5E_SCENE))
+    ur5e_spec = mujoco.MjSpec.from_file(str(UR5E_SCENE))
+    add_ur5e_gravcomp(ur5e_spec)
+    ur5e_env = Environment.from_model(ur5e_spec.compile())
     ur5e = create_ur5e_arm(ur5e_env)
     for i, idx in enumerate(ur5e.joint_qpos_indices):
         ur5e_env.data.qpos[idx] = UR5E_HOME[i]
@@ -139,13 +142,8 @@ def main():
     # --- Franka ---
     spec = mujoco.MjSpec.from_file(str(FRANKA_SCENE))
     add_franka_ee_site(spec)
-    franka_dir = FRANKA_SCENE.parent
-    tmp_path = franka_dir / "_demo_franka_ee.xml"
-    try:
-        tmp_path.write_text(spec.to_xml())
-        franka_env = Environment(str(tmp_path))
-    finally:
-        tmp_path.unlink(missing_ok=True)
+    add_franka_gravcomp(spec)
+    franka_env = Environment.from_model(spec.compile())
 
     franka = create_franka_arm(franka_env)
     for i, idx in enumerate(franka.joint_qpos_indices):

--- a/demos/bt_recycle.py
+++ b/demos/bt_recycle.py
@@ -32,9 +32,15 @@ from tsr.placement import StablePlacer
 from mj_manipulator.arms.franka import (
     FRANKA_HOME,
     add_franka_ee_site,
+    add_franka_gravcomp,
     create_franka_arm,
 )
-from mj_manipulator.arms.ur5e import UR5E_HOME, UR5E_ROBOTIQ_EE_SITE, create_ur5e_arm
+from mj_manipulator.arms.ur5e import (
+    UR5E_HOME,
+    UR5E_ROBOTIQ_EE_SITE,
+    add_ur5e_gravcomp,
+    create_ur5e_arm,
+)
 from mj_manipulator.bt import pickup_with_recovery, place_with_recovery
 from mj_manipulator.config import PhysicsConfig, PhysicsExecutionConfig
 from mj_manipulator.grasp_manager import GraspManager
@@ -84,6 +90,7 @@ def setup_scene(robot_type):
     """Build scene with robot + table + cans + bin."""
     if robot_type == "ur5e":
         spec = mujoco.MjSpec.from_file(str(UR5E_SCENE))
+        add_ur5e_gravcomp(spec)
         robotiq_spec = mujoco.MjSpec.from_file(str(ROBOTIQ_MODEL))
         wrist = spec.worldbody.find_child("wrist_3_link")
         frame = wrist.add_frame()
@@ -93,6 +100,7 @@ def setup_scene(robot_type):
     else:
         spec = mujoco.MjSpec.from_file(str(FRANKA_SCENE))
         add_franka_ee_site(spec)
+        add_franka_gravcomp(spec)
 
     # Table + cans
     table_half = [0.15, 0.15, 0.23]

--- a/demos/ik_solver.py
+++ b/demos/ik_solver.py
@@ -28,9 +28,10 @@ from mj_environment import Environment
 from mj_manipulator.arms.franka import (
     FRANKA_HOME,
     add_franka_ee_site,
+    add_franka_gravcomp,
     create_franka_arm,
 )
-from mj_manipulator.arms.ur5e import UR5E_HOME, create_ur5e_arm
+from mj_manipulator.arms.ur5e import UR5E_HOME, add_ur5e_gravcomp, create_ur5e_arm
 from mj_manipulator.menagerie import menagerie_scene
 
 # ---------------------------------------------------------------------------
@@ -175,7 +176,9 @@ def demo_roundtrip(arm, label):
 # ---------------------------------------------------------------------------
 def main():
     # === UR5e (6-DOF, direct analytical IK) ===
-    ur5e_env = Environment(str(UR5E_SCENE))
+    ur5e_spec = mujoco.MjSpec.from_file(str(UR5E_SCENE))
+    add_ur5e_gravcomp(ur5e_spec)
+    ur5e_env = Environment.from_model(ur5e_spec.compile())
     ur5e = create_ur5e_arm(ur5e_env)
     for i, idx in enumerate(ur5e.joint_qpos_indices):
         ur5e_env.data.qpos[idx] = UR5E_HOME[i]
@@ -195,13 +198,8 @@ def main():
     # === Franka Panda (7-DOF, joint-5 discretization) ===
     spec = mujoco.MjSpec.from_file(str(FRANKA_SCENE))
     add_franka_ee_site(spec)
-    franka_dir = FRANKA_SCENE.parent
-    tmp_path = franka_dir / "_demo_franka_ee.xml"
-    try:
-        tmp_path.write_text(spec.to_xml())
-        franka_env = Environment(str(tmp_path))
-    finally:
-        tmp_path.unlink(missing_ok=True)
+    add_franka_gravcomp(spec)
+    franka_env = Environment.from_model(spec.compile())
 
     franka = create_franka_arm(franka_env)
     for i, idx in enumerate(franka.joint_qpos_indices):

--- a/demos/recycling.py
+++ b/demos/recycling.py
@@ -53,9 +53,15 @@ from tsr.placement import StablePlacer
 from mj_manipulator.arms.franka import (
     FRANKA_HOME,
     add_franka_ee_site,
+    add_franka_gravcomp,
     create_franka_arm,
 )
-from mj_manipulator.arms.ur5e import UR5E_HOME, UR5E_ROBOTIQ_EE_SITE, create_ur5e_arm
+from mj_manipulator.arms.ur5e import (
+    UR5E_HOME,
+    UR5E_ROBOTIQ_EE_SITE,
+    add_ur5e_gravcomp,
+    create_ur5e_arm,
+)
 from mj_manipulator.cartesian import CartesianController
 from mj_manipulator.config import PhysicsConfig, PhysicsExecutionConfig
 from mj_manipulator.grasp_manager import GraspManager
@@ -286,6 +292,7 @@ def setup_ur5e():
             sys.exit(1)
 
     spec = mujoco.MjSpec.from_file(str(UR5E_SCENE))
+    add_ur5e_gravcomp(spec)
     robotiq_spec = mujoco.MjSpec.from_file(str(ROBOTIQ_MODEL))
 
     # Attach Robotiq 2F-140 at the UR5e flange
@@ -307,6 +314,7 @@ def setup_franka():
 
     spec = mujoco.MjSpec.from_file(str(FRANKA_SCENE))
     add_franka_ee_site(spec)
+    add_franka_gravcomp(spec)
 
     _add_table_and_cans(spec)
     return _compile_and_create_arm(spec, "franka")

--- a/demos/sim_context.py
+++ b/demos/sim_context.py
@@ -25,9 +25,10 @@ from mj_environment import Environment
 from mj_manipulator.arms.franka import (
     FRANKA_HOME,
     add_franka_ee_site,
+    add_franka_gravcomp,
     create_franka_arm,
 )
-from mj_manipulator.arms.ur5e import UR5E_HOME, create_ur5e_arm
+from mj_manipulator.arms.ur5e import UR5E_HOME, add_ur5e_gravcomp, create_ur5e_arm
 from mj_manipulator.config import PhysicsConfig, PhysicsExecutionConfig
 from mj_manipulator.menagerie import menagerie_scene
 from mj_manipulator.sim_context import SimContext
@@ -174,7 +175,9 @@ def main():
     )
 
     # --- UR5e (6-DOF) ---
-    ur5e_env = Environment(str(UR5E_SCENE))
+    ur5e_spec = mujoco.MjSpec.from_file(str(UR5E_SCENE))
+    add_ur5e_gravcomp(ur5e_spec)
+    ur5e_env = Environment.from_model(ur5e_spec.compile())
     ur5e = create_ur5e_arm(ur5e_env, with_ik=False)
     _set_arm_positions(ur5e, ur5e_env, UR5E_HOME)
 
@@ -187,13 +190,8 @@ def main():
     # --- Franka Panda (7-DOF) ---
     spec = mujoco.MjSpec.from_file(str(FRANKA_SCENE))
     add_franka_ee_site(spec)
-    franka_dir = FRANKA_SCENE.parent
-    tmp_path = franka_dir / "_demo_franka_ee.xml"
-    try:
-        tmp_path.write_text(spec.to_xml())
-        franka_env = Environment(str(tmp_path))
-    finally:
-        tmp_path.unlink(missing_ok=True)
+    add_franka_gravcomp(spec)
+    franka_env = Environment.from_model(spec.compile())
 
     franka = create_franka_arm(franka_env, with_ik=False)
     _set_arm_positions(franka, franka_env, FRANKA_HOME)

--- a/src/mj_manipulator/arms/ur5e.py
+++ b/src/mj_manipulator/arms/ur5e.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import mujoco
 import numpy as np
 
 from mj_manipulator.arm import Arm
@@ -52,6 +53,44 @@ UR5E_HOME = np.array([-1.5708, -1.5708, 1.5708, -1.5708, -1.5708, 0.0])
 # From UR5e datasheet, halved for conservative planning
 UR5E_VELOCITY_LIMITS = np.array([3.14, 3.14, 3.14, 6.28, 6.28, 6.28]) * 0.5
 UR5E_ACCELERATION_LIMITS = np.array([2.5, 2.5, 2.5, 5.0, 5.0, 5.0]) * 0.5
+
+
+# ---------------------------------------------------------------------------
+# MjSpec helpers (must run before spec.compile())
+# ---------------------------------------------------------------------------
+
+
+def add_ur5e_gravcomp(spec: mujoco.MjSpec) -> None:
+    """Enable gravity compensation on every UR5e body in an MjSpec.
+
+    Must be called **before** ``spec.compile()``. MuJoCo optimizes gravcomp
+    away at compile time if every body has ``gravcomp=0``; runtime changes
+    to ``model.body_gravcomp`` are silently ignored.
+
+    The menagerie UR5e model ships without gravcomp. Real UR5e controllers
+    (URScript / RTDE / URCap) run gravity compensation internally, so
+    enabling it in sim matches hardware behavior — otherwise the PD loop
+    must fight gravity via steady-state position error, producing sag at
+    rest and tracking lag in motion. Call this on every UR5e MjSpec loaded
+    from the menagerie. The geodude_assets UR5e already has ``gravcomp=1``
+    baked into its source XML, so this helper is a no-op there.
+
+    Args:
+        spec: MjSpec loaded from a UR5e scene XML.
+    """
+    _UR5E_BODIES = [
+        "base",
+        "shoulder_link",
+        "upper_arm_link",
+        "forearm_link",
+        "wrist_1_link",
+        "wrist_2_link",
+        "wrist_3_link",
+    ]
+    for name in _UR5E_BODIES:
+        body = spec.body(name)
+        if body is not None:
+            body.gravcomp = 1.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #85.

## Summary

Two logical pieces:

1. **New \`add_ur5e_gravcomp(spec)\` helper** mirroring the \`add_franka_gravcomp\` helper from #86. Mandatory-before-compile MjSpec walk that sets \`gravcomp=1\` on every UR5e body, because MuJoCo optimizes gravcomp away at compile time if every body has \`gravcomp=0\` and runtime writes to \`model.body_gravcomp\` are silently ignored.

2. **Wire both helpers into every demo that loads an arm via MjSpec**. The 6 affected demos are \`_debug_franka_grasp.py\`, \`arm_planning.py\`, \`bt_recycle.py\`, \`ik_solver.py\`, \`recycling.py\`, \`sim_context.py\`. After this PR, the \`Arm.__init__\` "no gravcomp on subtree" warning fires zero times across the demo suite, and physics-mode sim behavior for scripted motion matches real robot controller behavior (Franka FCI, UR RTDE both run gravcomp internally at 1 kHz).

Most of the demos that still used the legacy \`Environment(str(path))\` constructor for Franka (plus a temp-XML roundtrip hack because the legacy constructor couldn't take an MjSpec with an added EE site) are also migrated to the modern \`MjSpec → add_*_gravcomp → compile → Environment.from_model\` pattern, which removes the hack entirely.

The \`geodude_assets\` UR5e XML already has \`gravcomp="1"\` baked in via source-XML edits, so \`add_ur5e_gravcomp\` is a no-op when called on it — this helper exists for mj_manipulator's own demos which load the UR5e from the menagerie directly.

## Scope notes

Two demos are **intentionally not touched** by this PR and are tracked as follow-up #89:

- **\`demos/grippers.py\`** — reaches into \`geodude_assets\` via hardcoded relative path traversal (\`WORKSPACE / "geodude_assets" / ...\`). Same architectural issue we just fixed in #87 for \`test_grippers.py\` and needs the same kind of split. Out of scope for a gravcomp rollout.
- **\`demos/cartesian_control.py\`** — exercises \`CartesianController.step/move/move_to\` which are documented as broken in physics mode in #84. Mixes working kinematic and broken physics code paths in the same file. Deserves focused rewrite, not just a helper insertion.

## Test plan

- [x] \`uv run ruff check .\` passes
- [x] \`uv run ruff format --check .\` passes
- [x] \`uv run pytest tests/\` → 319 passed (same as post-#88)
- [x] \`uv run python demos/verify_cartesian_lift.py\` → 3/3 scenarios PASS
- [x] \`uv run python demos/arm_planning.py\` runs end-to-end on both UR5e and Franka with no gravcomp warning fired
- [x] Direct verification that \`add_ur5e_gravcomp\` + compile produces \`qfrc_gravcomp == qfrc_bias\` (max residual 0.0000) at UR5E_HOME
- [ ] CI green (should be; no new tests, just runtime fix)

## Related

- #85 — the issue this resolves
- #86 — introduced the pattern (\`add_franka_gravcomp\`, gravcomp warning in \`Arm.__init__\`)
- #89 — follow-up for \`grippers.py\` and \`cartesian_control.py\` leftover cleanups