### PR TITLE
primitives: add grasp_confirmed blackboard key for honest pickup-failure reports

### DIFF
--- a/src/mj_manipulator/primitives.py
+++ b/src/mj_manipulator/primitives.py
@@ -140,23 +140,30 @@ def _deactivate_teleop_for_arms(robot, arms: list[str] | None = None) -> None:
             ctx._deactivate_teleop_for(arm_name)
 
 
-def _pickup_details(ns: str) -> tuple[list[str], str | None, bool, bool, str | None]:
+def _pickup_details(ns: str) -> tuple[list[str], str | None, bool, bool | None, str | None]:
     """Read pickup results from blackboard after a failed attempt.
 
     Returns:
-        (attempted_objects, reached_object, plan_succeeded, grasp_succeeded,
-         plan_failure_reason)
+        ``(attempted_objects, reached_object, plan_succeeded,
+        grasp_confirmed, plan_failure_reason)``.
+
+        ``grasp_confirmed`` is ``None`` when the BT never got far
+        enough to check the verifier (e.g. plan failed before any
+        grasp was attempted), ``False`` when the grasp close ran but
+        the verifier then rejected it, and ``True`` when the grasp
+        held long enough for a downstream node (e.g. ``LiftBase``) to
+        confirm it.
     """
     attempted: list[str] = []
     reached: str | None = None
     plan_failed = False
-    grasped = False
+    grasp_confirmed: bool | None = None
     plan_reason: str | None = None
     try:
         bb = py_trees.blackboard.Client(name=f"pickup_report{ns}")
         bb.register_key(key=f"{ns}/tsr_to_object", access=Access.READ)
         bb.register_key(key=f"{ns}/object_name", access=Access.READ)
-        bb.register_key(key=f"{ns}/grasped", access=Access.READ)
+        bb.register_key(key=f"{ns}/grasp_confirmed", access=Access.READ)
         bb.register_key(key=f"{ns}/plan_failure_reason", access=Access.READ)
         mapping = bb.get(f"{ns}/tsr_to_object")
         if mapping:
@@ -166,10 +173,10 @@ def _pickup_details(ns: str) -> tuple[list[str], str | None, bool, bool, str | N
             reached = obj
         plan_reason = bb.get(f"{ns}/plan_failure_reason")
         plan_failed = plan_reason is not None
-        grasped = bool(bb.get(f"{ns}/grasped"))
+        grasp_confirmed = bb.get(f"{ns}/grasp_confirmed")
     except (KeyError, RuntimeError):
         pass
-    return attempted, reached, not plan_failed, grasped, plan_reason
+    return attempted, reached, not plan_failed, grasp_confirmed, plan_reason
 
 
 def _report_pickup_failure(robot, sides_tried: list[str], target: str | None) -> None:
@@ -180,9 +187,10 @@ def _report_pickup_failure(robot, sides_tried: list[str], target: str | None) ->
 
     for side in sides_tried:
         ns = f"/{side}"
-        attempted, reached, planned, grasped, plan_reason = _pickup_details(ns)
+        attempted, reached, planned, grasp_confirmed, plan_reason = _pickup_details(ns)
         all_attempted.update(attempted)
-        if reached and planned and not grasped:
+        if reached and planned and grasp_confirmed is False:
+            # Got to the object, grasp sequence ran, verifier rejected.
             grasp_failures.append(f"{reached} ({side} arm)")
             _set_hud_action(robot, side, "✗ pickup: grasp failed")
         elif reached and not planned:
@@ -194,7 +202,10 @@ def _report_pickup_failure(robot, sides_tried: list[str], target: str | None) ->
             _set_hud_action(robot, side, f"✗ pickup: {short}")
 
     if grasp_failures:
-        logger.warning("Pickup failed: reached %s but grasp failed", ", ".join(grasp_failures))
+        logger.warning(
+            "Pickup failed: reached %s but verifier rejected the grasp",
+            ", ".join(grasp_failures),
+        )
     elif plan_failures:
         logger.warning("Pickup failed: could not plan to %s", "; ".join(plan_failures))
     elif all_attempted:
@@ -226,6 +237,7 @@ def _setup_blackboard(robot, ctx, arm_name: str, arm, ns: str) -> None:
         f"{ns}/goal_tsr_index",
         f"{ns}/plan_failure_reason",
         f"{ns}/grasped",
+        f"{ns}/grasp_confirmed",
         f"{ns}/path",
         f"{ns}/trajectory",
         f"{ns}/twist",
@@ -267,6 +279,7 @@ def _setup_blackboard(robot, ctx, arm_name: str, arm, ns: str) -> None:
         "path",
         "trajectory",
         "grasped",
+        "grasp_confirmed",
         "grasp_tsrs",
         "place_tsrs",
         "tsr_to_object",


### PR DESCRIPTION
Small diagnostic fix. After personalrobotics/mj_manipulator#102 (grasp() returns optimistically before the verifier verifies), the BT's \`grasped\` blackboard key reflects *intent*, not *sensor-confirmed state*. \`_report_pickup_failure\` was trusting it and misclassifying grasp failures as plan failures, producing logs like:

\`\`\`
Pickup failed: could not plan to can_0, cracker_box_0, plastic_glass_0, sugar_box_0, sugar_box_1
\`\`\`

...when the pickup actually planned fine, reached the object, closed the gripper, and then the verifier rejected the grasp. The top-level error message disagreed with what actually happened.

## Fix

Add a new tri-valued blackboard key \`{ns}/grasp_confirmed\`:

- **None** — BT never reached the confirmation step (plan failed, or we never got to the grasp node)
- **False** — grasp close ran but the verifier rejected it (HOLDING → LOST)
- **True** — grasp held and a downstream node confirmed

\`_report_pickup_failure\` reads this instead of the ambiguous \`grasped\`, and reports three distinct cases:

- \`\"reached X but verifier rejected the grasp\"\` when grasp_confirmed=False
- \`\"could not plan to X\"\` when the planner never succeeded
- \`\"no graspable X found\"\` when TSR generation returned nothing

The \`grasped\` key is unchanged — \`Grasp.update()\` still writes the target name for downstream nodes (Release, LiftBase) that need to know what we *think* we're holding.

## Who writes grasp_confirmed

This PR only *reads* the key in \`_report_pickup_failure\` and registers it in \`_setup_blackboard\`. Setting it is the responsibility of the first BT node after \`Grasp\` + \`Sync\` that has a chance to check the verifier — for geodude that's \`LiftBase\`, for fixed-base arms it'll be a dedicated \`CheckHeld\` node (not in this PR; filed separately).

A companion personalrobotics/geodude PR wires \`LiftBase\` to write \`grasp_confirmed = gripper.is_holding\` at its precondition check.

## Test plan

- [x] \`uv run pytest tests/ -q\` → 368 passed
- [x] \`uv run ruff check . && uv run ruff format --check .\` → clean
- [ ] CI
- [ ] **Do not merge until @siddh confirms the recycling demo shows correct messages** after the companion geodude PR also lands. This PR on its own is a no-op on downstream behavior: new key is registered and cleared but never set to True/False until LiftBase writes it.

## Related

- personalrobotics/mj_manipulator#102 — tick-pump deletion (upstream of the optimistic return)
- personalrobotics/geodude#179 — geodude verifier wiring (will get a companion commit)
- personalrobotics/geodude#173 — motivating bug