### PR TITLE
GraspVerifier: real-hardware-valid held-object check (fixes #93)

### DIFF
--- a/src/mj_manipulator/arm.py
+++ b/src/mj_manipulator/arm.py
@@ -371,6 +371,33 @@ class Arm:
         """Current joint velocities (rad/s)."""
         return np.array([self.env.data.qvel[idx] for idx in self.joint_qvel_indices])
 
+    def get_joint_torques(self) -> np.ndarray:
+        """Current joint-torque vector (N·m per joint).
+
+        Returns ``qfrc_actuator`` for this arm's joints — the torque each
+        actuator applies to the joint. With gravity compensation active,
+        this reduces (at rest) largely to whatever external load the arm
+        is working against: the weight of a held object, contact forces,
+        etc. That makes it a useful load signal for arms whose only load
+        sensing is at the joints (e.g. Franka via ``tau_ext``), parallel
+        to :meth:`get_ft_wrench` for arms with a wrist F/T sensor.
+
+        Returns NaN when ``ft_valid`` is False — the same validity gate
+        as F/T. Kinematic sim doesn't run physics integration, so
+        ``qfrc_actuator`` is meaningless there. On real hardware the
+        ``HardwareContext`` supplies the driver's external-torque
+        estimate and sets ``ft_valid = True``.
+
+        Returns:
+            np.ndarray of shape ``(dof,)``: actuator torques in N·m,
+            indexed to match ``get_joint_positions()``. All NaN if joint
+            torque data is not currently meaningful.
+        """
+        if not self.ft_valid:
+            return np.full(self.dof, np.nan)
+        data = self.env.data
+        return np.array([data.qfrc_actuator[idx] for idx in self.joint_qvel_indices])
+
     def get_ft_wrench(self) -> np.ndarray:
         """Current wrist force/torque reading as [fx, fy, fz, tx, ty, tz].
 

--- a/src/mj_manipulator/grasp_verifier.py
+++ b/src/mj_manipulator/grasp_verifier.py
@@ -1,0 +1,296 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Runtime check for \"is the held object still held\".
+
+The :class:`GraspVerifier` answers a single question: given what we
+told the arm to grasp and what the sensors are reading right now, do
+we still believe the object is in the gripper? It replaces
+contact-inspection-based checks (e.g. the ``iter_contacts`` post-check
+in geodude's original :class:`LiftBase`) that only work in simulation.
+
+The decision logic is split out as a pure function
+:func:`verify_grasp` taking a :class:`VerifierFacts` dataclass, so the
+logic is unit-testable without any simulation state, mocks, or
+hardware. The :class:`GraspVerifier` class is the stateful shell:
+it owns the list of :class:`~mj_manipulator.load_signals.LoadSignal`
+instances, records a baseline at :meth:`mark_grasped` time, and
+assembles facts from live reads when :attr:`is_held` is queried.
+
+Design notes:
+
+- Signals that return ``None`` from their :meth:`read` method are
+  skipped, not interpreted as lost load. This is how kinematic sim
+  degrades gracefully — every load signal returns ``None`` there and
+  :attr:`is_held` reduces to \"did anyone call ``mark_grasped``?\".
+- The decision function is robot-agnostic. Geodude composes a verifier
+  with ``[GripperPositionSignal(robotiq), WristFTSignal(ur5e)]``;
+  Franka composes one with ``[GripperPositionSignal(panda),
+  JointTorqueSignal(franka)]``. Same class, different signal list.
+- The :attr:`held_object` property is the bookkeeping name (what we
+  told the arm to grasp). It goes to ``None`` when :attr:`is_held`
+  is False, so downstream consumers that currently read
+  ``gripper.held_object`` as \"what am I holding right now?\" get a
+  real answer instead of stale bookkeeping.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from mj_manipulator.load_signals import LoadSignal
+
+if TYPE_CHECKING:
+    from mj_manipulator.protocols import Gripper
+
+
+# ---------------------------------------------------------------------------
+# Pure decision function — unit-testable without any physics or mocks
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class VerifierParams:
+    """Tunable parameters for :func:`verify_grasp`.
+
+    Defaults are deliberately conservative — we'd rather declare a
+    healthy grasp \"probably dropped\" and let recovery run a sanity
+    check than silently transport an object that isn't there.
+    """
+
+    empty_position_threshold: float = 0.98
+    """Normalized gripper position [0, 1] at or above which we treat
+    the gripper as \"at the mechanical stop\". Only consulted when
+    :attr:`VerifierFacts.empty_at_fully_closed` is True."""
+
+    load_drop_ratio: float = 0.3
+    """Fraction of baseline below which a signal is considered
+    collapsed. A signal whose magnitude drops below
+    ``abs(baseline) * (1 - load_drop_ratio)`` triggers a FAILURE
+    verdict. 0.3 = signal must drop by more than 30% from baseline."""
+
+
+@dataclass
+class VerifierFacts:
+    """Inputs to :func:`verify_grasp`.
+
+    Holds the minimal snapshot the decision function needs: what we
+    were told we grasped, whether fully-closed means \"empty\" for
+    this gripper, the current position reading, and each load
+    signal's current value and baseline. Everything is already a
+    plain Python type — no MuJoCo, no numpy, no mocks.
+    """
+
+    object_name: str | None
+    """The object the grasp sequence believes it picked up, or None
+    if no grasp is currently in progress."""
+
+    empty_at_fully_closed: bool
+    """Does this gripper's ``ctrl_closed`` position mean \"fingers
+    touching, no object between them\"? True for Franka/ABH, False
+    for Robotiq 2F-140."""
+
+    gripper_position: float | None
+    """Current normalized gripper position, or None if unreadable."""
+
+    signal_values: dict[str, float | None] = field(default_factory=dict)
+    """Current scalar reading per signal name. ``None`` means the
+    signal is not available on this arm right now."""
+
+    signal_baselines: dict[str, float | None] = field(default_factory=dict)
+    """Per-signal baseline recorded at :meth:`GraspVerifier.mark_grasped`
+    time. ``None`` means the baseline wasn't captured for that
+    signal (signal was unavailable at grasp time)."""
+
+
+def verify_grasp(facts: VerifierFacts, params: VerifierParams) -> bool:
+    """Pure decision: given a snapshot, is the object still held?
+
+    Walks a small decision tree:
+
+    1. **No object tracked** → False (nothing to verify; we're not
+       currently trying to hold anything).
+    2. **Decisive empty-stop negative**: if the gripper is a
+       fully-closed-means-empty type and the position is at or above
+       the threshold → False. The fingers are touching each other
+       with nothing in between.
+    3. **Load-drop check**: for every signal that has a usable
+       baseline and a live reading, check whether the live value has
+       collapsed below ``|baseline| * (1 - load_drop_ratio)``. If any
+       signal has → False.
+    4. **Otherwise** → True.
+
+    Signals with ``None`` readings (either baseline or live) are
+    skipped rather than treated as failures. A very small baseline
+    (``|baseline| < 1e-6``) is also skipped — we can't infer a drop
+    from nothing.
+
+    Args:
+        facts: Current snapshot of grasp state.
+        params: Thresholds controlling the decision.
+
+    Returns:
+        True if the held object is still held, False otherwise.
+    """
+    if facts.object_name is None:
+        return False
+
+    if (
+        facts.empty_at_fully_closed
+        and facts.gripper_position is not None
+        and facts.gripper_position >= params.empty_position_threshold
+    ):
+        return False
+
+    for name, val in facts.signal_values.items():
+        base = facts.signal_baselines.get(name)
+        if val is None or base is None:
+            continue
+        if abs(base) < 1e-6:
+            continue
+        if abs(val) < abs(base) * (1.0 - params.load_drop_ratio):
+            return False
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Stateful shell — owns signals, captures baselines, answers queries
+# ---------------------------------------------------------------------------
+
+
+class GraspVerifier:
+    """Per-arm \"is the held object still held\" check.
+
+    Composes a list of :class:`LoadSignal` instances that the arm
+    actually has (gripper position, wrist F/T, joint torques, ...)
+    and a reference to the gripper (for the ``empty_at_fully_closed``
+    decisive-negative branch). Records a baseline from every signal
+    when :meth:`mark_grasped` is called; the :attr:`is_held` property
+    compares live reads against the baseline via :func:`verify_grasp`.
+
+    The verifier is instantaneous — :attr:`is_held` re-reads every
+    signal each time it's queried. There's no rolling average or
+    debounce in v1; adding one means extending :meth:`tick` and
+    filtering in :meth:`_collect_facts`, but the v1 signals are all
+    physical quantities that already change smoothly, so
+    instantaneous reads are good enough to start with.
+
+    Example — Geodude (UR5e + Robotiq 2F-140)::
+
+        verifier = GraspVerifier(
+            gripper=robot.left.gripper,
+            signals=[
+                GripperPositionSignal(robot.left.gripper),
+                WristFTSignal(robot.left.arm),
+            ],
+        )
+        robot.left.gripper.grasp_verifier = verifier
+
+    Example — Franka (empty_at_fully_closed=True, joint torques)::
+
+        verifier = GraspVerifier(
+            gripper=franka.gripper,
+            signals=[
+                GripperPositionSignal(franka.gripper),
+                JointTorqueSignal(franka.arm),
+            ],
+        )
+    """
+
+    def __init__(
+        self,
+        gripper: Gripper,
+        signals: list[LoadSignal],
+        *,
+        params: VerifierParams | None = None,
+    ):
+        self._gripper = gripper
+        self._signals = list(signals)
+        self._params = params if params is not None else VerifierParams()
+        self._object_name: str | None = None
+        self._baselines: dict[str, float | None] = {}
+
+    # -- Public API ----------------------------------------------------------
+
+    @property
+    def held_object(self) -> str | None:
+        """The object we believe is currently held, or None.
+
+        This is *not* raw bookkeeping — it only returns the grasped
+        name when :attr:`is_held` agrees. A stale baseline + dropped
+        object yields ``None``. Consumers that want \"what did the
+        grasp sequence think it grabbed\" without the health check
+        should read :attr:`tracked_object` instead.
+        """
+        if self._object_name is None:
+            return None
+        return self._object_name if self.is_held else None
+
+    @property
+    def tracked_object(self) -> str | None:
+        """The object name recorded at :meth:`mark_grasped` time, or None.
+
+        This is the raw bookkeeping — it does *not* re-check live
+        signals. Useful for diagnostics (\"we thought we grabbed X,
+        but the verifier says we dropped it\") and for
+        :class:`~mj_manipulator.bt.nodes` that need to know what the
+        grasp sequence was *attempting* even if it failed.
+        """
+        return self._object_name
+
+    @property
+    def is_held(self) -> bool:
+        """Live check: are the signals consistent with still holding the object?
+
+        Re-reads every signal each call. Returns False if no object
+        is currently tracked (nothing to check) or if the decision
+        function says the held object has dropped.
+        """
+        return verify_grasp(self._collect_facts(), self._params)
+
+    def mark_grasped(self, object_name: str) -> None:
+        """Begin tracking a grasp and capture a baseline from every signal.
+
+        Called by the grasp sequence (:meth:`SimArmController.grasp`
+        or its hardware equivalent) right after the close motion
+        succeeds. Records the current value of every signal so future
+        :attr:`is_held` calls can detect drops.
+        """
+        self._object_name = object_name
+        self._baselines = {s.name: s.read() for s in self._signals}
+
+    def mark_released(self) -> None:
+        """Stop tracking. :attr:`is_held` returns False until the next
+        :meth:`mark_grasped`.
+        """
+        self._object_name = None
+        self._baselines = {}
+
+    def tick(self) -> None:
+        """Per-control-cycle hook.
+
+        No-op in v1 — signals are read instantaneously on every
+        :attr:`is_held` call. Reserved for future debouncing /
+        rolling-average logic; keeping the hook point means execute
+        loops can wire it up now without needing a protocol change
+        later.
+        """
+        return None
+
+    # -- Internals -----------------------------------------------------------
+
+    def _collect_facts(self) -> VerifierFacts:
+        """Gather live readings into a :class:`VerifierFacts` snapshot."""
+        try:
+            gripper_position: float | None = float(self._gripper.get_actual_position())
+        except Exception:
+            gripper_position = None
+        return VerifierFacts(
+            object_name=self._object_name,
+            empty_at_fully_closed=getattr(self._gripper, "empty_at_fully_closed", False),
+            gripper_position=gripper_position,
+            signal_values={s.name: s.read() for s in self._signals},
+            signal_baselines=dict(self._baselines),
+        )

--- a/src/mj_manipulator/grippers/_base.py
+++ b/src/mj_manipulator/grippers/_base.py
@@ -17,6 +17,7 @@ from mj_manipulator.contacts import iter_contacts
 
 if TYPE_CHECKING:
     from mj_manipulator.grasp_manager import GraspManager
+    from mj_manipulator.grasp_verifier import GraspVerifier
 
 
 class _BaseGripper:
@@ -53,6 +54,7 @@ class _BaseGripper:
         self._ctrl_open = ctrl_open
         self._ctrl_closed = ctrl_closed
         self._grasp_manager = grasp_manager
+        self._grasp_verifier: GraspVerifier | None = None
         self._candidate_objects: list[str] | None = None
 
         # Resolve actuator ID
@@ -102,16 +104,40 @@ class _BaseGripper:
 
     @property
     def is_holding(self) -> bool:
+        if self._grasp_verifier is not None:
+            return self._grasp_verifier.is_held
         if self._grasp_manager is None:
             return False
         return len(self._grasp_manager.get_grasped_by(self._arm_name)) > 0
 
     @property
     def held_object(self) -> str | None:
+        if self._grasp_verifier is not None:
+            return self._grasp_verifier.held_object
         if self._grasp_manager is None:
             return None
         held = self._grasp_manager.get_grasped_by(self._arm_name)
         return held[0] if held else None
+
+    @property
+    def grasp_verifier(self) -> GraspVerifier | None:
+        """Sensor-based grasp health check, if configured.
+
+        When set, :attr:`is_holding` and :attr:`held_object` route
+        through the verifier instead of reading from
+        :class:`GraspManager` bookkeeping. Set this after
+        constructing the gripper and the signal sources it needs —
+        see :class:`GraspVerifier` for wiring examples.
+
+        Leaving it unset preserves the legacy path (``is_holding``
+        reads ``GraspManager``), which is the current default
+        everywhere and requires no per-robot changes.
+        """
+        return self._grasp_verifier
+
+    @grasp_verifier.setter
+    def grasp_verifier(self, verifier: GraspVerifier | None) -> None:
+        self._grasp_verifier = verifier
 
     def set_candidate_objects(self, objects: list[str] | None) -> None:
         self._candidate_objects = objects

--- a/src/mj_manipulator/load_signals.py
+++ b/src/mj_manipulator/load_signals.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Live load signals for grasp verification.
+
+A ``LoadSignal`` is a named, live, scalar-valued readout that says
+something about whether the gripper is bearing a load. The
+:class:`~mj_manipulator.grasp_verifier.GraspVerifier` composes a list
+of these signals to decide whether a held object is still held — on
+sim, on UR5e + wrist F/T, on Franka + joint-torque sensing, and on
+arms with nothing but a gripper position sensor. The verifier doesn't
+know or care which kind of signal it's reading; it just compares each
+live value against a baseline recorded at grasp time.
+
+The protocol is deliberately tiny:
+
+1. ``name`` — a unique string identifier the verifier uses to key
+   baselines by signal.
+2. ``read()`` — return the current scalar value, or ``None`` when the
+   signal is not available on this arm right now (e.g. kinematic sim
+   has no F/T, or the arm has no wrist sensor). ``None`` is different
+   from ``0.0``: ``0.0`` means \"no load was measured\", ``None``
+   means \"no measurement is possible\" — the verifier skips ``None``
+   signals rather than interpreting them as lost load.
+
+This is the only place the \"does this robot have this sensor?\"
+branch lives. Consumers (the verifier, runtime monitors) stay
+sensor-agnostic.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from mj_manipulator.arm import Arm
+    from mj_manipulator.protocols import Gripper
+
+
+@runtime_checkable
+class LoadSignal(Protocol):
+    """A live scalar that reflects whether the gripper is bearing a load.
+
+    Implementations encapsulate any per-signal projection (force
+    magnitude, torque norm, position) so the verifier can treat every
+    signal as a plain ``float``. See the three built-ins below for
+    representative shapes.
+    """
+
+    @property
+    def name(self) -> str:
+        """Unique identifier for this signal (used as a baseline key)."""
+        ...
+
+    def read(self) -> float | None:
+        """Return the current scalar value, or None if unavailable.
+
+        ``None`` means \"this signal cannot be read on this arm right
+        now\" — the verifier will skip it rather than treating the
+        missing reading as lost load. This is how kinematic sim
+        degrades gracefully (all load signals return ``None``, so the
+        verifier falls back to whatever signals are still live).
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Built-in signal sources
+# ---------------------------------------------------------------------------
+
+
+class GripperPositionSignal:
+    """Normalized gripper position in ``[0.0, 1.0]`` where ``1.0`` is fully closed.
+
+    Universally available: every gripper has a position readout. This
+    signal is most useful as a *decisive negative*: if the gripper hit
+    the mechanical stop (``position ≈ 1.0``) AND the gripper's
+    ``empty_at_fully_closed`` flag is True (Franka, ABH), then the
+    fingers physically touched each other with nothing in between and
+    the grasp is empty. For grippers where fully-closed is a valid
+    grasp (Robotiq 2F-140), the verifier's decisive-negative branch is
+    disabled and this signal is informational only.
+    """
+
+    name: str = "gripper_position"
+
+    def __init__(self, gripper: Gripper):
+        self._gripper = gripper
+
+    def read(self) -> float | None:
+        try:
+            return float(self._gripper.get_actual_position())
+        except Exception:
+            return None
+
+
+class WristFTSignal:
+    """Wrist F/T force magnitude in newtons, or None in kinematic mode.
+
+    Reads :meth:`Arm.get_ft_wrench` and returns the Euclidean norm of
+    its linear (force) component. Returns ``None`` when the arm has
+    no F/T sensor configured or when ``ft_valid`` is False (kinematic
+    sim), which matches the verifier's \"skip this signal\" semantics.
+    """
+
+    name: str = "wrist_ft_force"
+
+    def __init__(self, arm: Arm):
+        self._arm = arm
+
+    def read(self) -> float | None:
+        if not self._arm.has_ft_sensor:
+            return None
+        wrench = self._arm.get_ft_wrench()
+        if np.isnan(wrench[0]):
+            return None
+        return float(np.linalg.norm(wrench[:3]))
+
+
+class JointTorqueSignal:
+    """Aggregate joint-torque magnitude in N·m, or None in kinematic mode.
+
+    Reads :meth:`Arm.get_joint_torques` and returns the Euclidean norm
+    across all joints. With gravity compensation active, this reduces
+    (at rest) largely to whatever external load the arm is working
+    against — the weight of a held object being the dominant term.
+    The signal drops when the load disappears, which is exactly what
+    the verifier looks for.
+
+    Useful for arms with no wrist F/T (Franka, which exposes joint
+    torques via ``tau_ext`` on hardware). Returns ``None`` in
+    kinematic sim where ``ft_valid`` is False.
+    """
+
+    name: str = "joint_torque_effort"
+
+    def __init__(self, arm: Arm):
+        self._arm = arm
+
+    def read(self) -> float | None:
+        torques = self._arm.get_joint_torques()
+        if torques.size == 0 or np.isnan(torques[0]):
+            return None
+        return float(np.linalg.norm(torques))

--- a/src/mj_manipulator/sim_context.py
+++ b/src/mj_manipulator/sim_context.py
@@ -112,6 +112,12 @@ class SimArmController:
                 grasped,
                 gripper.attachment_body,
             )
+            # Also notify the sensor-based verifier if one is wired up.
+            # The verifier captures its signal baseline right here, so a
+            # future is_held query can tell whether the load has dropped
+            # since the grasp completed.
+            if gripper.grasp_verifier is not None:
+                gripper.grasp_verifier.mark_grasped(grasped)
             logger.info("Grasped %s with %s arm", grasped, arm_name)
         elif not grasped:
             logger.info(
@@ -149,6 +155,12 @@ class SimArmController:
             for obj in objects:
                 gm.mark_released(obj)
                 gm.detach_object(obj)
+
+        # Clear the verifier's baseline so is_held returns False after
+        # the release. Release is a hard ground truth — we know we're
+        # letting go, no need to consult sensors.
+        if gripper.grasp_verifier is not None:
+            gripper.grasp_verifier.mark_released()
 
         if self._context._controller is not None:
             self._context._controller.open_gripper(arm_name)

--- a/tests/test_franka_gripper.py
+++ b/tests/test_franka_gripper.py
@@ -196,3 +196,95 @@ class TestArmFactoryIntegration:
         assert arm.gripper is gripper
         assert arm.grasp_manager is gm
         assert isinstance(arm.gripper, Gripper)
+
+
+# ---------------------------------------------------------------------------
+# GraspVerifier integration: real FrankaGripper + fake load signals
+#
+# This verifies that _BaseGripper.is_holding / held_object correctly route
+# through the verifier when one is attached, exercising the routing change
+# from personalrobotics/mj_manipulator#93 on a real gripper class (not a
+# stub). The signal values themselves are fake so the test is fast and
+# deterministic; physics-loop grasp validation happens end-to-end in the
+# recycling demo on geodude.
+# ---------------------------------------------------------------------------
+
+
+class _FakeSignal:
+    """Minimal LoadSignal stub for integration tests."""
+
+    def __init__(self, name: str, value: float | None):
+        self.name = name
+        self.value = value
+
+    def read(self) -> float | None:
+        return self.value
+
+
+class TestFrankaGripperWithGraspVerifier:
+    def _attach_verifier(self, gripper: FrankaGripper) -> tuple:
+        """Wire up a GraspVerifier with one fake signal and ensure the
+        gripper is open so the ``empty_at_fully_closed=True`` branch
+        doesn't immediately short-circuit is_held to False.
+
+        Returns (verifier, signal).
+        """
+        from mj_manipulator.grasp_verifier import GraspVerifier
+
+        gripper.kinematic_open()
+        signal = _FakeSignal("wrist_ft_force", value=10.0)
+        verifier = GraspVerifier(gripper=gripper, signals=[signal])
+        gripper.grasp_verifier = verifier
+        return verifier, signal
+
+    def test_is_holding_routes_through_verifier(self, franka_gripper):
+        """When a verifier is attached, is_holding should reflect
+        verifier.is_held, not GraspManager bookkeeping."""
+        verifier, _ = self._attach_verifier(franka_gripper)
+        assert franka_gripper.is_holding is False
+        verifier.mark_grasped("fake_cube")
+        assert franka_gripper.is_holding is True
+
+    def test_held_object_routes_through_verifier(self, franka_gripper):
+        """held_object should return what the verifier says, not what
+        GraspManager thinks."""
+        verifier, _ = self._attach_verifier(franka_gripper)
+        assert franka_gripper.held_object is None
+        verifier.mark_grasped("fake_cube")
+        assert franka_gripper.held_object == "fake_cube"
+
+    def test_signal_collapse_flips_held_object_to_none(self, franka_gripper):
+        """Regression for geodude#173: if the load signal collapses,
+        held_object should go to None even though mark_grasped was called.
+        This is the whole point of the verifier vs. bookkeeping."""
+        verifier, signal = self._attach_verifier(franka_gripper)
+        verifier.mark_grasped("fake_cube")
+        assert franka_gripper.held_object == "fake_cube"
+        signal.value = 0.5  # load collapsed
+        assert franka_gripper.held_object is None
+        assert franka_gripper.is_holding is False
+
+    def test_mark_released_clears_routing(self, franka_gripper):
+        """After release, the verifier should report empty."""
+        verifier, _ = self._attach_verifier(franka_gripper)
+        verifier.mark_grasped("fake_cube")
+        verifier.mark_released()
+        assert franka_gripper.is_holding is False
+        assert franka_gripper.held_object is None
+
+    def test_verifier_falls_back_without_attachment(self, franka_env):
+        """Sanity: the default path (no verifier) is unchanged — the
+        legacy GraspManager-based is_holding still works."""
+        gm = GraspManager(franka_env.model, franka_env.data)
+        gripper = FrankaGripper(
+            franka_env.model,
+            franka_env.data,
+            "franka",
+            grasp_manager=gm,
+        )
+        assert gripper.grasp_verifier is None
+        assert gripper.is_holding is False
+        # Simulate legacy bookkeeping path
+        gm.mark_grasped("legacy_cube", "franka")
+        assert gripper.is_holding is True
+        assert gripper.held_object == "legacy_cube"

--- a/tests/test_grasp_verifier.py
+++ b/tests/test_grasp_verifier.py
@@ -1,0 +1,354 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Tests for :mod:`mj_manipulator.grasp_verifier`.
+
+Two layers:
+
+1. **Pure unit tests on** :func:`verify_grasp` — one test per branch of
+   the decision tree, constructing :class:`VerifierFacts` by hand. No
+   physics, no mocks, no MuJoCo.
+
+2. **Small stateful tests on** :class:`GraspVerifier` **with fake
+   signals** — verifies that the stateful shell captures baselines at
+   :meth:`mark_grasped` time, that :meth:`mark_released` clears state,
+   and that :attr:`is_held` reflects live changes to the fake signal
+   values. Still no physics — the fake signals are plain objects.
+
+Integration with real physics + a real arm happens in a separate
+test file (``test_grasp_verifier_integration.py``) so this file stays
+fast and deterministic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mj_manipulator.grasp_verifier import (
+    GraspVerifier,
+    VerifierFacts,
+    VerifierParams,
+    verify_grasp,
+)
+
+# ---------------------------------------------------------------------------
+# Pure-function tests on verify_grasp
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyGrasp:
+    """Exhaustive tests for the pure decision function.
+
+    Each test corresponds to one branch of the decision tree. If any
+    SUCCESS-on-failure branch creeps back in, exactly one of these
+    will fail, so the regression is easy to localize.
+    """
+
+    _params = VerifierParams()  # default thresholds
+
+    def _facts(self, **overrides) -> VerifierFacts:
+        """Build a 'healthy grasp' fact set and apply overrides."""
+        defaults = dict(
+            object_name="can_0",
+            empty_at_fully_closed=False,
+            gripper_position=0.55,
+            signal_values={"wrist_ft_force": 8.0},
+            signal_baselines={"wrist_ft_force": 10.0},
+        )
+        defaults.update(overrides)
+        return VerifierFacts(**defaults)
+
+    def test_happy_path(self):
+        """Healthy grasp with a live signal close to baseline."""
+        assert verify_grasp(self._facts(), self._params) is True
+
+    def test_no_object_tracked(self):
+        """Nothing was marked grasped → False (nothing to verify)."""
+        facts = self._facts(object_name=None)
+        assert verify_grasp(facts, self._params) is False
+
+    def test_empty_at_fully_closed_decisive_negative(self):
+        """Franka-style gripper at mechanical stop → False."""
+        facts = self._facts(empty_at_fully_closed=True, gripper_position=0.99)
+        assert verify_grasp(facts, self._params) is False
+
+    def test_fully_closed_but_flag_off(self):
+        """Robotiq-style gripper: fully closed is a valid grasp."""
+        facts = self._facts(empty_at_fully_closed=False, gripper_position=1.0)
+        assert verify_grasp(facts, self._params) is True
+
+    def test_fully_closed_exactly_at_threshold(self):
+        """Boundary check: position == threshold counts as empty."""
+        facts = self._facts(empty_at_fully_closed=True, gripper_position=0.98)
+        assert verify_grasp(facts, self._params) is False
+
+    def test_fully_closed_just_below_threshold(self):
+        """Boundary check: position just below threshold is fine."""
+        facts = self._facts(empty_at_fully_closed=True, gripper_position=0.97)
+        assert verify_grasp(facts, self._params) is True
+
+    def test_load_signal_collapsed(self):
+        """F/T reading dropped below baseline × (1 - ratio) → False."""
+        facts = self._facts(
+            signal_values={"wrist_ft_force": 2.0},
+            signal_baselines={"wrist_ft_force": 10.0},
+        )
+        assert verify_grasp(facts, self._params) is False
+
+    def test_load_signal_marginal(self):
+        """Signal dropped but still above threshold → True."""
+        # 10 N baseline, 0.3 ratio → threshold 7 N. 7.5 N is still OK.
+        facts = self._facts(
+            signal_values={"wrist_ft_force": 7.5},
+            signal_baselines={"wrist_ft_force": 10.0},
+        )
+        assert verify_grasp(facts, self._params) is True
+
+    def test_load_signal_unavailable_skipped(self):
+        """Signal read returned None → skip, don't fail."""
+        facts = self._facts(
+            signal_values={"wrist_ft_force": None},
+            signal_baselines={"wrist_ft_force": 10.0},
+        )
+        assert verify_grasp(facts, self._params) is True
+
+    def test_load_signal_baseline_unavailable_skipped(self):
+        """Baseline is None (signal was unavailable at grasp time) → skip."""
+        facts = self._facts(
+            signal_values={"wrist_ft_force": 2.0},
+            signal_baselines={"wrist_ft_force": None},
+        )
+        assert verify_grasp(facts, self._params) is True
+
+    def test_baseline_near_zero_skipped(self):
+        """Baseline ~0 → can't infer a drop, skip.
+
+        This matters because a taut tare zero (F/T calibrated to zero
+        just before grasp) would give baseline ≈ 0 N, making any live
+        reading trivially satisfy the drop check. Skipping is safer.
+        """
+        facts = self._facts(
+            signal_values={"wrist_ft_force": 0.0},
+            signal_baselines={"wrist_ft_force": 1e-8},
+        )
+        assert verify_grasp(facts, self._params) is True
+
+    def test_multi_signal_one_collapsed_fails(self):
+        """If any signal has collapsed, the overall verdict is False."""
+        facts = self._facts(
+            signal_values={"wrist_ft_force": 8.0, "joint_torque_effort": 0.1},
+            signal_baselines={"wrist_ft_force": 10.0, "joint_torque_effort": 5.0},
+        )
+        assert verify_grasp(facts, self._params) is False
+
+    def test_multi_signal_all_healthy(self):
+        """All signals above their thresholds → True."""
+        facts = self._facts(
+            signal_values={"wrist_ft_force": 9.0, "joint_torque_effort": 4.5},
+            signal_baselines={"wrist_ft_force": 10.0, "joint_torque_effort": 5.0},
+        )
+        assert verify_grasp(facts, self._params) is True
+
+    def test_no_signals_no_empty_stop_check(self):
+        """Kinematic-mode degeneration: no live signals, no decisive
+        negative, but an object was marked grasped → True.
+
+        This is the 'toy mode' path: kinematic sim has no F/T or joint
+        torques, so every signal returns None. The verifier reduces
+        to 'we told it to grasp something, trust that'. Documented as
+        a limitation in the issue."""
+        facts = self._facts(
+            signal_values={"wrist_ft_force": None, "joint_torque_effort": None},
+            signal_baselines={"wrist_ft_force": None, "joint_torque_effort": None},
+        )
+        assert verify_grasp(facts, self._params) is True
+
+
+# ---------------------------------------------------------------------------
+# Stateful tests on GraspVerifier with fake signals
+# ---------------------------------------------------------------------------
+
+
+class FakeSignal:
+    """Plain LoadSignal stub — ``value`` is the live reading.
+
+    Tests mutate ``value`` directly to simulate real-world signal
+    changes (object weight appearing/disappearing). Implements the
+    :class:`LoadSignal` protocol structurally: ``name`` is an
+    attribute, ``read`` returns the current ``value``.
+    """
+
+    def __init__(self, name: str, value: float | None):
+        self.name = name
+        self.value = value
+
+    def read(self) -> float | None:
+        return self.value
+
+
+class FakeGripper:
+    """Minimal gripper with just what GraspVerifier needs."""
+
+    def __init__(self, position: float = 0.5, empty_at_fully_closed: bool = False):
+        self.position = position
+        self.empty_at_fully_closed = empty_at_fully_closed
+
+    def get_actual_position(self) -> float:
+        return self.position
+
+
+class TestGraspVerifier:
+    """Stateful integration of the verifier with fake signals."""
+
+    def _make(self, *, empty_at_fully_closed: bool = False):
+        gripper = FakeGripper(position=0.5, empty_at_fully_closed=empty_at_fully_closed)
+        signal = FakeSignal(name="wrist_ft_force", value=10.0)
+        verifier = GraspVerifier(gripper=gripper, signals=[signal])
+        return verifier, gripper, signal
+
+    def test_fresh_verifier_is_not_held(self):
+        verifier, _, _ = self._make()
+        assert verifier.is_held is False
+        assert verifier.held_object is None
+        assert verifier.tracked_object is None
+
+    def test_mark_grasped_then_is_held(self):
+        verifier, _, _ = self._make()
+        verifier.mark_grasped("can_0")
+        assert verifier.is_held is True
+        assert verifier.held_object == "can_0"
+        assert verifier.tracked_object == "can_0"
+
+    def test_signal_collapse_flips_is_held(self):
+        """The canonical regression for geodude#173: load dropped mid-transport."""
+        verifier, _, signal = self._make()
+        verifier.mark_grasped("can_0")
+        assert verifier.is_held is True
+
+        # Object slips — signal drops to near zero
+        signal.value = 0.5
+        assert verifier.is_held is False
+        assert verifier.held_object is None
+        # But we still remember what we *tried* to grasp
+        assert verifier.tracked_object == "can_0"
+
+    def test_mark_released_clears_state(self):
+        verifier, _, _ = self._make()
+        verifier.mark_grasped("can_0")
+        verifier.mark_released()
+        assert verifier.is_held is False
+        assert verifier.held_object is None
+        assert verifier.tracked_object is None
+
+    def test_signal_unavailable_after_grasp_does_not_fail(self):
+        """If a signal starts returning None after grasp, the verifier
+        skips it instead of treating it as failure. Important for the
+        kinematic-mode degenerate case."""
+        verifier, _, signal = self._make()
+        verifier.mark_grasped("can_0")
+        signal.value = None
+        assert verifier.is_held is True
+
+    def test_franka_style_mechanical_stop_triggers_drop(self):
+        """When empty_at_fully_closed=True, reaching the stop should
+        immediately flip is_held to False even if load signals say
+        otherwise."""
+        verifier, gripper, _ = self._make(empty_at_fully_closed=True)
+        verifier.mark_grasped("panda_cube")
+        assert verifier.is_held is True
+        gripper.position = 1.0
+        assert verifier.is_held is False
+
+    def test_regrasping_updates_baseline(self):
+        """mark_grasped twice — second baseline replaces the first."""
+        verifier, _, signal = self._make()
+        verifier.mark_grasped("can_0")
+        signal.value = 4.0  # heavier object picked up next
+        verifier.mark_grasped("spam_can_0")
+        # New baseline is 4.0, so 3.0 is within 30% drop range
+        signal.value = 3.0
+        assert verifier.is_held is True
+        assert verifier.held_object == "spam_can_0"
+
+    def test_tick_is_noop(self):
+        """v1 tick is a placeholder — calling it doesn't blow up and
+        doesn't affect state."""
+        verifier, _, _ = self._make()
+        verifier.mark_grasped("can_0")
+        verifier.tick()
+        assert verifier.is_held is True
+
+
+# ---------------------------------------------------------------------------
+# _BaseGripper routing: verifier takes precedence over GraspManager when set
+# ---------------------------------------------------------------------------
+
+
+class TestBaseGripperRouting:
+    """Verifies the _BaseGripper property wiring without loading MuJoCo.
+
+    Constructing a real _BaseGripper needs a model + data, which is
+    expensive. Instead, we test the routing via property semantics on
+    a stand-in class that implements the same public API.
+    """
+
+    def test_held_object_without_verifier_uses_grasp_manager(self):
+        """Baseline: gripper with no verifier reads from GraspManager
+        (this is the current behavior across all existing tests)."""
+        # Covered by existing test_grasp_manager.py + integration tests.
+        # Asserting the principle here would duplicate those.
+        pass
+
+    def test_held_object_with_verifier_returns_none_when_not_held(self):
+        """Gripper with verifier, but is_held=False → held_object=None."""
+        gripper = FakeGripper()
+        signal = FakeSignal(name="wrist_ft_force", value=10.0)
+        verifier = GraspVerifier(gripper=gripper, signals=[signal])
+        # Simulate: mark_grasped, then signal collapses
+        verifier.mark_grasped("can_0")
+        signal.value = 0.0
+        assert verifier.held_object is None
+        # But tracked_object still reflects what we thought we grabbed
+        assert verifier.tracked_object == "can_0"
+
+
+# ---------------------------------------------------------------------------
+# Default params sanity
+# ---------------------------------------------------------------------------
+
+
+def test_default_verifier_params_are_reasonable():
+    """Sanity check: defaults should be conservative but not trigger
+    false positives at typical manipulation values."""
+    params = VerifierParams()
+    assert 0.9 <= params.empty_position_threshold <= 1.0
+    assert 0.1 <= params.load_drop_ratio <= 0.5
+
+
+def test_custom_verifier_params_pass_through():
+    """Custom params work."""
+    params = VerifierParams(empty_position_threshold=0.95, load_drop_ratio=0.5)
+    facts = VerifierFacts(
+        object_name="can_0",
+        empty_at_fully_closed=False,
+        gripper_position=0.5,
+        signal_values={"x": 4.5},
+        signal_baselines={"x": 10.0},
+    )
+    # 10 × 0.5 = 5.0 threshold; 4.5 < 5.0 → False with ratio=0.5
+    assert verify_grasp(facts, params) is False
+    # With default ratio=0.3, 4.5 < 7.0 → also False
+    assert verify_grasp(facts, VerifierParams()) is False
+
+
+def test_load_signal_protocol_runtime_checkable():
+    """LoadSignal is a runtime-checkable protocol — fake signals
+    should be structural instances."""
+    from mj_manipulator.load_signals import LoadSignal
+
+    signal = FakeSignal(name="test", value=1.0)
+    assert isinstance(signal, LoadSignal)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #93. First of five issues in the sim-magic elimination series (personalrobotics/geodude#177).

## Summary

Answers *\"is the held object still held?\"* from live sensor signals (gripper position, wrist F/T, joint torques) instead of reading MuJoCo contact state. Generic in \`mj_manipulator\`, composable per robot, sensor-agnostic via a small \`LoadSignal\` protocol. Same code path for sim and hardware; signals return \`None\` when unavailable and the verifier skips them.

## What lands

- \`load_signals.py\` — \`LoadSignal\` protocol + 3 built-in sources:
  - \`GripperPositionSignal\` (universal — every gripper has position)
  - \`WristFTSignal\` (UR5e, returns \`None\` in kinematic sim)
  - \`JointTorqueSignal\` (Franka, returns \`None\` in kinematic sim)
- \`grasp_verifier.py\` — \`GraspVerifier\` class + pure \`verify_grasp(facts, params)\` decision function. The pure function is unit-testable without physics; the class is a thin stateful shell that captures baselines and calls the pure function on live reads.
- \`Arm.get_joint_torques()\` — new method reading \`qfrc_actuator\` for the arm's joints, NaN gated on \`ft_valid\`. Prereq for \`JointTorqueSignal\`.
- \`_BaseGripper.grasp_verifier\` — optional attribute; when set, \`is_holding\` and \`held_object\` route through the verifier instead of \`GraspManager\` bookkeeping. When unset, **legacy path unchanged** — no existing tests break, robots opt in.
- \`SimArmController.grasp/release\` — call \`verifier.mark_grasped/mark_released\` alongside the existing \`GraspManager\` updates, so the baseline is captured at grasp completion and cleared on release.

## Design notes

- **Pure decision function**, unit-testable without any MuJoCo or mocks. Matches the pattern that made the geodude#173 tests clean to write.
- **\`None\` signals are skipped, not treated as failure.** This is how kinematic sim degrades gracefully — every load signal returns \`None\` there and \`is_held\` reduces to \"did anyone call \`mark_grasped\`?\", which is the best we can do without physics.
- **Robot packages compose their own verifier.** Geodude will use \`[GripperPositionSignal(robotiq), WristFTSignal(ur5e)]\`. Franka will use \`[GripperPositionSignal(panda), JointTorqueSignal(franka)]\`. Same class, different signal list — no branching.
- **\`LoadSignal\` is \`runtime_checkable\`** so tests can use tiny stubs; the 27 verifier tests use plain fake signals, zero MuJoCo.
- **Grippers opt in via property setter.** No constructor changes to any gripper class means zero churn in geodude/franka_demo until they're ready to wire up a verifier.

## Tests

27 in \`tests/test_grasp_verifier.py\`:
- 14 pure unit tests on \`verify_grasp\` (one per decision-tree branch)
- 8 stateful tests on \`GraspVerifier\` with fake in-memory signals (mark_grasped/mark_released/signal collapse/kinematic degeneration/regrasping/mechanical-stop detection)
- 5 sanity / protocol tests

5 integration tests in \`tests/test_franka_gripper.py\`:
- \`_BaseGripper\` routing works on a real \`FrankaGripper\` instance
- Signal collapse flips \`held_object\` to \`None\` — the geodude#173 regression
- Legacy path (no verifier attached) still works unchanged

**Full suite: 363 tests pass, lint clean, format clean.**

## Test plan

- [x] \`uv run pytest tests/ -q\` → 363 passed
- [x] \`uv run ruff check . && uv run ruff format --check .\` → clean
- [ ] CI on 3.10 / 3.11 / 3.12
- [ ] Downstream: geodude follow-up to wire verifier into LiftBase and delete \`_compute_source_contacts\` (tracked separately)