### PR TITLE
WristFTSignal: read world Z instead of sensor-local magnitude

### DIFF
--- a/src/mj_manipulator/load_signals.py
+++ b/src/mj_manipulator/load_signals.py
@@ -97,15 +97,58 @@ class GripperPositionSignal:
 
 
 class WristFTSignal:
-    """Wrist F/T force magnitude in newtons, or None in kinematic mode.
+    """Signed vertical (world Z) force at the wrist in newtons.
 
-    Reads :meth:`Arm.get_ft_wrench` and returns the Euclidean norm of
-    its linear (force) component. Returns ``None`` when the arm has
-    no F/T sensor configured or when ``ft_valid`` is False (kinematic
-    sim), which matches the verifier's \"skip this signal\" semantics.
+    Reads :meth:`Arm.get_ft_wrench_world` and returns the Z component
+    of the linear force — the projection of the wrench onto the
+    gravity axis. This is the quantity that *most directly*
+    corresponds to \"is the gripper still holding the object's
+    weight\", because a held object of mass ``m`` contributes a
+    constant ``±m*g`` to the world-Z reading regardless of how the
+    arm is posed. When the object drops, the contribution vanishes
+    and the reading returns to whatever the taread baseline
+    contained (nominally zero, if :meth:`Arm.tare_ft` was called
+    immediately before grasping).
+
+    Why world Z instead of the sensor-local frame:
+
+    - The F/T sensor's local frame rotates with the wrist flange.
+      The same held object projects differently onto each local axis
+      depending on the arm's pose. A signed-Z check in the local
+      frame would need pose-dependent thresholds — not general.
+    - Projecting into the world frame makes the \"how much vertical
+      load am I carrying\" signal pose-independent. Gravity is
+      gravity regardless of how the arm is oriented.
+
+    Why signed Z instead of the total-force magnitude:
+
+    - ``np.linalg.norm(wrench[:3])`` mixes gravity load with lateral
+      contact forces and angular-inertial bleed from each axis. A
+      moving arm with a held object sees the magnitude swing around
+      even when the grip is perfectly healthy, producing false LOST
+      transitions.
+    - The Z component is dominated by gravity (the thing we care
+      about) and only contaminated by vertical acceleration. X/Y
+      inertial forces from lateral motion don't touch it.
+
+    **Caveat — inertial forces during motion.** When the arm is
+    accelerating vertically, the Z reading includes the inertial
+    force of the held object as well as its weight. A hard upward
+    lift makes the reading grow; a hard deceleration at the top of
+    the lift makes it shrink transiently, sometimes below the
+    drop-detection threshold. The verifier's settling window
+    (:attr:`VerifierParams.settling_ticks`) handles the immediate
+    post-grasp transient, but does not handle mid-trajectory motion.
+    Consumers that need reliable mid-motion drop detection should
+    additionally gate verification on arm quiescence (e.g.
+    ``|qvel| < threshold``) — not done in this signal.
+
+    Returns ``None`` when the arm has no F/T sensor configured or
+    when ``ft_valid`` is False (kinematic sim), which matches the
+    verifier's \"skip this signal\" semantics.
     """
 
-    name: str = "wrist_ft_force"
+    name: str = "wrist_ft_force_z"
 
     def __init__(self, arm: Arm):
         self._arm = arm
@@ -113,10 +156,10 @@ class WristFTSignal:
     def read(self) -> float | None:
         if not self._arm.has_ft_sensor:
             return None
-        wrench = self._arm.get_ft_wrench()
-        if np.isnan(wrench[0]):
+        wrench_world = self._arm.get_ft_wrench_world()
+        if np.isnan(wrench_world[0]):
             return None
-        return float(np.linalg.norm(wrench[:3]))
+        return float(wrench_world[2])
 
 
 class JointTorqueSignal:

--- a/tests/test_load_signals.py
+++ b/tests/test_load_signals.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Tests for :mod:`mj_manipulator.load_signals`.
+
+Each signal encapsulates a small amount of per-signal projection
+logic (e.g. \"project to world Z\", \"take norm of joint torques\").
+The tests pin that logic against fake Arm / Gripper stubs so the
+axis conventions can't silently drift.
+
+Integration on a real MuJoCo arm is covered by
+``test_grasp_verifier.py`` (for the protocol) and end-to-end
+recycling demo runs (for the numeric plausibility of the baseline
+values in physics sim).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from mj_manipulator.load_signals import (
+    GripperPositionSignal,
+    JointTorqueSignal,
+    LoadSignal,
+    WristFTSignal,
+)
+
+# ---------------------------------------------------------------------------
+# Fake Arm / Gripper for signal tests
+# ---------------------------------------------------------------------------
+
+
+class FakeArm:
+    """Minimal Arm stub: exposes the attributes the signal classes read."""
+
+    def __init__(
+        self,
+        *,
+        has_ft_sensor: bool = True,
+        wrench_world: np.ndarray | None = None,
+        joint_torques: np.ndarray | None = None,
+    ):
+        self.has_ft_sensor = has_ft_sensor
+        self._wrench_world = wrench_world
+        self._joint_torques = joint_torques
+
+    def get_ft_wrench_world(self) -> np.ndarray:
+        if self._wrench_world is None:
+            return np.full(6, np.nan)
+        return self._wrench_world
+
+    def get_joint_torques(self) -> np.ndarray:
+        if self._joint_torques is None:
+            return np.full(6, np.nan)
+        return self._joint_torques
+
+
+class FakeGripper:
+    def __init__(self, position: float = 0.5):
+        self.position = position
+
+    def get_actual_position(self) -> float:
+        return self.position
+
+
+# ---------------------------------------------------------------------------
+# GripperPositionSignal
+# ---------------------------------------------------------------------------
+
+
+class TestGripperPositionSignal:
+    def test_reads_current_position(self):
+        gripper = FakeGripper(position=0.42)
+        signal = GripperPositionSignal(gripper)
+        assert signal.read() == 0.42
+
+    def test_returns_none_on_exception(self):
+        """If the gripper raises for any reason (disconnected hardware,
+        stale model handle), the signal returns None so the verifier
+        skips it rather than propagating the exception."""
+
+        class BrokenGripper:
+            def get_actual_position(self):
+                raise RuntimeError("nope")
+
+        signal = GripperPositionSignal(BrokenGripper())
+        assert signal.read() is None
+
+    def test_satisfies_protocol(self):
+        signal = GripperPositionSignal(FakeGripper())
+        assert isinstance(signal, LoadSignal)
+        assert signal.name == "gripper_position"
+
+
+# ---------------------------------------------------------------------------
+# WristFTSignal — the interesting one
+# ---------------------------------------------------------------------------
+
+
+class TestWristFTSignal:
+    """Pin the world-Z projection convention.
+
+    The F/T sensor's local frame rotates with the wrist flange, so
+    the raw local reading projects gravity differently depending on
+    arm pose. Reading world Z (via :meth:`Arm.get_ft_wrench_world`)
+    gives a pose-independent \"how much vertical load is the arm
+    carrying\" that's directly comparable across poses.
+
+    The signal returns the Z component directly (not the norm, not
+    the absolute value) so the verifier's ``abs(val) < abs(base)``
+    comparison can work symmetrically regardless of the sign
+    convention MuJoCo's :class:`mujoco.force` sensor uses for the
+    child-to-parent wrench.
+    """
+
+    def test_returns_world_z_component(self):
+        """Signal.read() should return exactly wrench_world[2], not
+        the magnitude, not the L2 norm, not any other projection."""
+        arm = FakeArm(wrench_world=np.array([1.5, -2.3, -0.7, 0.1, 0.2, 0.3]))
+        signal = WristFTSignal(arm)
+        assert signal.read() == -0.7  # the Z force, signed
+
+    def test_ignores_x_and_y_forces(self):
+        """A held object only shows up in Z (gravity axis). Lateral
+        contact forces on X/Y should not contaminate the signal."""
+        arm = FakeArm(wrench_world=np.array([100.0, 100.0, -0.5, 0, 0, 0]))
+        signal = WristFTSignal(arm)
+        assert signal.read() == -0.5
+
+    def test_ignores_torques(self):
+        """Linear forces only — torques live in wrench_world[3:] and
+        must not contaminate the scalar."""
+        arm = FakeArm(wrench_world=np.array([0.0, 0.0, -1.0, 50.0, 50.0, 50.0]))
+        signal = WristFTSignal(arm)
+        assert signal.read() == -1.0
+
+    def test_returns_none_when_arm_lacks_sensor(self):
+        """Franka / arms without wrist F/T return None so the
+        verifier skips the signal entirely."""
+        arm = FakeArm(has_ft_sensor=False)
+        signal = WristFTSignal(arm)
+        assert signal.read() is None
+
+    def test_returns_none_in_kinematic_mode(self):
+        """When ``ft_valid`` is False, get_ft_wrench_world() returns
+        all-NaN, and the signal should translate that to None."""
+        arm = FakeArm(has_ft_sensor=True, wrench_world=None)  # None → NaN fallback
+        signal = WristFTSignal(arm)
+        assert signal.read() is None
+
+    def test_satisfies_protocol(self):
+        arm = FakeArm(wrench_world=np.zeros(6))
+        signal = WristFTSignal(arm)
+        assert isinstance(signal, LoadSignal)
+        assert signal.name == "wrist_ft_force_z"
+
+    def test_signed_value_flows_through_verifier_decision(self):
+        """Regression test for the sign convention: verify_grasp uses
+        abs(val) < abs(base), so signed-Z should work symmetrically.
+        If someone later 'fixes' the signal to return abs(Z), this
+        test catches the silent information loss."""
+        from mj_manipulator.grasp_verifier import (
+            VerifierFacts,
+            VerifierParams,
+            verify_grasp,
+        )
+
+        # Baseline was -0.7 N (gravity pulling a held object down).
+        # Live reading is -0.05 N (object dropped, only tare residuals).
+        # abs(0.05) < abs(0.7) * 0.7 = 0.49 → object lost.
+        facts = VerifierFacts(
+            object_name="can_0",
+            empty_at_fully_closed=False,
+            gripper_position=0.5,
+            signal_values={"wrist_ft_force_z": -0.05},
+            signal_baselines={"wrist_ft_force_z": -0.7},
+        )
+        assert verify_grasp(facts, VerifierParams()) is False
+
+
+# ---------------------------------------------------------------------------
+# JointTorqueSignal
+# ---------------------------------------------------------------------------
+
+
+class TestJointTorqueSignal:
+    def test_returns_norm_of_joint_torques(self):
+        arm = FakeArm(joint_torques=np.array([3.0, 4.0, 0.0, 0.0, 0.0, 0.0]))
+        signal = JointTorqueSignal(arm)
+        assert signal.read() == 5.0
+
+    def test_returns_none_when_nan(self):
+        arm = FakeArm(joint_torques=np.full(6, np.nan))
+        signal = JointTorqueSignal(arm)
+        assert signal.read() is None
+
+    def test_returns_none_on_empty_array(self):
+        arm = FakeArm(joint_torques=np.array([]))
+        signal = JointTorqueSignal(arm)
+        assert signal.read() is None
+
+    def test_satisfies_protocol(self):
+        arm = FakeArm(joint_torques=np.zeros(6))
+        signal = JointTorqueSignal(arm)
+        assert isinstance(signal, LoadSignal)
+        assert signal.name == "joint_torque_effort"


### PR DESCRIPTION
Follow-up to #99. The v1 \`WristFTSignal\` was structurally wrong and would false-positive LOST during any moderately fast transport — observed in a live recycling demo run with:

\`\`\`
GraspVerifier: LOST plastic_glass_0 (reason: wrist_ft_force dropped from 1.770 → 1.234 (threshold 1.239))
\`\`\`

That's 30% below baseline right at the default drop threshold, caused entirely by motion dynamics on what would have been a healthy grasp.

## Root cause

The v1 signal read \`np.linalg.norm(arm.get_ft_wrench()[:3])\` — the Euclidean norm of the full linear-force vector in the sensor's **local** frame. Two problems:

1. **The local frame rotates with the wrist flange.** A held object's gravity load projects differently onto each local axis depending on arm pose. The norm stays roughly constant across poses, but there's no clean separation between gravitational load and lateral contact forces.

2. **The norm mixes inertial noise from every axis.** During motion, inertial forces on X, Y, and Z all contribute through \`sqrt(x² + y² + z²)\`. Even pure lateral motion makes the magnitude swing, producing false LOST with no relation to grip health.

## Fix

Project into the world frame via \`arm.get_ft_wrench_world()\` and return the **signed Z** component.

- World Z is gravity-aligned. A held object of mass m contributes a constant ±m·g regardless of arm pose.
- Lateral motion goes into world X and Y and leaves Z alone.
- Signed Z instead of abs(Z) because \`verify_grasp\` already compares via \`abs(val) < abs(base) * (1 - drop_ratio)\`, so sign convention doesn't affect the decision and keeping the sign makes log lines more informative.

Signal renamed from \`wrist_ft_force\` to \`wrist_ft_force_z\` to reflect the semantic change (magnitude → single signed axis). Verifier baseline dicts key off \`signal.name\` so the rename flows through automatically.

## Caveat — vertical acceleration still contaminates Z

A hard upward lift makes Z grow; a deceleration at the top makes it shrink transiently. World Z is *gravity*-independent from arm pose but *not* independent from arm vertical acceleration. The settling window handles the immediate post-grasp transient but not mid-trajectory motion.

The follow-up (probably Option B from the discussion in #98) is an **arm quiescence gate**: the signal returns \`None\` when \`max(|qvel|) > threshold\`, which short-circuits drop detection while the arm is moving and catches drops when motion slows or stops. Held for a separate PR so we can first verify world Z alone is enough improvement for the demo.

## Tests

New \`tests/test_load_signals.py\` — 14 tests covering \`GripperPositionSignal\`, \`WristFTSignal\`, \`JointTorqueSignal\`. The WristFT tests specifically pin the world-Z projection convention (axis, sign, None fallbacks) so the contract can't silently drift. Also a regression test for the signed-value path through \`verify_grasp\` — if someone later \"fixes\" the signal to return \`abs(Z)\`, the silent information loss is caught.

**Full suite: 382 tests pass (up from 368).**

## Test plan

- [x] \`uv run pytest tests/ -q\` → 382 passed
- [x] \`uv run ruff check . && uv run ruff format --check .\` → clean
- [ ] CI 3.10 / 3.11 / 3.12
- [ ] **Do not merge until @siddh verifies the signal is sensible in a live recycling demo run.** The whole point of this PR is to make the signal match physics; next step is for the user to check the log lines and confirm the baseline/live readings look reasonable before landing.

## Related

- personalrobotics/mj_manipulator#99 — state machine refactor (just landed; this fixes a bug in its signal definition)
- personalrobotics/geodude#173 — the original motivating bug
- personalrobotics/geodude#177 — sim-magic elimination meta-issue