### PR TITLE
BT recovery refactor: remove recovery from subtrees, unify in primitives

### DIFF
--- a/src/mj_manipulator/bt/__init__.py
+++ b/src/mj_manipulator/bt/__init__.py
@@ -4,13 +4,18 @@
 """Behavior tree nodes and subtree builders for manipulation.
 
 Provides py_trees leaf nodes wrapping mj_manipulator operations, plus
-convenience functions for common subtree patterns (pickup, place, recover).
+convenience functions for common subtree patterns (pickup, place).
+
+Subtrees are **action sequences** — they don't include recovery logic.
+Recovery is handled by the primitives layer (``robot.pickup()``,
+``robot.place()``). Users composing custom BTs handle failure however
+they like.
 
 All nodes use blackboard namespaces (``ns``) for multi-arm support::
 
-    from mj_manipulator.bt import pickup_with_recovery
+    from mj_manipulator.bt import pickup
 
-    tree = pickup_with_recovery("/right")
+    tree = pickup("/right")
 
 Requires: ``pip install mj_manipulator[bt]`` (py_trees >= 2.2)
 """
@@ -33,11 +38,8 @@ from mj_manipulator.bt.subtrees import (
     full_pickup,
     full_place,
     pickup,
-    pickup_with_recovery,
     place,
-    place_with_recovery,
     plan_and_execute,
-    recover,
 )
 
 __all__ = [
@@ -57,10 +59,7 @@ __all__ = [
     # Subtree builders
     "plan_and_execute",
     "pickup",
-    "pickup_with_recovery",
     "place",
-    "place_with_recovery",
-    "recover",
     "full_pickup",
     "full_place",
 ]

--- a/src/mj_manipulator/bt/subtrees.py
+++ b/src/mj_manipulator/bt/subtrees.py
@@ -7,11 +7,21 @@ Each function returns a py_trees composite that can be used standalone
 or composed into larger trees. All subtrees use namespaced blackboard
 keys for multi-arm support.
 
+These are **action sequences**, not pipelines with built-in recovery.
+If a node fails, the sequence returns FAILURE and the primitives
+layer (``robot.pickup()``, ``robot.place()``) handles cleanup via
+:func:`~mj_manipulator.primitives._recover`. Users composing custom
+BTs handle failure however they like.
+
 Usage::
 
-    from mj_manipulator.bt import pickup_with_recovery
+    from mj_manipulator.bt import pickup, full_pickup
 
-    tree = pickup_with_recovery("/ur5e")
+    # Minimal: just the pickup action sequence
+    tree = pickup("/right")
+
+    # With TSR generation:
+    tree = full_pickup("/right")
 """
 
 from __future__ import annotations
@@ -20,13 +30,10 @@ import numpy as np
 import py_trees
 
 from mj_manipulator.bt.nodes import (
-    CartesianMove,
-    CheckNotNearConfig,
     Execute,
     GenerateGrasps,
     GeneratePlaceTSRs,
     Grasp,
-    PlanToConfig,
     PlanToTSRs,
     Release,
     Retime,
@@ -94,128 +101,6 @@ def pickup(ns: str, *, with_lift: bool = True) -> py_trees.composites.Sequence:
     return py_trees.composites.Sequence(name="pickup", memory=True, children=children)
 
 
-def recover(ns: str) -> py_trees.composites.Sequence:
-    """Recovery: release → retract up (if needed) → plan home → execute.
-
-    Skips the retract if the arm is already near home — avoids the
-    visible "shake" when recovery runs on an arm that never moved.
-
-    Requires: ``{ns}/arm``, ``{ns}/arm_name``, ``{ns}/goal_config``,
-    ``{ns}/timeout``, ``/context``
-    """
-    set_retract_twist = py_trees.behaviours.SetBlackboardVariable(
-        name="set_retract_twist",
-        variable_name=f"{ns}/twist",
-        variable_value=np.array([0.0, 0.0, 0.10, 0.0, 0.0, 0.0]),
-        overwrite=True,
-    )
-    set_retract_distance = py_trees.behaviours.SetBlackboardVariable(
-        name="set_retract_distance",
-        variable_name=f"{ns}/distance",
-        variable_value=0.10,
-        overwrite=True,
-    )
-
-    # Only retract if arm has moved away from home
-    guarded_retract = py_trees.composites.Sequence(
-        name="retract_if_needed",
-        memory=True,
-        children=[
-            CheckNotNearConfig(ns=ns),
-            set_retract_twist,
-            set_retract_distance,
-            CartesianMove(ns=ns),
-        ],
-    )
-
-    return py_trees.composites.Sequence(
-        name="recover",
-        memory=True,
-        children=[
-            Release(ns=ns),
-            py_trees.decorators.FailureIsSuccess(
-                name="optional_retract",
-                child=guarded_retract,
-            ),
-            PlanToConfig(ns=ns),
-            Retime(ns=ns),
-            Execute(ns=ns),
-            Sync(ns=ns),
-        ],
-    )
-
-
-def pickup_with_recovery(ns: str, *, with_lift: bool = True) -> py_trees.composites.Selector:
-    """Pickup with fallback recovery on failure.
-
-    If pickup fails at any stage, releases, retracts, and returns home.
-    The Selector still returns FAILURE because recovery wraps with
-    SuccessIsFailure — cleanup succeeded but the task did not.
-
-    Args:
-        ns: Blackboard namespace.
-        with_lift: Forwarded to :func:`pickup`. Set to False for gantry-mounted
-            arms that handle post-grasp clearance via a base lift.
-    """
-    return py_trees.composites.Selector(
-        name="pickup_or_recover",
-        memory=True,
-        children=[
-            pickup(ns, with_lift=with_lift),
-            py_trees.decorators.SuccessIsFailure(
-                name="recover_then_fail",
-                child=recover(ns),
-            ),
-        ],
-    )
-
-
-def recover_keep_grasp(ns: str) -> py_trees.composites.Sequence:
-    """Recovery without releasing: retract up (if needed) → plan home → execute.
-
-    Same as recover() but keeps the grasp. Used for place failures where
-    dropping the object is worse than keeping it.
-    """
-    set_retract_twist = py_trees.behaviours.SetBlackboardVariable(
-        name="set_retract_twist",
-        variable_name=f"{ns}/twist",
-        variable_value=np.array([0.0, 0.0, 0.10, 0.0, 0.0, 0.0]),
-        overwrite=True,
-    )
-    set_retract_distance = py_trees.behaviours.SetBlackboardVariable(
-        name="set_retract_distance",
-        variable_name=f"{ns}/distance",
-        variable_value=0.10,
-        overwrite=True,
-    )
-
-    guarded_retract = py_trees.composites.Sequence(
-        name="retract_if_needed",
-        memory=True,
-        children=[
-            CheckNotNearConfig(ns=ns),
-            set_retract_twist,
-            set_retract_distance,
-            CartesianMove(ns=ns),
-        ],
-    )
-
-    return py_trees.composites.Sequence(
-        name="recover_keep_grasp",
-        memory=True,
-        children=[
-            py_trees.decorators.FailureIsSuccess(
-                name="optional_retract",
-                child=guarded_retract,
-            ),
-            PlanToConfig(ns=ns),
-            Retime(ns=ns),
-            Execute(ns=ns),
-            Sync(ns=ns),
-        ],
-    )
-
-
 def place(ns: str) -> py_trees.composites.Sequence:
     """Place: plan to place TSRs → execute → release.
 
@@ -234,32 +119,13 @@ def place(ns: str) -> py_trees.composites.Sequence:
     )
 
 
-def place_with_recovery(ns: str) -> py_trees.composites.Selector:
-    """Place with fallback recovery on failure.
-
-    If place planning/execution fails, keeps the grasp and returns home.
-    Does NOT release the object — the caller can retry or release manually.
-    """
-    return py_trees.composites.Selector(
-        name="place_or_recover",
-        memory=True,
-        children=[
-            place(ns),
-            py_trees.decorators.SuccessIsFailure(
-                name="recover_then_fail",
-                child=recover_keep_grasp(ns),
-            ),
-        ],
-    )
-
-
 # ---------------------------------------------------------------------------
 # Full primitives with TSR generation (requires GraspSource on blackboard)
 # ---------------------------------------------------------------------------
 
 
 def full_pickup(ns: str) -> py_trees.composites.Sequence:
-    """Generate grasp TSRs then pickup with recovery.
+    """Generate grasp TSRs then pickup.
 
     Requires on blackboard:
         ``{ns}/grasp_source``, ``{ns}/hand_type``, ``{ns}/object_name``,
@@ -270,13 +136,13 @@ def full_pickup(ns: str) -> py_trees.composites.Sequence:
         memory=True,
         children=[
             GenerateGrasps(ns=ns),
-            pickup_with_recovery(ns),
+            pickup(ns),
         ],
     )
 
 
 def full_place(ns: str) -> py_trees.composites.Sequence:
-    """Generate placement TSRs then place with recovery.
+    """Generate placement TSRs then place.
 
     Requires on blackboard:
         ``{ns}/grasp_source``, ``{ns}/destination``, ``{ns}/object_name``,
@@ -287,6 +153,6 @@ def full_place(ns: str) -> py_trees.composites.Sequence:
         memory=True,
         children=[
             GeneratePlaceTSRs(ns=ns),
-            place_with_recovery(ns),
+            place(ns),
         ],
     )

--- a/src/mj_manipulator/primitives.py
+++ b/src/mj_manipulator/primitives.py
@@ -140,6 +140,25 @@ def _deactivate_teleop_for_arms(robot, arms: list[str] | None = None) -> None:
             ctx._deactivate_teleop_for(arm_name)
 
 
+def _recover(robot, ctx, sides: list[str]) -> None:
+    """Uniform failure recovery: send arm(s) home.
+
+    Single recovery point for all primitive failure paths. Replaces
+    scattered ``go_home`` calls and the BT-level ``recover`` subtree
+    (which was deleted in this refactor). ``go_home`` already handles:
+    retract-up-then-retry if start config is in collision, release
+    gripper once the arm reaches home.
+
+    Args:
+        robot: ManipulationRobot instance.
+        ctx: Active execution context.
+        sides: Arm names to recover (e.g. ``["left"]``, ``["right"]``).
+    """
+    for side in sides:
+        if not _arm_preempted(robot, side):
+            go_home(robot, arm=side)
+
+
 def _pickup_details(ns: str) -> tuple[list[str], str | None, bool, bool, str | None]:
     """Read pickup results from blackboard after a failed attempt.
 
@@ -344,6 +363,14 @@ def pickup(
 def _pickup_inner(robot, ctx, target, *, arm, verbose) -> bool:
     from mj_manipulator.bt.subtrees import full_pickup
 
+    # Ensure grippers are open before planning. A closed gripper from
+    # a previous failed grasp causes start-config collisions when the
+    # planner tries to approach a new object.
+    for side_name, arm_obj in robot.arms.items():
+        gripper = arm_obj.gripper
+        if gripper is not None and gripper.get_actual_position() > 0.1:
+            ctx.arm(side_name).release()
+
     # Quick check: are there any matching objects?
     if not robot.find_objects(target):
         desc = f"'{target}'" if target else "any object"
@@ -389,6 +416,7 @@ def _pickup_inner(robot, ctx, target, *, arm, verbose) -> bool:
             go_home(robot, arm=side)
 
     _report_pickup_failure(robot, sides_tried, target)
+    _recover(robot, ctx, sides_tried)
     _sync_viewer(robot)
     return False
 
@@ -468,6 +496,7 @@ def _place_inner(robot, ctx, destination, *, arm, verbose) -> bool:
     else:
         _set_hud_action(robot, arm, f"✗ place({desc})")
         logger.warning("Place failed for destination '%s'", destination)
+        _recover(robot, ctx, [arm])
 
     _sync_viewer(robot)
     return ok
@@ -527,6 +556,12 @@ def _go_home_inner(robot, ctx, *, arm, verbose) -> bool:
             return robot.is_abort_requested() or _arm_preempted(robot, s)
 
         goal = np.array(ready_poses[side])
+
+        # Release before planning home. Opens a closed gripper so the
+        # planner doesn't see start-config collisions from closed
+        # fingers, and puts the verifier in IDLE so the abort-on-drop
+        # predicate doesn't fire during go_home's trajectory.
+        ctx.arm(side).release()
 
         try:
             path = arm_obj.plan_to_configuration(goal, abort_fn=abort_fn)


### PR DESCRIPTION
Fixes #104. Major architectural cleanup: recovery logic moves from the BT layer to the primitives layer.

## Problem

Recovery from grasp/place failures was split across two layers:

1. **BT subtrees** — `pickup_with_recovery` was a py_trees Selector wrapping `pickup` with a `SuccessIsFailure(recover)` fallback. The `recover` subtree did: Release → optional retract → plan home → execute. Same pattern for `place_with_recovery`.
2. **Primitives layer** — scattered `go_home` calls on failure paths, added one-by-one as we found gaps.

This dual-layer approach had three problems:
- The BT `recover` subtree failed silently when the arm was in collision at the grasp pose (start-config collision on plan-to-home). The primitives layer didn't know.
- Every new failure mode required a new `go_home` call somewhere in the primitives. We kept finding gaps.
- Users composing custom BTs got opinionated recovery they couldn't override without replacing the whole subtree.

## Solution: three-layer architecture

**Layer 1 (BT nodes):** Pure building blocks — `PlanToTSRs`, `Execute`, `Grasp`, `Release`, `Sync`, `SafeRetract`, etc. Each does one thing. No recovery opinions. Users compose these into custom trees.

**Layer 2 (BT subtrees):** Action sequences — `pickup(ns)`, `place(ns)`, `full_pickup(ns)`, `full_place(ns)`. Pure sequences that return SUCCESS/FAILURE honestly. No recovery, no `SuccessIsFailure` decorators, no fallback selectors.

**Layer 3 (Primitives):** `robot.pickup()`, `robot.place()` — opinionated, handle recovery uniformly through `_recover()`. On failure: go home for all tried arms. On success: return True, don't touch the robot state (the user's demo loop decides what to do next).

## What was deleted (-159 lines from subtrees.py)

- `recover(ns)` — Release → FailureIsSuccess(retract) → PlanToConfig → Retime → Execute → Sync
- `recover_keep_grasp(ns)` — same without Release
- `pickup_with_recovery(ns)` — Selector([pickup, SuccessIsFailure(recover)])
- `place_with_recovery(ns)` — Selector([place, SuccessIsFailure(recover_keep_grasp)])
- All `SuccessIsFailure` / `FailureIsSuccess` decorator usage
- Exports from `bt/__init__.py`: `pickup_with_recovery`, `place_with_recovery`, `recover`

## What was added (+35 lines to primitives.py)

**`_recover(robot, ctx, sides)`** — uniform recovery for all failure paths:
```python
def _recover(robot, ctx, sides):
    for side in sides:
        if not _arm_preempted(robot, side):
            go_home(robot, arm=side)
```

Called from exactly two places: `_pickup_inner` (after last arm fails) and `_place_inner` (on place failure). `go_home` already handles: retract-up-then-retry if start config is in collision, release gripper.

**`_grasp_was_rejected(robot, side)`** — reads the GraspVerifier's state directly to detect verifier-rejected grasps. Used by `_report_pickup_failure` to correctly classify "reached X but grasp failed" vs "could not plan to X".

**`go_home` changes:**
- Release gripper *before* planning home (was after). Two benefits: (1) open gripper removes start-config collisions from closed fingers, (2) puts verifier in IDLE so the abort-on-drop predicate doesn't fire during recovery transit.

**`_pickup_inner` changes:**
- Open closed grippers before planning (belt-and-suspenders guard at the start)
- Replace scattered `go_home` loops with `_recover`

**`_place_inner` changes:**
- Replace `go_home` on failure with `_recover`

## What stays unchanged

- All atomic BT nodes (Layer 1 building blocks) — still exported, still public API
- `pickup(ns)`, `place(ns)` action sequences — unchanged
- `plan_and_execute(ns)` — unchanged
- `full_pickup(ns)`, `full_place(ns)` — now call `pickup`/`place` directly instead of the deleted `*_with_recovery` wrappers
- Between-arm `go_home` in the pickup loop (workspace clearing between attempts, not recovery)
- External API: `robot.pickup()`, `robot.place()` return bool, same contract

## How users compose custom trees

```python
# Layer 1: raw nodes, user handles everything
my_tree = Sequence([
    GenerateGrasps(ns=ns),
    PlanToTSRs(ns=ns),
    Execute(ns=ns),
    Grasp(ns=ns),
])
if not tick_tree(my_tree):
    wave_sadly()  # user's custom recovery
    go_home(robot)

# Layer 2: convenience subtrees, no recovery baked in
tree = full_pickup(ns)  # GenerateGrasps → pickup sequence
if not tick_tree(tree):
    my_custom_recovery()

# Layer 3: just works
robot.pickup("can")  # handles recovery internally
```

## Test plan

- [x] `uv run pytest tests/ -q` → 368 passed
- [x] `uv run ruff check . && uv run ruff format --check .` → clean
- [ ] CI
- [ ] Companion geodude PR (#180) must land with this