### PR TITLE
GraspVerifier: sticky state machine + tick-driven verification (fixes #98)

### DIFF
--- a/src/mj_manipulator/grasp_verifier.py
+++ b/src/mj_manipulator/grasp_verifier.py
@@ -3,46 +3,102 @@
 
 """Runtime check for \"is the held object still held\".
 
-The :class:`GraspVerifier` answers a single question: given what we
-told the arm to grasp and what the sensors are reading right now, do
-we still believe the object is in the gripper? It replaces
-contact-inspection-based checks (e.g. the ``iter_contacts`` post-check
-in geodude's original :class:`LiftBase`) that only work in simulation.
+:class:`GraspVerifier` is a small sticky state machine driven by
+per-tick signal verification. It answers a single question — *are
+the live sensor signals consistent with still holding the object we
+grasped?* — from whatever signals the arm actually has (gripper
+position, wrist F/T, joint torques). It replaces contact-inspection
+post-checks like geodude's original `LiftBase._compute_source_contacts`
+that only work in simulation.
 
-The decision logic is split out as a pure function
-:func:`verify_grasp` taking a :class:`VerifierFacts` dataclass, so the
-logic is unit-testable without any simulation state, mocks, or
-hardware. The :class:`GraspVerifier` class is the stateful shell:
-it owns the list of :class:`~mj_manipulator.load_signals.LoadSignal`
-instances, records a baseline at :meth:`mark_grasped` time, and
-assembles facts from live reads when :attr:`is_held` is queried.
+Three states:
 
-Design notes:
+- ``IDLE`` — not tracking a grasp. `is_held` is False.
+- ``HOLDING`` — `mark_grasped` was called, the baseline was captured,
+  and subsequent ticks have agreed with it. `is_held` is True.
+- ``LOST`` — the state machine was in HOLDING and a tick observed a
+  signal collapse. **Sticky**: only the next `mark_grasped` can
+  leave this state. `is_held` is False.
 
-- Signals that return ``None`` from their :meth:`read` method are
-  skipped, not interpreted as lost load. This is how kinematic sim
-  degrades gracefully — every load signal returns ``None`` there and
-  :attr:`is_held` reduces to \"did anyone call ``mark_grasped``?\".
-- The decision function is robot-agnostic. Geodude composes a verifier
-  with ``[GripperPositionSignal(robotiq), WristFTSignal(ur5e)]``;
-  Franka composes one with ``[GripperPositionSignal(panda),
-  JointTorqueSignal(franka)]``. Same class, different signal list.
-- The :attr:`held_object` property is the bookkeeping name (what we
-  told the arm to grasp). It goes to ``None`` when :attr:`is_held`
-  is False, so downstream consumers that currently read
-  ``gripper.held_object`` as \"what am I holding right now?\" get a
-  real answer instead of stale bookkeeping.
+Stickiness matches reality: a dropped object doesn't self-heal, so
+momentarily-flickering signals shouldn't push us back to HOLDING.
+If noise produces false positives, the right fix is a settling
+window (already built in) or an N-consecutive-tick debounce (future).
+
+The decision logic itself lives as a pure function
+:func:`verify_grasp` taking a :class:`VerifierFacts` dataclass, so
+the branch logic is unit-testable without any simulation state,
+mocks, or hardware. :class:`GraspVerifier` is the stateful shell
+that records baselines, ticks on a schedule, and logs transitions.
+
+Design points:
+
+- **Tick-driven, not live-query.** `is_held` is a plain state read,
+  cheap and consistent across multiple reads in the same cycle. The
+  work of re-reading signals happens in :meth:`tick`, which the
+  execution context calls exactly once per control cycle. Consumers
+  never tick manually.
+- **Signals with ``None`` readings are skipped, not treated as
+  failure.** Kinematic sim has no F/T or joint-torque data, so every
+  load signal returns ``None``; the verifier falls back to \"trust
+  that `mark_grasped` was called\" in that mode.
+- **Baseline settling.** Right after `close_gripper` finishes, the
+  constraint solver is still settling and the F/T reading is
+  transient. :class:`VerifierParams.settling_ticks` defaults to 5 —
+  the first 5 ticks after `mark_grasped` don't run drop-detection,
+  they just let physics settle. After that the baseline is live and
+  drops trigger LOST transitions.
+- **Release is explicit, drop detection is observational.** Commanded
+  releases (`SimArmController.release()`) call :meth:`mark_released`
+  directly — the caller's intent is authoritative, and we want
+  `is_held` to flip immediately on the same tick (not after the
+  settling window observes the load drop). The tick-driven
+  observation path is reserved for *unintended* drops: an object
+  slipping from the gripper mid-transport, a grasp that looked
+  successful but wasn't holding, etc. Both paths end in the same
+  ``is_held → False`` signal to downstream consumers.
+- **Robot packages compose their own verifier.** Geodude uses
+  `[GripperPositionSignal(robotiq), WristFTSignal(ur5e)]`; Franka
+  uses `[GripperPositionSignal(panda), JointTorqueSignal(franka)]`.
+  Same class, different signal list.
 """
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import TYPE_CHECKING
 
 from mj_manipulator.load_signals import LoadSignal
 
 if TYPE_CHECKING:
     from mj_manipulator.protocols import Gripper
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# State machine primitives
+# ---------------------------------------------------------------------------
+
+
+class GraspState(Enum):
+    """Sticky state for the grasp verifier.
+
+    Transitions:
+
+    - ``mark_grasped(name)``: any state → HOLDING (baseline captured,
+      settling window begins)
+    - ``tick()`` during HOLDING, post-settling, signals collapse:
+      HOLDING → LOST
+    - ``mark_released()``: any state → IDLE (manual override; not
+      called from the normal release path)
+    """
+
+    IDLE = "idle"
+    HOLDING = "holding"
+    LOST = "lost"
 
 
 # ---------------------------------------------------------------------------
@@ -52,7 +108,7 @@ if TYPE_CHECKING:
 
 @dataclass
 class VerifierParams:
-    """Tunable parameters for :func:`verify_grasp`.
+    """Tunable parameters for :func:`verify_grasp` and :class:`GraspVerifier`.
 
     Defaults are deliberately conservative — we'd rather declare a
     healthy grasp \"probably dropped\" and let recovery run a sanity
@@ -67,8 +123,17 @@ class VerifierParams:
     load_drop_ratio: float = 0.3
     """Fraction of baseline below which a signal is considered
     collapsed. A signal whose magnitude drops below
-    ``abs(baseline) * (1 - load_drop_ratio)`` triggers a FAILURE
-    verdict. 0.3 = signal must drop by more than 30% from baseline."""
+    ``abs(baseline) * (1 - load_drop_ratio)`` triggers a LOST
+    transition. 0.3 = signal must drop by more than 30% from
+    baseline."""
+
+    settling_ticks: int = 5
+    """Number of ticks after :meth:`GraspVerifier.mark_grasped`
+    during which drop-detection is suppressed. The physics state is
+    still settling right after the gripper finishes closing, and the
+    F/T reading is transient; forcing a few ticks of warmup before
+    the verifier goes live prevents spurious LOST transitions on the
+    first tick after grasp completion. 5 × 8ms = 40ms at 125Hz."""
 
 
 @dataclass
@@ -84,7 +149,7 @@ class VerifierFacts:
 
     object_name: str | None
     """The object the grasp sequence believes it picked up, or None
-    if no grasp is currently in progress."""
+    if no grasp is currently tracked."""
 
     empty_at_fully_closed: bool
     """Does this gripper's ``ctrl_closed`` position mean \"fingers
@@ -109,12 +174,10 @@ def verify_grasp(facts: VerifierFacts, params: VerifierParams) -> bool:
 
     Walks a small decision tree:
 
-    1. **No object tracked** → False (nothing to verify; we're not
-       currently trying to hold anything).
+    1. **No object tracked** → False.
     2. **Decisive empty-stop negative**: if the gripper is a
        fully-closed-means-empty type and the position is at or above
-       the threshold → False. The fingers are touching each other
-       with nothing in between.
+       the threshold → False.
     3. **Load-drop check**: for every signal that has a usable
        baseline and a live reading, check whether the live value has
        collapsed below ``|baseline| * (1 - load_drop_ratio)``. If any
@@ -156,26 +219,18 @@ def verify_grasp(facts: VerifierFacts, params: VerifierParams) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Stateful shell — owns signals, captures baselines, answers queries
+# Stateful shell — owns signals, drives the state machine, ticks per cycle
 # ---------------------------------------------------------------------------
 
 
 class GraspVerifier:
-    """Per-arm \"is the held object still held\" check.
+    """Per-arm sticky state machine for \"is the held object still held\".
 
-    Composes a list of :class:`LoadSignal` instances that the arm
-    actually has (gripper position, wrist F/T, joint torques, ...)
-    and a reference to the gripper (for the ``empty_at_fully_closed``
-    decisive-negative branch). Records a baseline from every signal
-    when :meth:`mark_grasped` is called; the :attr:`is_held` property
-    compares live reads against the baseline via :func:`verify_grasp`.
-
-    The verifier is instantaneous — :attr:`is_held` re-reads every
-    signal each time it's queried. There's no rolling average or
-    debounce in v1; adding one means extending :meth:`tick` and
-    filtering in :meth:`_collect_facts`, but the v1 signals are all
-    physical quantities that already change smoothly, so
-    instantaneous reads are good enough to start with.
+    Composes a list of :class:`LoadSignal` instances the arm actually
+    has (gripper position, wrist F/T, joint torques, ...) and a
+    reference to the gripper (for the ``empty_at_fully_closed``
+    decisive-negative branch). Drives a three-state machine via
+    :meth:`mark_grasped` and per-cycle :meth:`tick` calls.
 
     Example — Geodude (UR5e + Robotiq 2F-140)::
 
@@ -188,15 +243,11 @@ class GraspVerifier:
         )
         robot.left.gripper.grasp_verifier = verifier
 
-    Example — Franka (empty_at_fully_closed=True, joint torques)::
-
-        verifier = GraspVerifier(
-            gripper=franka.gripper,
-            signals=[
-                GripperPositionSignal(franka.gripper),
-                JointTorqueSignal(franka.arm),
-            ],
-        )
+    The verifier never ticks itself. The execution context
+    (:class:`SimContext`) ticks every configured verifier exactly
+    once per control cycle inside :meth:`SimContext.step` and inside
+    every trajectory execution. Consumers only call :meth:`is_held`
+    (cheap state read) and :meth:`mark_grasped`.
     """
 
     def __init__(
@@ -209,75 +260,141 @@ class GraspVerifier:
         self._gripper = gripper
         self._signals = list(signals)
         self._params = params if params is not None else VerifierParams()
+        self._state: GraspState = GraspState.IDLE
         self._object_name: str | None = None
         self._baselines: dict[str, float | None] = {}
+        self._ticks_since_grasp: int = 0
 
     # -- Public API ----------------------------------------------------------
 
     @property
-    def held_object(self) -> str | None:
-        """The object we believe is currently held, or None.
+    def state(self) -> GraspState:
+        """Current state of the grasp verifier.
 
-        This is *not* raw bookkeeping — it only returns the grasped
-        name when :attr:`is_held` agrees. A stale baseline + dropped
-        object yields ``None``. Consumers that want \"what did the
-        grasp sequence think it grabbed\" without the health check
-        should read :attr:`tracked_object` instead.
+        Useful for diagnostics (\"we were HOLDING, now we're LOST,
+        something slipped\") and for tests that want to assert on
+        exact state rather than the bool shorthand.
         """
-        if self._object_name is None:
-            return None
-        return self._object_name if self.is_held else None
+        return self._state
+
+    @property
+    def is_held(self) -> bool:
+        """True iff the state machine is in HOLDING.
+
+        Plain state read — does not re-invoke :func:`verify_grasp`.
+        Consistent across multiple reads in the same cycle. The work
+        of deciding whether we still hold the object happens in
+        :meth:`tick`, which the execution context calls once per
+        control cycle.
+        """
+        return self._state is GraspState.HOLDING
+
+    @property
+    def held_object(self) -> str | None:
+        """The object we're currently holding, or None.
+
+        Returns the tracked name when :attr:`is_held` is True,
+        otherwise None. A stale baseline + dropped object yields
+        ``None``. Consumers that want *\"what did the grasp sequence
+        try to grab?\"* regardless of current health should read
+        :attr:`tracked_object` instead.
+        """
+        return self._object_name if self._state is GraspState.HOLDING else None
 
     @property
     def tracked_object(self) -> str | None:
         """The object name recorded at :meth:`mark_grasped` time, or None.
 
-        This is the raw bookkeeping — it does *not* re-check live
-        signals. Useful for diagnostics (\"we thought we grabbed X,
-        but the verifier says we dropped it\") and for
-        :class:`~mj_manipulator.bt.nodes` that need to know what the
-        grasp sequence was *attempting* even if it failed.
+        This is the raw bookkeeping — it does *not* check the state
+        machine. Useful for diagnostics (\"we thought we grabbed X,
+        but the verifier says we dropped it\") and for recovery
+        subtrees that need to know what the grasp sequence was
+        *attempting* even if it failed. Goes to None on
+        :meth:`mark_released` and stays at the last-grasp name
+        while the state is LOST.
         """
         return self._object_name
 
-    @property
-    def is_held(self) -> bool:
-        """Live check: are the signals consistent with still holding the object?
-
-        Re-reads every signal each call. Returns False if no object
-        is currently tracked (nothing to check) or if the decision
-        function says the held object has dropped.
-        """
-        return verify_grasp(self._collect_facts(), self._params)
-
     def mark_grasped(self, object_name: str) -> None:
-        """Begin tracking a grasp and capture a baseline from every signal.
+        """Begin tracking a grasp, capture baseline, enter HOLDING.
 
         Called by the grasp sequence (:meth:`SimArmController.grasp`
         or its hardware equivalent) right after the close motion
-        succeeds. Records the current value of every signal so future
-        :attr:`is_held` calls can detect drops.
+        finishes. Records the current value of every signal so
+        subsequent ticks can detect drops, and starts the settling
+        window — drop-detection is suppressed for the first
+        ``settling_ticks`` ticks to let physics settle.
+
+        Transitions the state machine to HOLDING unconditionally,
+        even if the previous state was LOST. A fresh grasp overrides
+        any previous state.
         """
         self._object_name = object_name
         self._baselines = {s.name: s.read() for s in self._signals}
+        self._state = GraspState.HOLDING
+        self._ticks_since_grasp = 0
+
+        if self._baselines:
+            baseline_str = ", ".join(
+                f"{name}={'unavailable' if value is None else f'{value:.3f}'}"
+                for name, value in self._baselines.items()
+            )
+            logger.info(
+                "GraspVerifier: HOLDING %s (baseline: %s, settling for %d ticks)",
+                object_name,
+                baseline_str,
+                self._params.settling_ticks,
+            )
+        else:
+            logger.info(
+                "GraspVerifier: HOLDING %s (no load signals configured)",
+                object_name,
+            )
 
     def mark_released(self) -> None:
-        """Stop tracking. :attr:`is_held` returns False until the next
-        :meth:`mark_grasped`.
+        """Force state to IDLE and clear baseline.
+
+        Called by `SimArmController.release()` (and the hardware
+        equivalent) when the caller explicitly commands a release.
+        Intent is authoritative: the state flips immediately, with no
+        wait for :meth:`tick` to observe the load drop.
+
+        The tick-driven observation path (HOLDING → LOST on load
+        collapse) is reserved for *unintended* drops — an object
+        slipping mid-transport, a grasp that looked successful but
+        wasn't holding, etc. Both paths end in ``is_held → False``.
         """
+        if self._state is not GraspState.IDLE:
+            logger.info("GraspVerifier: released %s manually (→ IDLE)", self._object_name)
+        self._state = GraspState.IDLE
         self._object_name = None
         self._baselines = {}
+        self._ticks_since_grasp = 0
 
     def tick(self) -> None:
-        """Per-control-cycle hook.
+        """Advance the state machine by one control cycle.
 
-        No-op in v1 — signals are read instantaneously on every
-        :attr:`is_held` call. Reserved for future debouncing /
-        rolling-average logic; keeping the hook point means execute
-        loops can wire it up now without needing a protocol change
-        later.
+        No-op when IDLE or LOST. When HOLDING:
+
+        - Increments the settling counter.
+        - If still inside the settling window, does nothing else.
+        - Otherwise re-reads every signal, runs :func:`verify_grasp`,
+          and transitions to LOST if the verdict is False.
+
+        Called by the execution context once per control cycle. Not
+        meant to be called by user code — consumers read
+        :attr:`is_held` between ticks.
         """
-        return None
+        if self._state is not GraspState.HOLDING:
+            return
+
+        self._ticks_since_grasp += 1
+        if self._ticks_since_grasp <= self._params.settling_ticks:
+            return
+
+        facts = self._collect_facts()
+        if not verify_grasp(facts, self._params):
+            self._transition_to_lost(facts)
 
     # -- Internals -----------------------------------------------------------
 
@@ -294,3 +411,23 @@ class GraspVerifier:
             signal_values={s.name: s.read() for s in self._signals},
             signal_baselines=dict(self._baselines),
         )
+
+    def _transition_to_lost(self, facts: VerifierFacts) -> None:
+        """Move HOLDING → LOST and log what tripped it."""
+        reasons = []
+        if (
+            facts.empty_at_fully_closed
+            and facts.gripper_position is not None
+            and facts.gripper_position >= self._params.empty_position_threshold
+        ):
+            reasons.append(f"gripper at mechanical stop (pos={facts.gripper_position:.3f})")
+        for name, val in facts.signal_values.items():
+            base = facts.signal_baselines.get(name)
+            if val is None or base is None or abs(base) < 1e-6:
+                continue
+            threshold = abs(base) * (1.0 - self._params.load_drop_ratio)
+            if abs(val) < threshold:
+                reasons.append(f"{name} dropped from {base:.3f} → {val:.3f} (threshold {threshold:.3f})")
+        reason_str = "; ".join(reasons) if reasons else "unknown"
+        logger.warning("GraspVerifier: LOST %s (reason: %s)", self._object_name, reason_str)
+        self._state = GraspState.LOST

--- a/src/mj_manipulator/physics_controller.py
+++ b/src/mj_manipulator/physics_controller.py
@@ -24,7 +24,6 @@ import mujoco
 import numpy as np
 
 from mj_manipulator.config import GripperPhysicsConfig, PhysicsExecutionConfig
-from mj_manipulator.grasp_manager import detect_grasped_object
 
 if TYPE_CHECKING:
     from mj_manipulator.arm import Arm
@@ -601,32 +600,41 @@ class PhysicsController:
         arm_name: str,
         candidate_objects: list[str] | None = None,
         steps: int | None = None,
-    ) -> str | None:
-        """Close gripper with contact detection.
+    ) -> bool:
+        """Close the gripper through its control ramp.
 
-        Gradually closes the gripper while monitoring for object contact.
-        After contact is detected, continues closing for a firm grip, then
-        performs final bilateral contact verification.
+        Runs the full open-then-close sequence: a few steps of opening
+        for a clean start, then the gradual close ramp, then a firm-grip
+        hold phase. Always runs the complete duration — no early exit on
+        contact detection. The caller decides whether the grasp succeeded
+        by inspecting :attr:`Gripper.grasp_verifier.is_held` after the
+        settling window elapses (:meth:`SimArmController.grasp` does
+        this automatically).
 
         Args:
             arm_name: Which arm's gripper to close.
-            candidate_objects: Objects to consider for grasp detection.
-                If None, considers all objects in contact.
+            candidate_objects: Unused (kept for signature compatibility;
+                candidate-object resolution is now a pure-signal
+                responsibility of :class:`GraspVerifier`).
             steps: Number of close steps (default from gripper_config).
 
         Returns:
-            Name of grasped object, or None if nothing grasped.
+            True if the close sequence ran to completion, False if the
+            arm has no configured gripper. The return value does **not**
+            reflect whether anything was grasped — that's the verifier's
+            job.
         """
+        del candidate_objects  # retained for signature compat only
+
         cfg = self.gripper_config
         if steps is None:
             steps = cfg.close_steps
 
         if arm_name not in self._grippers:
             logger.warning("No gripper found for %s", arm_name)
-            return None
+            return False
 
         gstate = self._grippers[arm_name]
-        gripper = gstate.gripper
 
         start_ctrl = gstate.ctrl_open
         end_ctrl = gstate.ctrl_closed
@@ -636,95 +644,25 @@ class PhysicsController:
         for _ in range(cfg.pre_open_steps):
             self.step()
 
-        contacts_detected = False
-        grasped = None
         sleep_dt = self.control_dt * 0.5 if self.viewer is not None else 0.0
 
-        # Gradually close
+        # Gradual close ramp — runs unconditionally
         for i in range(steps):
             t = (i + 1) / steps
             gstate.target_ctrl = start_ctrl + t * (end_ctrl - start_ctrl)
             self.step()
-
-            # Check contacts periodically (unilateral during closing)
-            if i % cfg.contact_check_interval == 0 and not contacts_detected:
-                grasped = detect_grasped_object(
-                    self.model,
-                    self.data,
-                    gripper.gripper_body_names,
-                    candidate_objects,
-                    require_bilateral=False,
-                    debug=cfg.debug,
-                )
-                if grasped:
-                    contacts_detected = True
-
             if sleep_dt > 0:
                 time.sleep(sleep_dt)
 
-        # Firm grip if contact was detected during closing
-        if contacts_detected:
-            for _ in range(cfg.firm_grip_steps):
-                self.step()
-                if sleep_dt > 0:
-                    time.sleep(sleep_dt)
+        # Firm grip phase — let the gripper settle at the target for
+        # a few steps so the grasp has a chance to stabilize before
+        # the verifier's settling window begins.
+        for _ in range(cfg.firm_grip_steps):
+            self.step()
+            if sleep_dt > 0:
+                time.sleep(sleep_dt)
 
-        # Final bilateral detection (robust)
-        grasped = detect_grasped_object(
-            self.model,
-            self.data,
-            gripper.gripper_body_names,
-            candidate_objects,
-            require_bilateral=True,
-            debug=cfg.debug,
-        )
-
-        if not grasped:
-            # Fallback to unilateral
-            grasped = detect_grasped_object(
-                self.model,
-                self.data,
-                gripper.gripper_body_names,
-                candidate_objects,
-                require_bilateral=False,
-                debug=cfg.debug,
-            )
-            if grasped:
-                logger.warning(
-                    "Gripper %s: only unilateral contact with %s — grasp may be unstable",
-                    arm_name,
-                    grasped,
-                )
-
-        # Check fully-closed state: for grippers whose fingers physically
-        # touch at fully-closed (e.g. Franka), this means nothing is held.
-        # For grippers with finger travel (e.g. Robotiq 2F-140), fully-closed
-        # is still a valid grasp position.
-        gripper_pos = gripper.get_actual_position()
-        if gripper_pos > cfg.fully_closed_threshold:
-            if getattr(gripper, "empty_at_fully_closed", False):
-                if grasped:
-                    logger.info(
-                        "Gripper %s: fully closed (pos=%.3f) — grasp rejected (%s)",
-                        arm_name,
-                        gripper_pos,
-                        grasped,
-                    )
-                else:
-                    logger.info(
-                        "Gripper %s: fully closed (pos=%.3f) — no object grasped",
-                        arm_name,
-                        gripper_pos,
-                    )
-                return None
-            elif not grasped:
-                logger.warning(
-                    "Gripper %s: fully closed (pos=%.3f) with no contacts",
-                    arm_name,
-                    gripper_pos,
-                )
-
-        return grasped
+        return True
 
     def open_gripper(self, arm_name: str, steps: int | None = None) -> None:
         """Open gripper while maintaining all arm positions.
@@ -817,12 +755,24 @@ class PhysicsController:
     # -- Internal -----------------------------------------------------------
 
     def _step_physics(self) -> None:
-        """Apply gripper ctrl, step MuJoCo, sync viewer."""
+        """Apply gripper ctrl, step MuJoCo, tick grasp verifiers, sync viewer."""
         for gstate in self._grippers.values():
             self.data.ctrl[gstate.actuator_id] = gstate.target_ctrl
 
         for _ in range(self.steps_per_control):
             mujoco.mj_step(self.model, self.data)
+
+        # Tick every configured GraspVerifier exactly once per control
+        # cycle. This is the single \"advance time by one control cycle\"
+        # primitive in physics mode, so every execution path
+        # (ctx.step, ctx.execute, gripper close sequences, trajectory
+        # runners) transitively runs verifier ticks through here. No
+        # consumer needs to remember to tick. Arms without a verifier
+        # are no-ops.
+        for astate in self._arms.values():
+            gripper = astate.arm.gripper
+            if gripper is not None and gripper.grasp_verifier is not None:
+                gripper.grasp_verifier.tick()
 
         if self.viewer is not None:
             now = time.time()

--- a/src/mj_manipulator/sim_context.py
+++ b/src/mj_manipulator/sim_context.py
@@ -100,43 +100,93 @@ class SimArmController:
         if self._arm.has_ft_sensor and self._arm.ft_valid:
             self._arm.tare_ft()
 
-        if self._context._controller is not None:
-            # Physics: realistic gripper close with contact detection
-            grasped = self._context._controller.close_gripper(
-                arm_name,
-                candidate_objects=candidates,
-            )
-        else:
-            # Kinematic: close incrementally with contact detection
-            grasped = gripper.kinematic_close()
-            if grasped is None:
-                logger.warning(
-                    "Kinematic grasp: no contact detected%s (gripper pos=%.2f)",
-                    f" with {object_name}" if object_name else "",
-                    gripper.get_actual_position(),
-                )
+        # Resolve which object we think we're grasping. For the BT path
+        # this is always the target name. For the nameless interactive
+        # path (REPL / teleop), we fall back to the legacy
+        # iter_contacts-based detection helper — documented as sim-only
+        # and slated for replacement once PerceptionService (#175) lands.
+        # On real hardware, the nameless path would need geometric
+        # matching from perceived object poses; not our problem yet.
+        target = object_name
+        if target is None:
+            from mj_manipulator.grasp_manager import detect_grasped_object
 
-        if grasped and self._arm.grasp_manager is not None:
-            self._arm.grasp_manager.mark_grasped(grasped, arm_name)
-            self._arm.grasp_manager.attach_object(
-                grasped,
-                gripper.attachment_body,
+            # Close the gripper first so the post-close contact state
+            # reflects what we grabbed.
+            self._run_close(candidates)
+            target = detect_grasped_object(
+                self._arm.env.model,
+                self._arm.env.data,
+                gripper.gripper_body_names,
+                candidate_objects=None,
+                require_bilateral=True,
             )
-            # Also notify the sensor-based verifier if one is wired up.
-            # The verifier captures its signal baseline right here, so a
-            # future is_held query can tell whether the load has dropped
-            # since the grasp completed.
-            if gripper.grasp_verifier is not None:
-                gripper.grasp_verifier.mark_grasped(grasped)
-            logger.info("Grasped %s with %s arm", grasped, arm_name)
-        elif not grasped:
-            logger.info(
-                "Grasp failed: no object detected%s",
-                f" (target was {object_name})" if object_name else "",
-            )
+            if target is None:
+                logger.info("Grasp (no target): no object detected between fingers")
+                self._context.sync()
+                return None
+        else:
+            self._run_close(candidates)
+
+        # Record the grasp in bookkeeping (kinematic weld) and in the
+        # verifier (baseline capture + HOLDING state). The verifier's
+        # tick in the settling window is a no-op; real verification
+        # runs a few ticks later. If the grasp didn't actually succeed
+        # (signals don't support the baseline), the verifier will
+        # transition to LOST during the verification tick pump, and we
+        # undo the mark_grasped so downstream consumers see a clean
+        # failure.
+        if self._arm.grasp_manager is not None:
+            self._arm.grasp_manager.mark_grasped(target, arm_name)
+            self._arm.grasp_manager.attach_object(target, gripper.attachment_body)
+
+        if gripper.grasp_verifier is not None:
+            gripper.grasp_verifier.mark_grasped(target)
+            self._run_grasp_verification_ticks()
+            if not gripper.grasp_verifier.is_held:
+                logger.info("Grasp rejected by verifier: %s with %s arm", target, arm_name)
+                # Undo the bookkeeping — the grasp didn't actually hold.
+                if self._arm.grasp_manager is not None:
+                    self._arm.grasp_manager.mark_released(target)
+                    self._arm.grasp_manager.detach_object(target)
+                gripper.grasp_verifier.mark_released()
+                self._context.sync()
+                return None
+            logger.info("Grasped %s with %s arm (verifier confirmed)", target, arm_name)
+        else:
+            logger.info("Grasped %s with %s arm", target, arm_name)
 
         self._context.sync()
-        return grasped
+        return target
+
+    def _run_close(self, candidates: list[str] | None) -> None:
+        """Dispatch to the physics or kinematic close routine."""
+        gripper = self._arm.gripper
+        arm_name = self._arm.config.name
+        if self._context._controller is not None:
+            self._context._controller.close_gripper(arm_name, candidate_objects=candidates)
+        else:
+            gripper.kinematic_close()  # type: ignore[union-attr]
+
+    def _run_grasp_verification_ticks(self) -> None:
+        """Pump extra physics ticks so the verifier can exit its
+        settling window and run a real drop-detection check.
+
+        Runs ``settling_ticks + 2`` physics steps after
+        :meth:`GraspVerifier.mark_grasped` so the first post-settling
+        tick actually evaluates the signals against the baseline.
+        Otherwise ``grasp()`` would return while the verifier is
+        still in its warmup window, and downstream ``is_held`` reads
+        would be stale.
+        """
+        gripper = self._arm.gripper
+        if gripper is None or gripper.grasp_verifier is None:
+            return
+        if self._context._controller is None:
+            return  # kinematic sim — no physics ticks to run
+        n_ticks = gripper.grasp_verifier._params.settling_ticks + 2
+        for _ in range(n_ticks):
+            self._context._controller.step()
 
     def release(self, object_name: str | None = None) -> None:
         """Open gripper and release held object(s).
@@ -325,6 +375,40 @@ class SimContext:
         self._ownership = None
         return False
 
+    def _make_drop_abort(self) -> Callable[[], bool] | None:
+        """Build an abort predicate that fires when any arm's verifier
+        transitions HOLDING → LOST during a trajectory.
+
+        Snapshots which arms are currently HOLDING at the start of the
+        trajectory. The returned predicate returns True if any of those
+        arms is no longer HOLDING on a subsequent check — meaning the
+        verifier saw a load collapse mid-motion and flipped to LOST.
+        That's the \"we dropped it during transport\" case.
+
+        Returns None if no arm has a verifier, or no arm is currently
+        HOLDING — either way there's nothing to monitor. Skipping the
+        predicate avoids per-tick function-call overhead in the vastly
+        more common case where no grasp is active.
+        """
+        holding_verifiers = []
+        for arm in self._arms.values():
+            gripper = arm.gripper
+            if gripper is None or gripper.grasp_verifier is None:
+                continue
+            if gripper.grasp_verifier.is_held:
+                holding_verifiers.append(gripper.grasp_verifier)
+
+        if not holding_verifiers:
+            return None
+
+        def _drop_check() -> bool:
+            for v in holding_verifiers:
+                if not v.is_held:
+                    return True
+            return False
+
+        return _drop_check
+
     # -- ExecutionContext protocol -------------------------------------------
 
     def execute(
@@ -430,11 +514,14 @@ class SimContext:
                 def _make_abort_fn(e=entity, ca=caller_abort):
                     reg = self._ownership
                     ctx_abort = self._abort_fn
+                    drop_check = self._make_drop_abort()
 
                     def _abort() -> bool:
                         if reg is not None and reg.is_aborted(e):
                             return True
                         if ctx_abort is not None and ctx_abort():
+                            return True
+                        if drop_check is not None and drop_check():
                             return True
                         if ca is not None and ca():
                             return True
@@ -444,12 +531,15 @@ class SimContext:
 
                 runner_abort_fn = _make_abort_fn()
             else:
-                # No ownership registry — still compose context + caller
+                # No ownership registry — still compose context + caller + drop
                 ctx_abort = self._abort_fn
-                if caller_abort is not None or ctx_abort is not None:
+                drop_check = self._make_drop_abort()
+                if caller_abort is not None or ctx_abort is not None or drop_check is not None:
 
-                    def _abort(ca=caller_abort, cx=ctx_abort) -> bool:
+                    def _abort(ca=caller_abort, cx=ctx_abort, dc=drop_check) -> bool:
                         if cx is not None and cx():
+                            return True
+                        if dc is not None and dc():
                             return True
                         if ca is not None and ca():
                             return True

--- a/tests/test_franka_gripper.py
+++ b/tests/test_franka_gripper.py
@@ -225,15 +225,21 @@ class TestFrankaGripperWithGraspVerifier:
     def _attach_verifier(self, gripper: FrankaGripper) -> tuple:
         """Wire up a GraspVerifier with one fake signal and ensure the
         gripper is open so the ``empty_at_fully_closed=True`` branch
-        doesn't immediately short-circuit is_held to False.
+        doesn't immediately short-circuit is_held to False. Uses
+        ``settling_ticks=0`` so the test doesn't need to pump the
+        warmup window.
 
         Returns (verifier, signal).
         """
-        from mj_manipulator.grasp_verifier import GraspVerifier
+        from mj_manipulator.grasp_verifier import GraspVerifier, VerifierParams
 
         gripper.kinematic_open()
         signal = _FakeSignal("wrist_ft_force", value=10.0)
-        verifier = GraspVerifier(gripper=gripper, signals=[signal])
+        verifier = GraspVerifier(
+            gripper=gripper,
+            signals=[signal],
+            params=VerifierParams(settling_ticks=0),
+        )
         gripper.grasp_verifier = verifier
         return verifier, signal
 
@@ -255,12 +261,14 @@ class TestFrankaGripperWithGraspVerifier:
 
     def test_signal_collapse_flips_held_object_to_none(self, franka_gripper):
         """Regression for geodude#173: if the load signal collapses,
-        held_object should go to None even though mark_grasped was called.
-        This is the whole point of the verifier vs. bookkeeping."""
+        the next tick flips the verifier to LOST and held_object goes
+        to None. This is the whole point of the verifier vs. the old
+        GraspManager bookkeeping."""
         verifier, signal = self._attach_verifier(franka_gripper)
         verifier.mark_grasped("fake_cube")
         assert franka_gripper.held_object == "fake_cube"
         signal.value = 0.5  # load collapsed
+        verifier.tick()  # tick observes the drop, state → LOST
         assert franka_gripper.held_object is None
         assert franka_gripper.is_holding is False
 

--- a/tests/test_grasp_verifier.py
+++ b/tests/test_grasp_verifier.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import pytest
 
 from mj_manipulator.grasp_verifier import (
+    GraspState,
     GraspVerifier,
     VerifierFacts,
     VerifierParams,
@@ -198,44 +199,81 @@ class FakeGripper:
 
 
 class TestGraspVerifier:
-    """Stateful integration of the verifier with fake signals."""
+    """Stateful integration of the verifier with fake signals.
 
-    def _make(self, *, empty_at_fully_closed: bool = False):
+    Tests use ``settling_ticks=0`` so they don't need to pump 5+
+    ticks per assertion. The settling window itself is exercised
+    separately in :class:`TestSettlingWindow`.
+    """
+
+    def _make(self, *, empty_at_fully_closed: bool = False, settling_ticks: int = 0):
         gripper = FakeGripper(position=0.5, empty_at_fully_closed=empty_at_fully_closed)
         signal = FakeSignal(name="wrist_ft_force", value=10.0)
-        verifier = GraspVerifier(gripper=gripper, signals=[signal])
+        verifier = GraspVerifier(
+            gripper=gripper,
+            signals=[signal],
+            params=VerifierParams(settling_ticks=settling_ticks),
+        )
         return verifier, gripper, signal
 
-    def test_fresh_verifier_is_not_held(self):
+    def test_fresh_verifier_is_idle(self):
         verifier, _, _ = self._make()
+        assert verifier.state is GraspState.IDLE
         assert verifier.is_held is False
         assert verifier.held_object is None
         assert verifier.tracked_object is None
 
-    def test_mark_grasped_then_is_held(self):
+    def test_mark_grasped_enters_holding(self):
         verifier, _, _ = self._make()
         verifier.mark_grasped("can_0")
+        assert verifier.state is GraspState.HOLDING
         assert verifier.is_held is True
         assert verifier.held_object == "can_0"
         assert verifier.tracked_object == "can_0"
 
-    def test_signal_collapse_flips_is_held(self):
-        """The canonical regression for geodude#173: load dropped mid-transport."""
+    def test_signal_collapse_transitions_to_lost_on_tick(self):
+        """The canonical regression for geodude#173: load dropped mid-transport.
+
+        With the tick-driven model, mutating the signal does not flip
+        is_held until the next tick runs the verification step.
+        """
         verifier, _, signal = self._make()
         verifier.mark_grasped("can_0")
         assert verifier.is_held is True
 
-        # Object slips — signal drops to near zero
+        # Object slips — signal drops. is_held does NOT change yet.
         signal.value = 0.5
+        assert verifier.is_held is True, "live query should not change state"
+
+        # Next tick runs verification, sees the collapse, flips to LOST.
+        verifier.tick()
+        assert verifier.state is GraspState.LOST
         assert verifier.is_held is False
         assert verifier.held_object is None
         # But we still remember what we *tried* to grasp
         assert verifier.tracked_object == "can_0"
 
+    def test_lost_state_is_sticky(self):
+        """Once LOST, subsequent ticks cannot recover. Only mark_grasped
+        can leave LOST — this matches reality (a dropped object doesn't
+        self-heal) and prevents sensor-noise flicker."""
+        verifier, _, signal = self._make()
+        verifier.mark_grasped("can_0")
+        signal.value = 0.5
+        verifier.tick()
+        assert verifier.state is GraspState.LOST
+
+        # Signal recovers — but we stay LOST.
+        signal.value = 10.0
+        verifier.tick()
+        assert verifier.state is GraspState.LOST
+        assert verifier.is_held is False
+
     def test_mark_released_clears_state(self):
         verifier, _, _ = self._make()
         verifier.mark_grasped("can_0")
         verifier.mark_released()
+        assert verifier.state is GraspState.IDLE
         assert verifier.is_held is False
         assert verifier.held_object is None
         assert verifier.tracked_object is None
@@ -247,36 +285,111 @@ class TestGraspVerifier:
         verifier, _, signal = self._make()
         verifier.mark_grasped("can_0")
         signal.value = None
+        verifier.tick()
         assert verifier.is_held is True
 
-    def test_franka_style_mechanical_stop_triggers_drop(self):
+    def test_franka_style_mechanical_stop_triggers_lost(self):
         """When empty_at_fully_closed=True, reaching the stop should
-        immediately flip is_held to False even if load signals say
-        otherwise."""
+        flip to LOST on the next tick."""
         verifier, gripper, _ = self._make(empty_at_fully_closed=True)
         verifier.mark_grasped("panda_cube")
         assert verifier.is_held is True
         gripper.position = 1.0
+        verifier.tick()
+        assert verifier.state is GraspState.LOST
         assert verifier.is_held is False
 
-    def test_regrasping_updates_baseline(self):
-        """mark_grasped twice — second baseline replaces the first."""
+    def test_regrasping_from_lost_resets_to_holding(self):
+        """mark_grasped from LOST should override and re-enter HOLDING
+        with a new baseline. A second grasp after a drop is still a
+        legitimate grasp."""
         verifier, _, signal = self._make()
         verifier.mark_grasped("can_0")
-        signal.value = 4.0  # heavier object picked up next
+        signal.value = 0.5
+        verifier.tick()
+        assert verifier.state is GraspState.LOST
+
+        # Fresh grasp of a different object.
+        signal.value = 4.0  # heavier
         verifier.mark_grasped("spam_can_0")
-        # New baseline is 4.0, so 3.0 is within 30% drop range
-        signal.value = 3.0
-        assert verifier.is_held is True
+        assert verifier.state is GraspState.HOLDING
         assert verifier.held_object == "spam_can_0"
 
-    def test_tick_is_noop(self):
-        """v1 tick is a placeholder — calling it doesn't blow up and
-        doesn't affect state."""
-        verifier, _, _ = self._make()
-        verifier.mark_grasped("can_0")
+        # New baseline is 4.0, so 3.0 is within 30% drop range.
+        signal.value = 3.0
         verifier.tick()
         assert verifier.is_held is True
+
+    def test_tick_while_idle_is_noop(self):
+        """Ticking in IDLE state should not transition or touch signals."""
+        verifier, _, _ = self._make()
+        verifier.tick()
+        assert verifier.state is GraspState.IDLE
+
+    def test_tick_while_lost_is_noop(self):
+        """Ticking in LOST stays LOST (stickiness verified above)."""
+        verifier, _, signal = self._make()
+        verifier.mark_grasped("can_0")
+        signal.value = 0.0
+        verifier.tick()
+        assert verifier.state is GraspState.LOST
+        verifier.tick()
+        verifier.tick()
+        assert verifier.state is GraspState.LOST
+
+
+class TestSettlingWindow:
+    """Verifies the settling window suppresses drop-detection for N ticks.
+
+    During the window, the physics state is still settling and the F/T
+    reading is transient. Forcing a few ticks of warmup before going
+    live prevents spurious LOST transitions on the first tick after
+    grasp completion.
+    """
+
+    def _make(self, settling_ticks: int = 5):
+        gripper = FakeGripper(position=0.5)
+        signal = FakeSignal(name="wrist_ft_force", value=10.0)
+        verifier = GraspVerifier(
+            gripper=gripper,
+            signals=[signal],
+            params=VerifierParams(settling_ticks=settling_ticks),
+        )
+        return verifier, signal
+
+    def test_ticks_in_settling_window_do_not_transition(self):
+        """Inside the window, even a severe signal drop should not
+        transition to LOST — the assumption is physics hasn't settled."""
+        verifier, signal = self._make(settling_ticks=5)
+        verifier.mark_grasped("can_0")
+        signal.value = 0.0  # would normally trigger LOST
+        for _ in range(5):
+            verifier.tick()
+            assert verifier.state is GraspState.HOLDING, "settling window not honored"
+
+    def test_tick_after_window_evaluates_signals(self):
+        """The (settling_ticks + 1)'th tick is the first one that
+        actually runs drop-detection."""
+        verifier, signal = self._make(settling_ticks=5)
+        verifier.mark_grasped("can_0")
+        signal.value = 0.0
+        for _ in range(5):
+            verifier.tick()
+        # Still holding after settling ticks.
+        assert verifier.state is GraspState.HOLDING
+        # Next tick evaluates.
+        verifier.tick()
+        assert verifier.state is GraspState.LOST
+
+    def test_zero_settling_ticks_evaluates_immediately(self):
+        """With settling_ticks=0, the first tick after mark_grasped
+        runs real verification. This is the knob tests use to avoid
+        pumping dozens of ticks."""
+        verifier, signal = self._make(settling_ticks=0)
+        verifier.mark_grasped("can_0")
+        signal.value = 0.0
+        verifier.tick()
+        assert verifier.state is GraspState.LOST
 
 
 # ---------------------------------------------------------------------------
@@ -299,14 +412,24 @@ class TestBaseGripperRouting:
         # Asserting the principle here would duplicate those.
         pass
 
-    def test_held_object_with_verifier_returns_none_when_not_held(self):
-        """Gripper with verifier, but is_held=False → held_object=None."""
+    def test_held_object_with_verifier_returns_none_when_lost(self):
+        """Gripper with verifier, state LOST → held_object=None.
+
+        The transition happens on tick, not on signal mutation —
+        this matches the tick-driven semantics and means downstream
+        consumers see consistent state until the next control cycle.
+        """
         gripper = FakeGripper()
         signal = FakeSignal(name="wrist_ft_force", value=10.0)
-        verifier = GraspVerifier(gripper=gripper, signals=[signal])
-        # Simulate: mark_grasped, then signal collapses
+        verifier = GraspVerifier(
+            gripper=gripper,
+            signals=[signal],
+            params=VerifierParams(settling_ticks=0),
+        )
         verifier.mark_grasped("can_0")
         signal.value = 0.0
+        verifier.tick()
+        assert verifier.state is GraspState.LOST
         assert verifier.held_object is None
         # But tracked_object still reflects what we thought we grabbed
         assert verifier.tracked_object == "can_0"


### PR DESCRIPTION
Fixes #98. Second PR in the sim-magic elimination series for #93 (see personalrobotics/geodude#177).

Replaces the v1 live-query \`GraspVerifier\` (shipped in #96) with a sticky three-state machine driven by per-tick signal verification. Absorbs #95 (close_gripper uses verifier signals) into the same refactor.

## Why (1-minute recap)

v1 was live-query: every read of \`gripper.is_holding\` re-computed from fresh signal reads. Three problems revealed themselves when wiring the first real consumer:

1. **No in-flight monitoring.** Execute loops didn't tick the verifier; mid-transport drops only got caught after the trajectory finished.
2. **Release trusted intent, not observation.**
3. **Grasp completion still used \`iter_contacts\` via \`detect_grasped_object\`** — no hardware analog.

The fix is a sticky state machine where \`tick()\` does the real work once per control cycle, the execute loop aborts on HOLDING → LOST transitions, and \`close_gripper\` becomes a dumb ramp that hands verdict-making to the verifier.

## State machine

\`\`\`
IDLE ─ mark_grasped ─▶ HOLDING ─ tick sees collapse ─▶ LOST
                         ▲                              │
                         └─── mark_grasped ─────────────┘
\`\`\`

- **Sticky**: only \`mark_grasped\` leaves LOST. Matches reality (dropped objects don't self-heal), prevents sensor-noise flicker.
- **Settling window**: \`VerifierParams.settling_ticks=5\` suppresses drop-detection for 40ms after \`mark_grasped\` so the physics state can settle before real verification.
- **\`is_held\` is a plain state read**, cheap and consistent across multiple reads in the same cycle.

## Where the tick runs

Single chokepoint: \`PhysicsController._step_physics\` ticks every configured verifier exactly once per control cycle, after \`mj_step\` and before viewer sync. Every path that advances time (\`ctx.step\`, \`ctx.execute\`, trajectory runners, \`close_gripper\` ramps) transitively runs through here. Arms without a verifier are no-ops.

## Abort on drop

\`SimContext._execute_impl\` and \`_execute_tick_driven\` compose a built-in abort predicate from \`_make_drop_abort()\`, which snapshots arms currently HOLDING at trajectory start and fires when any of them transitions to LOST. This is the *\"we often drop stuff during transport\"* case (user's exact words) — a slipped object aborts the trajectory on the cycle it happens, not 500ms later when the motion ends.

## close_gripper simplification

- Dropped intermediate \`iter_contacts\` early-exit
- Always runs full close ramp + firm grip
- Returns \`bool\` instead of \`str | None\` — the verdict comes from the verifier, not from detection

## SimArmController.grasp() shape

1. Tare F/T (from personalrobotics/mj_manipulator#97)
2. Resolve target name (caller arg, or legacy \`detect_grasped_object\` fallback for nameless REPL path — slated for removal when personalrobotics/geodude#175 lands)
3. Run close
4. \`mark_grasped\` on both GraspManager and verifier
5. Pump \`settling_ticks+2\` physics ticks
6. If verifier rejects → undo everything, return None
7. Otherwise return the target name

## Tests

- \`test_grasp_verifier.py\` — 32 tests (up from 27), rewritten for tick-driven semantics:
  - Pure \`verify_grasp\` tests (14, unchanged)
  - State machine tests on stateful shell with fake signals (10) including new LOST stickiness test
  - New \`TestSettlingWindow\` class (3 tests)
  - Routing + param sanity tests (5)
- \`test_franka_gripper.py\` — 5 integration tests updated: explicit \`tick()\` calls, \`settling_ticks=0\` fixture

**Full suite: 368 tests pass, lint + format clean.**

## What comes next

This PR by itself has no visible behavior change on existing consumers — \`SimArmController.grasp()\` still returns the name or None, \`gripper.is_holding\` still works. The visible value lands in the geodude follow-up PR (new one, replaces personalrobotics/geodude#178):

1. Wire the verifier into \`Geodude._create_arm\` with \`WristFTSignal\`
2. Rewrite \`LiftBase\` to read \`gripper.is_holding\` (precondition + post-condition)
3. Abort-on-drop during lifts and transports is automatic via \`_make_drop_abort()\`
4. Run the recycling demo and watch for \"dropped can mid-lift → FAILURE → recovery\"

## Test plan

- [x] \`uv run pytest tests/ -q\` → 368 passed
- [x] \`uv run ruff check . && uv run ruff format --check .\` → clean
- [ ] CI 3.10 / 3.11 / 3.12
- [ ] Geodude follow-up PR merged and recycling demo smoke-tested

## Related

- personalrobotics/mj_manipulator#93 / #96 — v1 live-query verifier (superseded by this)
- personalrobotics/mj_manipulator#97 — F/T tare-before-grasp (prereq, landed)
- personalrobotics/mj_manipulator#95 — absorbed / closed
- personalrobotics/geodude#178 — v1 wiring, closed; new wiring PR will follow
- personalrobotics/geodude#173 — motivating bug
- personalrobotics/geodude#177 — sim-magic meta-issue