### PR TITLE
RobotiqGripper: set empty_at_fully_closed = True

### DIFF
--- a/src/mj_manipulator/grippers/robotiq.py
+++ b/src/mj_manipulator/grippers/robotiq.py
@@ -198,8 +198,19 @@ class RobotiqGripper(_BaseGripper):
     """
 
     hand_type: str = "robotiq"
-    # Robotiq 2F-140 has 14cm finger travel — fully-closed can still hold
-    empty_at_fully_closed: bool = False
+    # The Robotiq 2F-140 has 14 cm of finger travel, so fully-closed
+    # can in principle still hold an extremely thin object — but in
+    # practice the objects we grasp are much wider than the
+    # ``empty_position_threshold`` resolution (default 2% = 2.8 mm on
+    # the 140 mm travel). Treating fully-closed as \"empty\" lets the
+    # :class:`~mj_manipulator.grasp_verifier.GraspVerifier`'s
+    # decisive-negative branch fire immediately when the gripper
+    # closed on nothing, which is a crisp, noise-free, motion-
+    # independent signal — better than trying to derive the same
+    # verdict from F/T readings that bounce around during transport.
+    # See personalrobotics/geodude#173 and personalrobotics/mj_manipulator#98
+    # for the full story.
+    empty_at_fully_closed: bool = True
 
     def __init__(
         self,


### PR DESCRIPTION
Small, important correctness flip based on real recycling-demo data.

## Why

The v1 \`WristFTSignal\` (replaced by #100) and even the world-Z version produce false LOST transitions for two different reasons observed live:

1. **Stale or contaminated baseline** — e.g. \`spam_can_1\` baselined at −13.1 N, which is an order of magnitude higher than its actual weight. The tare leaked something (gripper self-weight, residual load). Any live reading will look \"collapsed\" against that.
2. **Inertial forces during transport** — \`cracker_box_0\` baselined at −1.9 N, went to −0.9 N mid-motion purely because the arm was accelerating. Grip was perfectly healthy.

Both failures come from trying to derive a grasp-health verdict from a noisy, pose- and motion-dependent signal.

Meanwhile, the Robotiq 2F-140 has a **crisp, noise-free, motion-independent** signal sitting right there: *did the gripper stop somewhere other than fully closed?* If it did, the fingers found an object. If it didn't, they found nothing. This PR unlocks that.

## What changes

\`\`\`diff
-    # Robotiq 2F-140 has 14cm finger travel — fully-closed can still hold
-    empty_at_fully_closed: bool = False
+    empty_at_fully_closed: bool = True
\`\`\`

That's it. One flag. With it set, \`GraspVerifier\`'s decisive-negative branch fires immediately when the gripper closed on nothing:

\`\`\`python
if (
    facts.empty_at_fully_closed
    and facts.gripper_position is not None
    and facts.gripper_position >= params.empty_position_threshold
):
    return False
\`\`\`

## What we give up

Objects thinner than \`empty_position_threshold × finger_travel\` = 0.02 × 140 mm = **~2.8 mm** would incorrectly trip the check. Nothing in the recycling demo is that thin. If we ever need to grasp paper, thin cardboard, or similar, we can (a) lower \`empty_position_threshold\` per-object, or (b) revert this flag and go back to a load-based signal with a quiescence gate.

## What comes next

Companion PR in geodude drops \`WristFTSignal\` from the \`GraspVerifier\` wiring in \`Geodude._create_arm\`, leaving only \`GripperPositionSignal\` (which via the gripper.position reading also feeds the decisive-negative branch). The F/T tare in \`SimArmController.grasp\` stays as-is — it's harmless and useful if anyone later adds an F/T-based runtime monitor.

## Test plan

- [x] \`uv run pytest tests/ -q\` → 368 passed, no changes needed
- [x] \`uv run ruff check . && uv run ruff format --check .\` → clean
- [ ] CI
- [ ] **Do not merge until @siddh verifies that the recycling demo picks up real objects successfully with the companion geodude PR.** This PR is a trivial flag flip; the real validation is end-to-end.

## Related

- personalrobotics/mj_manipulator#99 — GraspVerifier state machine (merged)
- personalrobotics/mj_manipulator#100 — WristFTSignal → world Z (open, unmerged, will stay unmerged since we're pivoting away from F/T for geodude)
- personalrobotics/geodude#173 — the motivating bug
- personalrobotics/geodude#177 — sim-magic elimination meta-issue