### PR TITLE
SimArmController.grasp: tare F/T right before closing

### DIFF
--- a/src/mj_manipulator/sim_context.py
+++ b/src/mj_manipulator/sim_context.py
@@ -90,6 +90,16 @@ class SimArmController:
         gripper.set_candidate_objects(candidates)
         arm_name = self._arm.config.name
 
+        # Tare the wrist F/T right before closing: the reading at this
+        # moment reflects gripper weight + any existing load. Once the
+        # object is held, subsequent get_ft_wrench() readings reflect
+        # the object's weight alone, which is what GraspVerifier's
+        # WristFTSignal compares against its post-grasp baseline. Skip
+        # when the arm has no F/T sensor or F/T isn't meaningful
+        # (kinematic mode).
+        if self._arm.has_ft_sensor and self._arm.ft_valid:
+            self._arm.tare_ft()
+
         if self._context._controller is not None:
             # Physics: realistic gripper close with contact detection
             grasped = self._context._controller.close_gripper(


### PR DESCRIPTION
Small follow-up to #96 that makes \`GraspVerifier\` useful on real hardware.

## Why

After #96 shipped, I started wiring \`GraspVerifier\` into geodude and immediately hit a precondition problem: the F/T signal baseline captured at \`mark_grasped\` time reflects *gripper self-weight plus object weight*, not just the object. For a Robotiq 2F-140 + wrist adapter (~1 kg) holding a soda can (~50 g), baseline ≈ 10 N, loss-of-object changes the reading by ~0.5 N — a 5% delta, well below the default 30% drop threshold. The verifier can't see the drop.

## Fix

Tare the wrist F/T right before the gripper starts closing. The reading at that moment is the gripper's own weight (projected through current pose). Subsequent readings reflect only the *added* load, which is what the verifier actually wants to monitor.

With the tare: baseline ≈ object weight (0.5 N), drop = 100%, verifier fires.

## Safety gates

- \`has_ft_sensor\` — no-op if the arm has no wrist F/T (Franka path)
- \`ft_valid\` — no-op in kinematic sim (where \`tare_ft()\` would raise)

No behavior change for any existing consumer that doesn't read \`get_ft_wrench()\` around grasps.

## Test plan

- [x] \`uv run pytest tests/ -q\` → 363 passed
- [x] \`uv run ruff check . && uv run ruff format --check .\` → clean
- [ ] CI 3.10 / 3.11 / 3.12

## Related

- personalrobotics/mj_manipulator#93 / #96 — GraspVerifier lands and creates the need for this
- personalrobotics/geodude#173 — the motivating bug; follow-up PR wires the verifier into \`LiftBase\`
- personalrobotics/geodude#177 — sim-magic meta-issue (#93 → wiring follow-ups)