### PR TITLE
gravcomp: generic subtree walker, per-arm helpers become wrappers

### DIFF
--- a/src/mj_manipulator/arm.py
+++ b/src/mj_manipulator/arm.py
@@ -123,6 +123,84 @@ def _read_site_pose(
     return T
 
 
+def add_subtree_gravcomp(
+    spec: mujoco.MjSpec,
+    root_body_name: str,
+) -> int:
+    """Enable gravity compensation on a body and all its descendants.
+
+    Must be called **before** ``spec.compile()``. MuJoCo optimizes
+    gravcomp away at compile time if every body has ``gravcomp=0``;
+    runtime writes to ``model.body_gravcomp`` are silently ignored.
+    That's why this helper operates on the MjSpec (editable) rather
+    than a compiled ``MjModel``.
+
+    Walks the MjSpec body tree rooted at ``root_body_name`` via an
+    explicit stack (robust to whatever iteration the MjSpec API
+    provides) and sets ``body.gravcomp = 1.0`` on every body it
+    finds. This is the primitive that per-arm helpers like
+    :func:`mj_manipulator.arms.franka.add_franka_gravcomp` delegate
+    to — they just know the right root body name.
+
+    Idempotent: calling twice on the same spec, or on overlapping
+    subtrees, is harmless because setting ``gravcomp = 1.0`` twice
+    produces the same result.
+
+    Failure modes handled:
+
+    - **root_body_name not found**: raises ``ValueError`` with the
+      bad name AND the list of top-level world-body children, so
+      typos are easy to diagnose.
+    - **Root with no descendants**: still sets gravcomp on the root
+      and returns ``count = 1``. Degenerate but valid.
+
+    Not handled (caller's responsibility):
+
+    - Calling on an already-compiled spec. The MjSpec API doesn't
+      expose a reliable "was this compiled?" check; the call will
+      still "succeed" but have no effect on the existing MjModel.
+    - Scoping: if you pass a root that's an ancestor of bodies you
+      don't want gravcomp'd (e.g. the world body, or a linear base
+      beneath the arm), the walker will touch them too. Per-arm
+      helpers sidestep this by passing the arm's kinematic root,
+      not a higher ancestor.
+
+    Args:
+        spec: MjSpec loaded from a scene XML. Must not have been
+            compiled yet (or the gravcomp change will be ignored).
+        root_body_name: Name of the root body for the gravcomp
+            subtree. Typically the arm's base link (e.g. ``"link0"``
+            for Franka, ``"base"`` for UR5e).
+
+    Returns:
+        Number of bodies that had ``gravcomp`` set. Useful for
+        sanity-checking that the walker touched the expected count
+        (11 for Franka, 7 for bare UR5e, etc.).
+
+    Raises:
+        ValueError: If ``root_body_name`` is not found in the spec.
+            The message includes the bad name and the list of
+            top-level children of ``spec.worldbody`` so the caller
+            can see what's actually there.
+    """
+    root = spec.body(root_body_name)
+    if root is None:
+        available = [b.name for b in spec.worldbody.bodies if b.name]
+        raise ValueError(
+            f"add_subtree_gravcomp: body '{root_body_name}' not found in spec. "
+            f"Top-level worldbody children: {available}"
+        )
+
+    count = 0
+    stack = [root]
+    while stack:
+        body = stack.pop()
+        body.gravcomp = 1.0
+        count += 1
+        stack.extend(body.bodies)
+    return count
+
+
 # =============================================================================
 # Arm
 # =============================================================================

--- a/src/mj_manipulator/arms/franka.py
+++ b/src/mj_manipulator/arms/franka.py
@@ -217,37 +217,25 @@ def add_franka_pad_friction(
 def add_franka_gravcomp(spec: mujoco.MjSpec) -> None:
     """Enable gravity compensation on every Franka body in an MjSpec.
 
-    Must be called **before** ``spec.compile()``. MuJoCo optimizes gravcomp
-    away at compile time if every body has ``gravcomp=0``; runtime changes
-    to ``model.body_gravcomp`` are silently ignored.
+    Must be called **before** ``spec.compile()``. Real Franka FCI runs
+    gravity compensation internally at 1 kHz, so enabling it in sim
+    matches hardware behavior — otherwise the PD loop must fight
+    gravity via steady-state position error, producing sag at rest
+    and tracking lag in motion. Call this on every Franka MjSpec
+    loaded from the menagerie, analogous to ``add_franka_ee_site``.
 
-    The menagerie Franka model ships without gravcomp. Real Franka FCI runs
-    gravity compensation internally at 1 kHz, so enabling it in sim matches
-    hardware behavior — otherwise the PD loop must fight gravity via
-    steady-state position error, producing sag at rest and tracking lag in
-    motion. Call this on every Franka MjSpec loaded from the menagerie,
-    analogous to ``add_franka_ee_site``.
+    Delegates to :func:`mj_manipulator.arm.add_subtree_gravcomp` with
+    the Franka kinematic root ``"link0"``. The subtree walker visits
+    every descendant body, which for the menagerie Franka is the 7
+    arm links plus ``hand``, ``left_finger``, ``right_finger`` (11
+    bodies total).
 
     Args:
         spec: MjSpec loaded from a Franka scene XML.
     """
-    _FRANKA_BODIES = [
-        "link0",
-        "link1",
-        "link2",
-        "link3",
-        "link4",
-        "link5",
-        "link6",
-        "link7",
-        "hand",
-        "left_finger",
-        "right_finger",
-    ]
-    for name in _FRANKA_BODIES:
-        body = spec.body(name)
-        if body is not None:
-            body.gravcomp = 1.0
+    from mj_manipulator.arm import add_subtree_gravcomp
+
+    add_subtree_gravcomp(spec, "link0")
 
 
 # ---------------------------------------------------------------------------

--- a/src/mj_manipulator/arms/ur5e.py
+++ b/src/mj_manipulator/arms/ur5e.py
@@ -63,34 +63,28 @@ UR5E_ACCELERATION_LIMITS = np.array([2.5, 2.5, 2.5, 5.0, 5.0, 5.0]) * 0.5
 def add_ur5e_gravcomp(spec: mujoco.MjSpec) -> None:
     """Enable gravity compensation on every UR5e body in an MjSpec.
 
-    Must be called **before** ``spec.compile()``. MuJoCo optimizes gravcomp
-    away at compile time if every body has ``gravcomp=0``; runtime changes
-    to ``model.body_gravcomp`` are silently ignored.
-
-    The menagerie UR5e model ships without gravcomp. Real UR5e controllers
+    Must be called **before** ``spec.compile()``. Real UR5e controllers
     (URScript / RTDE / URCap) run gravity compensation internally, so
-    enabling it in sim matches hardware behavior — otherwise the PD loop
-    must fight gravity via steady-state position error, producing sag at
-    rest and tracking lag in motion. Call this on every UR5e MjSpec loaded
-    from the menagerie. The geodude_assets UR5e already has ``gravcomp=1``
-    baked into its source XML, so this helper is a no-op there.
+    enabling it in sim matches hardware behavior — otherwise the PD
+    loop must fight gravity via steady-state position error, producing
+    sag at rest and tracking lag in motion. Call this on every UR5e
+    MjSpec loaded from the menagerie. The geodude_assets UR5e already
+    has ``gravcomp=1`` baked into its source XML, so this helper is a
+    no-op there (idempotent).
+
+    Delegates to :func:`mj_manipulator.arm.add_subtree_gravcomp` with
+    the UR5e kinematic root ``"base"``. The subtree walker visits
+    every descendant body, which for the bare menagerie UR5e is the
+    7 arm links (``base`` through ``wrist_3_link``). If a gripper is
+    attached under ``wrist_3_link`` before this helper runs, its
+    bodies will also be included, which is usually what you want.
 
     Args:
         spec: MjSpec loaded from a UR5e scene XML.
     """
-    _UR5E_BODIES = [
-        "base",
-        "shoulder_link",
-        "upper_arm_link",
-        "forearm_link",
-        "wrist_1_link",
-        "wrist_2_link",
-        "wrist_3_link",
-    ]
-    for name in _UR5E_BODIES:
-        body = spec.body(name)
-        if body is not None:
-            body.gravcomp = 1.0
+    from mj_manipulator.arm import add_subtree_gravcomp
+
+    add_subtree_gravcomp(spec, "base")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gravcomp_helpers.py
+++ b/tests/test_gravcomp_helpers.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Tests for MjSpec-level gravcomp helpers.
+
+Covers:
+
+- ``add_subtree_gravcomp`` as a generic primitive:
+    - Returns correct body count (Franka = 11, UR5e = 7)
+    - Sets gravcomp=1 on the expected set of bodies (via compile + read
+      back from MjModel)
+    - Raises ValueError with a helpful message when the root body name
+      is missing
+    - Is idempotent on repeated calls and overlapping subtrees
+
+- ``add_franka_gravcomp`` and ``add_ur5e_gravcomp`` wrappers:
+    - Delegate correctly to ``add_subtree_gravcomp``
+    - Compiled model's ``qfrc_gravcomp`` matches ``qfrc_bias`` at the
+      home pose (the property that actually matters for sim-to-real
+      parity: gravity is fully compensated)
+
+Tests skip automatically if the mujoco_menagerie is not available.
+"""
+
+from __future__ import annotations
+
+import mujoco
+import numpy as np
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures — skip the whole module if menagerie is not available
+# ---------------------------------------------------------------------------
+
+
+try:
+    from mj_manipulator.menagerie import menagerie_scene
+except ImportError:  # pragma: no cover
+    pytest.skip("mj_manipulator.menagerie not available", allow_module_level=True)
+
+
+@pytest.fixture
+def franka_spec():
+    try:
+        scene = menagerie_scene("franka_emika_panda")
+    except FileNotFoundError:
+        pytest.skip("mujoco_menagerie/franka_emika_panda not found")
+    return mujoco.MjSpec.from_file(str(scene))
+
+
+@pytest.fixture
+def ur5e_spec():
+    try:
+        scene = menagerie_scene("universal_robots_ur5e")
+    except FileNotFoundError:
+        pytest.skip("mujoco_menagerie/universal_robots_ur5e not found")
+    return mujoco.MjSpec.from_file(str(scene))
+
+
+# ---------------------------------------------------------------------------
+# add_subtree_gravcomp — generic walker
+# ---------------------------------------------------------------------------
+
+
+# Body sets that the walker should touch for each menagerie arm. These
+# are the ground truth that the old hardcoded per-arm helpers curated
+# by hand. Asserting exact set equality catches both "walker missed a
+# body" and "walker grabbed something extra."
+_FRANKA_EXPECTED_BODIES = {
+    "link0",
+    "link1",
+    "link2",
+    "link3",
+    "link4",
+    "link5",
+    "link6",
+    "link7",
+    "hand",
+    "left_finger",
+    "right_finger",
+}
+
+_UR5E_EXPECTED_BODIES = {
+    "base",
+    "shoulder_link",
+    "upper_arm_link",
+    "forearm_link",
+    "wrist_1_link",
+    "wrist_2_link",
+    "wrist_3_link",
+}
+
+
+def _gravcomp_body_set(model: mujoco.MjModel) -> set[str]:
+    """Return the set of body names with gravcomp > 0 in a compiled model."""
+    out = set()
+    for bid in range(model.nbody):
+        if model.body_gravcomp[bid] > 0:
+            name = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, bid)
+            if name:
+                out.add(name)
+    return out
+
+
+class TestAddSubtreeGravcomp:
+    """Unit tests for the generic subtree walker."""
+
+    def test_franka_returns_expected_count(self, franka_spec):
+        from mj_manipulator.arm import add_subtree_gravcomp
+
+        count = add_subtree_gravcomp(franka_spec, "link0")
+        assert count == len(_FRANKA_EXPECTED_BODIES)
+
+    def test_franka_touches_expected_body_set(self, franka_spec):
+        from mj_manipulator.arm import add_subtree_gravcomp
+
+        add_subtree_gravcomp(franka_spec, "link0")
+        model = franka_spec.compile()
+        assert _gravcomp_body_set(model) == _FRANKA_EXPECTED_BODIES
+
+    def test_ur5e_returns_expected_count(self, ur5e_spec):
+        from mj_manipulator.arm import add_subtree_gravcomp
+
+        count = add_subtree_gravcomp(ur5e_spec, "base")
+        assert count == len(_UR5E_EXPECTED_BODIES)
+
+    def test_ur5e_touches_expected_body_set(self, ur5e_spec):
+        from mj_manipulator.arm import add_subtree_gravcomp
+
+        add_subtree_gravcomp(ur5e_spec, "base")
+        model = ur5e_spec.compile()
+        assert _gravcomp_body_set(model) == _UR5E_EXPECTED_BODIES
+
+    def test_missing_root_raises(self, franka_spec):
+        from mj_manipulator.arm import add_subtree_gravcomp
+
+        with pytest.raises(ValueError) as exc_info:
+            add_subtree_gravcomp(franka_spec, "totally_not_a_body")
+        msg = str(exc_info.value)
+        assert "totally_not_a_body" in msg
+        # Error message lists top-level world-body children so the
+        # user can see what's actually available.
+        assert "link0" in msg
+
+    def test_idempotent_repeated_calls(self, franka_spec):
+        from mj_manipulator.arm import add_subtree_gravcomp
+
+        # Two calls on the same spec — second should not error and
+        # should not change the set of gravcomp'd bodies.
+        count1 = add_subtree_gravcomp(franka_spec, "link0")
+        count2 = add_subtree_gravcomp(franka_spec, "link0")
+        assert count1 == count2 == len(_FRANKA_EXPECTED_BODIES)
+        model = franka_spec.compile()
+        assert _gravcomp_body_set(model) == _FRANKA_EXPECTED_BODIES
+
+    def test_overlapping_subtrees_are_idempotent(self, franka_spec):
+        from mj_manipulator.arm import add_subtree_gravcomp
+
+        # Touching link0 (root) then link1 (child of link0) should
+        # visit link1's subtree twice but end in the same state.
+        add_subtree_gravcomp(franka_spec, "link0")
+        add_subtree_gravcomp(franka_spec, "link1")
+        model = franka_spec.compile()
+        assert _gravcomp_body_set(model) == _FRANKA_EXPECTED_BODIES
+
+    def test_does_not_touch_bodies_outside_subtree(self, franka_spec):
+        """Adding an extra body under worldbody (not under link0) should
+        not be affected by a call that targets link0."""
+        from mj_manipulator.arm import add_subtree_gravcomp
+
+        # Add a table body as a sibling of link0 under worldbody
+        table = franka_spec.worldbody.add_body()
+        table.name = "table"
+        g = table.add_geom()
+        g.type = mujoco.mjtGeom.mjGEOM_BOX
+        g.size = [0.5, 0.5, 0.05]
+        g.pos = [0, 0, -0.05]
+
+        add_subtree_gravcomp(franka_spec, "link0")
+        model = franka_spec.compile()
+        gc_bodies = _gravcomp_body_set(model)
+
+        # link0 subtree should have gravcomp
+        assert "link0" in gc_bodies
+        # The table we added should NOT have gravcomp — the walker
+        # was scoped to the link0 subtree.
+        assert "table" not in gc_bodies
+
+
+# ---------------------------------------------------------------------------
+# Per-arm wrapper delegation
+# ---------------------------------------------------------------------------
+
+
+class TestPerArmWrappers:
+    """Tests that the per-arm helpers delegate to the walker correctly
+    and produce models where gravity is fully compensated at home."""
+
+    def test_franka_wrapper_matches_walker_body_set(self, franka_spec):
+        from mj_manipulator.arms.franka import add_franka_gravcomp
+
+        add_franka_gravcomp(franka_spec)
+        model = franka_spec.compile()
+        assert _gravcomp_body_set(model) == _FRANKA_EXPECTED_BODIES
+
+    def test_ur5e_wrapper_matches_walker_body_set(self, ur5e_spec):
+        from mj_manipulator.arms.ur5e import add_ur5e_gravcomp
+
+        add_ur5e_gravcomp(ur5e_spec)
+        model = ur5e_spec.compile()
+        assert _gravcomp_body_set(model) == _UR5E_EXPECTED_BODIES
+
+    def test_franka_wrapper_qfrc_gravcomp_matches_qfrc_bias_at_home(self, franka_spec):
+        """The property that actually matters: after add_franka_gravcomp
+        + compile, the gravity term in qfrc_bias is fully canceled by
+        qfrc_gravcomp at the home pose, so the PD loop doesn't have to
+        fight gravity.
+        """
+        from mj_manipulator.arms.franka import FRANKA_HOME, add_franka_gravcomp
+
+        add_franka_gravcomp(franka_spec)
+        model = franka_spec.compile()
+        data = mujoco.MjData(model)
+
+        # Set home qpos on joint1-joint7
+        for i in range(7):
+            jid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, f"joint{i + 1}")
+            data.qpos[model.jnt_qposadr[jid]] = FRANKA_HOME[i]
+        mujoco.mj_forward(model, data)
+
+        # Residual = gravity_torque - gravcomp_torque ≈ 0
+        max_residual = float(np.max(np.abs(data.qfrc_bias - data.qfrc_gravcomp)))
+        assert max_residual < 1e-6, f"Franka gravity not fully compensated: residual={max_residual}"
+
+    def test_ur5e_wrapper_qfrc_gravcomp_matches_qfrc_bias_at_home(self, ur5e_spec):
+        """Same regression check for UR5e."""
+        from mj_manipulator.arms.ur5e import UR5E_HOME, add_ur5e_gravcomp
+
+        add_ur5e_gravcomp(ur5e_spec)
+        model = ur5e_spec.compile()
+        data = mujoco.MjData(model)
+
+        joint_names = [
+            "shoulder_pan_joint",
+            "shoulder_lift_joint",
+            "elbow_joint",
+            "wrist_1_joint",
+            "wrist_2_joint",
+            "wrist_3_joint",
+        ]
+        for i, jname in enumerate(joint_names):
+            jid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, jname)
+            data.qpos[model.jnt_qposadr[jid]] = UR5E_HOME[i]
+        mujoco.mj_forward(model, data)
+
+        max_residual = float(np.max(np.abs(data.qfrc_bias - data.qfrc_gravcomp)))
+        assert max_residual < 1e-6, f"UR5e gravity not fully compensated: residual={max_residual}"


### PR DESCRIPTION
Fixes #91.

## Summary

Replaces the hardcoded per-arm body lists in \`add_franka_gravcomp\` and \`add_ur5e_gravcomp\` with a single primitive \`add_subtree_gravcomp(spec, root_body_name)\` in \`mj_manipulator/arm.py\`. Each per-arm helper becomes a one-liner delegating to the walker.

### Before

\`\`\`python
def add_franka_gravcomp(spec):
    _FRANKA_BODIES = ["link0", "link1", "link2", "link3", "link4",
                      "link5", "link6", "link7", "hand",
                      "left_finger", "right_finger"]
    for name in _FRANKA_BODIES:
        body = spec.body(name)
        if body is not None:
            body.gravcomp = 1.0
\`\`\`

### After

\`\`\`python
def add_franka_gravcomp(spec):
    add_subtree_gravcomp(spec, "link0")
\`\`\`

Adding a new arm (xArm7, KUKA iiwa, ABB GoFa, etc.) is now a single-line addition to that arm's module. No body enumeration by hand.

## Graceful failure modes

The walker handles the cases that actually come up:

| Failure mode | Handling |
|---|---|
| \`root_body_name\` not found | \`ValueError\` with the bad name AND a list of available top-level worldbody children, so typos are easy to diagnose |
| Root with no descendants | Still sets gravcomp on the root, returns \`count=1\`. Degenerate but valid. |
| Repeated calls on the same root | Idempotent — setting \`gravcomp=1.0\` twice is harmless |
| Overlapping subtree calls (e.g. \`link0\` then \`link1\`) | Idempotent for the same reason |
| Bodies outside the scoped subtree | Not touched. Scope follows the caller's root choice. |

Not handled (caller's responsibility, documented as constraints):

- **Called on an already-compiled spec**: MjSpec doesn't reliably expose a "was this compiled?" check. The call will "succeed" but the values won't take effect. Same pre-compile constraint as the old helpers.
- **Calling on an ancestor that includes bodies you don't want gravcomp'd**: the per-arm wrappers sidestep this by naming the arm's kinematic root specifically.

## Why not fully automatic in \`Arm.__init__\`

Two structural reasons gravcomp can't be set automatically inside the \`Arm\` constructor:

1. **Timing**: gravcomp must be set on the MjSpec **before** \`spec.compile()\`. \`Arm.__init__\` takes an already-compiled \`Environment\`. By the time the \`Arm\` exists, it's too late.
2. **Scope knowledge**: the MjSpec layer doesn't know yet which bodies belong to "the arm's kinematic chain" — that structure only exists after compile. Before compile, you're operating on an XML document, not a kinematic chain.

The \`Arm.__init__\` warning introduced in #86 still fires loudly when someone constructs an arm whose subtree has no gravcomp, so the guardrail is preserved.

## Test coverage

New \`tests/test_gravcomp_helpers.py\` with 12 tests split into two classes:

**\`TestAddSubtreeGravcomp\`** — the walker primitive:
- Franka returns expected count (11) ✓
- Franka touches the expected body set (set equality, not just count) ✓
- UR5e returns expected count (7) ✓
- UR5e touches the expected body set ✓
- Missing root raises \`ValueError\` with bad name + available bodies in the message ✓
- Repeated calls are idempotent ✓
- Overlapping subtree calls are idempotent ✓
- Adding a sibling body to worldbody: walker does NOT touch it ✓

**\`TestPerArmWrappers\`** — the per-arm helpers delegate correctly and produce the right physics:
- \`add_franka_gravcomp\` touches the expected Franka body set ✓
- \`add_ur5e_gravcomp\` touches the expected UR5e body set ✓
- Franka \`qfrc_gravcomp == qfrc_bias\` at \`FRANKA_HOME\` (max residual < 1e-6) ✓
- UR5e \`qfrc_gravcomp == qfrc_bias\` at \`UR5E_HOME\` (max residual < 1e-6) ✓

The set-equality assertions against hardcoded ground-truth body lists (\`_FRANKA_EXPECTED_BODIES\`, \`_UR5E_EXPECTED_BODIES\`) mean that if the walker or the menagerie XMLs ever change the body structure, a test will fail and the author has to consciously update the ground truth.

All tests skip automatically if \`mujoco_menagerie\` is not available.

## Test plan

- [x] \`uv run ruff check .\` passes
- [x] \`uv run ruff format --check .\` passes
- [x] \`uv run pytest tests/\` → 331 passed (319 baseline + 12 new)
- [x] \`uv run python demos/verify_cartesian_lift.py\` → 3/3 scenarios PASS
- [x] Direct verification: Franka qfrc_gravcomp residual < 1e-6 at home, UR5e same
- [ ] CI green

## Related

- #85 — systematic gravcomp rollout (the predecessor that surfaced the per-arm boilerplate pain)
- #86 — introduced \`add_franka_gravcomp\` + the \`Arm.__init__\` warning
- #90 — wired the per-arm helpers into every MjSpec-loading demo
- #91 — the refactor this PR fixes