### PR TITLE
SimArmController: stop pumping physics ticks from grasp()

### DIFF
--- a/src/mj_manipulator/sim_context.py
+++ b/src/mj_manipulator/sim_context.py
@@ -129,33 +129,38 @@ class SimArmController:
             self._run_close(candidates)
 
         # Record the grasp in bookkeeping (kinematic weld) and in the
-        # verifier (baseline capture + HOLDING state). The verifier's
-        # tick in the settling window is a no-op; real verification
-        # runs a few ticks later. If the grasp didn't actually succeed
-        # (signals don't support the baseline), the verifier will
-        # transition to LOST during the verification tick pump, and we
-        # undo the mark_grasped so downstream consumers see a clean
-        # failure.
+        # verifier (baseline capture + HOLDING state).
+        #
+        # The verifier enters HOLDING *inside its settling window* —
+        # drop-detection is suppressed for the first ``settling_ticks``
+        # ticks to give the actuator time to settle into its final
+        # grip configuration. Real verification runs on whatever the
+        # next physics cycle is, which is the next motion's
+        # ``ctx.execute`` call. For the BT path this is always a
+        # Sync/LiftBase that immediately runs through the event
+        # loop's normal tick pump, so the settling window elapses
+        # before any consumer reads ``is_held`` as authoritative.
+        #
+        # We deliberately do *not* pump extra physics ticks here to
+        # \"confirm\" the grasp synchronously: doing so blocks the
+        # caller thread and races with the event loop's own tick
+        # schedule, producing (a) visible lag in every downstream
+        # movement and (b) false positives when the verifier runs
+        # its first verification inside the actuator-integration
+        # transient that follows close_gripper. See the investigation
+        # recorded in the recycling-demo diagnostic run where
+        # empty-close → pos=1.000 but a healthy can-close → pos=0.46
+        # with perfectly stable post-settle readings — the readings
+        # themselves were fine, the synchronous tick pump was reading
+        # them during the transient settling window.
         if self._arm.grasp_manager is not None:
             self._arm.grasp_manager.mark_grasped(target, arm_name)
             self._arm.grasp_manager.attach_object(target, gripper.attachment_body)
 
         if gripper.grasp_verifier is not None:
             gripper.grasp_verifier.mark_grasped(target)
-            self._run_grasp_verification_ticks()
-            if not gripper.grasp_verifier.is_held:
-                logger.info("Grasp rejected by verifier: %s with %s arm", target, arm_name)
-                # Undo the bookkeeping — the grasp didn't actually hold.
-                if self._arm.grasp_manager is not None:
-                    self._arm.grasp_manager.mark_released(target)
-                    self._arm.grasp_manager.detach_object(target)
-                gripper.grasp_verifier.mark_released()
-                self._context.sync()
-                return None
-            logger.info("Grasped %s with %s arm (verifier confirmed)", target, arm_name)
-        else:
-            logger.info("Grasped %s with %s arm", target, arm_name)
 
+        logger.info("Grasped %s with %s arm", target, arm_name)
         self._context.sync()
         return target
 
@@ -167,26 +172,6 @@ class SimArmController:
             self._context._controller.close_gripper(arm_name, candidate_objects=candidates)
         else:
             gripper.kinematic_close()  # type: ignore[union-attr]
-
-    def _run_grasp_verification_ticks(self) -> None:
-        """Pump extra physics ticks so the verifier can exit its
-        settling window and run a real drop-detection check.
-
-        Runs ``settling_ticks + 2`` physics steps after
-        :meth:`GraspVerifier.mark_grasped` so the first post-settling
-        tick actually evaluates the signals against the baseline.
-        Otherwise ``grasp()`` would return while the verifier is
-        still in its warmup window, and downstream ``is_held`` reads
-        would be stale.
-        """
-        gripper = self._arm.gripper
-        if gripper is None or gripper.grasp_verifier is None:
-            return
-        if self._context._controller is None:
-            return  # kinematic sim — no physics ticks to run
-        n_ticks = gripper.grasp_verifier._params.settling_ticks + 2
-        for _ in range(n_ticks):
-            self._context._controller.step()
 
     def release(self, object_name: str | None = None) -> None:
         """Open gripper and release held object(s).


### PR DESCRIPTION
Fix for two symptoms observed live in the recycling demo after personalrobotics/mj_manipulator#99 / #101 landed:

1. **\"Super slow all of a sudden.\"** Every grasp blocked the caller thread for \`settling_ticks + 2\` synchronous physics steps, racing with the event loop's tick pump.
2. **False positive on a real grasp**: \`fuze_bottle_0\` rejected with \`pos=0.980\`, even though the gripper had wrapped around a cylinder.

Both are caused by the same line I added in #99 — a synchronous physics-step pump at the end of \`SimArmController.grasp()\` so the verifier could produce a verdict before returning. It shouldn't have been there.

## Diagnostic that proved the signal is fine

Ran a REPL diagnostic with the verifier detached:

\`\`\`
empty close → pos = 0.9998  (correct — fingers hit each other)
can close   → pos = 0.4642  (correct — wrapped on a real object)
  t+0ms   0.4642
  t+100ms 0.4642
  ...
  t+900ms 0.4642  (bit-for-bit stable, no drift)
\`\`\`

So the Robotiq position signal is clean and the threshold (0.98) correctly distinguishes healthy grasps from empty closes. The false positive wasn't the signal — it was my code reading it **during the actuator integration transient** right after \`close_gripper\` returned, before physics had settled.

## Fix

Delete \`_run_grasp_verification_ticks\` and the verdict-undo block. \`grasp()\` now:

1. Runs \`close_gripper\` (unchanged)
2. Calls \`GraspManager.mark_grasped\` + \`attach_object\`
3. Calls \`verifier.mark_grasped\` (enters HOLDING inside settling window)
4. Returns immediately with the target name

The verifier's real verification happens on the **next motion cycle**, which is always a motion in the BT path — \`Grasp\` → \`Sync\` → \`LiftBase\`, all three of which run through \`ctx.execute\`'s tick pump. The settling window elapses inside that execute, and if the grasp was empty, the state flips to LOST and the abort-on-drop composition halts the trajectory on the next control cycle.

Failure timing shifts from *\"inside \`grasp()\`\"* to *\"a few ticks into the first motion after grasp\"*. That's actually better — a failed grasp aborts whatever motion just started, instead of flailing through a lift before learning it was empty.

## Caveat: REPL wart

At the REPL, \`robot.left.grasp()\` followed immediately by \`robot.left.is_holding\` will briefly see True even for empty grasps, because the verifier is still in its settling window and no physics has ticked. Window is ~40ms; any subsequent action ticks the event loop and updates. If this becomes a problem we can add an explicit \`ctx.wait_for_settled_grasp()\` helper that pumps exactly the settling window off the event loop.

## What's unchanged

Nothing about the state machine architecture changed:
- GraspVerifier state machine (IDLE → HOLDING → LOST, sticky)
- LoadSignal protocol + all three built-in signals
- Tick hook in \`PhysicsController._step_physics\` (every cycle)
- Abort-on-drop composition in \`SimContext._make_drop_abort\`
- Settling window (still 5 ticks)
- \`mark_released\` on explicit \`release()\`
- \`_BaseGripper\` routing (is_holding / held_object via verifier)

The only deletion is the synchronous tick-pump side effect.

## Test plan

- [x] \`uv run pytest tests/ -q\` → 368 passed
- [x] \`uv run ruff check . && uv run ruff format --check .\` → clean
- [ ] CI
- [ ] **Do not merge until @siddh re-runs the recycling demo and confirms:**
  - [ ] Movement is back to normal speed
  - [ ] No false positives on real grasps (fuze_bottle, cracker_box, etc.)
  - [ ] Failed grasps still get caught (the BT's next motion should abort within ~50ms)

If the speed problem persists after this change, it wasn't thread contention from the pumped ticks — I'll add timing instrumentation and dig further. If false positives persist, the signal mapping itself is wrong and we need to bump \`settling_ticks\` or switch the decisive-negative threshold.

## Related

- personalrobotics/mj_manipulator#99 — state machine refactor (added the tick pump)
- personalrobotics/mj_manipulator#101 — Robotiq \`empty_at_fully_closed=True\` (dependency for this to be meaningful)
- personalrobotics/geodude#179 — geodude wiring (unchanged, still unmerged, waiting for this)
- personalrobotics/geodude#173 — motivating bug