### PR TITLE
Safety layer: enforce velocity and acceleration limits (fixes #106)

### DIFF
--- a/src/mj_manipulator/config.py
+++ b/src/mj_manipulator/config.py
@@ -10,8 +10,27 @@ belong in the robot-specific package, not here.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 
 import numpy as np
+
+
+class SafetyResponse(Enum):
+    """How the controller responds to velocity/acceleration limit violations.
+
+    Applied per control cycle inside :meth:`PhysicsController.step`.
+    """
+
+    WARN = "warn"
+    """Log the violation but don't modify the command. Use for debugging."""
+
+    CLAMP = "clamp"
+    """Clamp the command to within limits and log. Default for sim."""
+
+    FAULT = "fault"
+    """Halt the arm (hold current position), set a fault flag, log at
+    ERROR. Matches UR5e protective stop / Franka reflex behavior.
+    Call :meth:`PhysicsController.clear_fault` to resume."""
 
 
 @dataclass
@@ -92,6 +111,7 @@ class PhysicsExecutionConfig:
     velocity_tolerance: float = 0.1  # rad/s
     convergence_timeout_steps: int = 500
     base_settling_steps: int = 50
+    safety_response: SafetyResponse = SafetyResponse.CLAMP
 
     @classmethod
     def tight(cls) -> "PhysicsExecutionConfig":

--- a/src/mj_manipulator/physics_controller.py
+++ b/src/mj_manipulator/physics_controller.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Callable
 import mujoco
 import numpy as np
 
-from mj_manipulator.config import GripperPhysicsConfig, PhysicsExecutionConfig
+from mj_manipulator.config import GripperPhysicsConfig, PhysicsExecutionConfig, SafetyResponse
 
 if TYPE_CHECKING:
     from mj_manipulator.arm import Arm
@@ -49,6 +49,12 @@ class _ArmState:
     target_position: np.ndarray
     target_velocity: np.ndarray
     lookahead: float | None = None  # None = use controller default
+    # Safety layer state
+    prev_target_velocity: np.ndarray | None = None
+    faulted: bool = False
+    first_step: bool = True  # skip accel check on the very first cycle
+    velocity_limits: np.ndarray | None = None
+    acceleration_limits: np.ndarray | None = None
 
 
 @dataclass
@@ -284,6 +290,13 @@ class PhysicsController:
             else:
                 target_pos = arm.get_joint_positions().copy()
 
+            # Cache kinematic limits for the safety layer. Arms without
+            # kinematic_limits (e.g. test mocks) get None → safety check
+            # is skipped for that arm.
+            limits = getattr(arm.config, "kinematic_limits", None)
+            vel_lim = limits.velocity.copy() if limits is not None else None
+            acc_lim = limits.acceleration.copy() if limits is not None else None
+
             self._arms[name] = _ArmState(
                 arm=arm,
                 actuator_ids=np.array(arm.actuator_ids, dtype=np.intp),
@@ -291,6 +304,9 @@ class PhysicsController:
                 joint_qvel_indices=np.array(arm.joint_qvel_indices, dtype=np.intp),
                 target_position=target_pos,
                 target_velocity=np.zeros(arm.dof),
+                prev_target_velocity=np.zeros(arm.dof),
+                velocity_limits=vel_lim,
+                acceleration_limits=acc_lim,
             )
 
             gripper = arm.gripper
@@ -371,6 +387,105 @@ class PhysicsController:
             np.asarray(velocity).copy() if velocity is not None else np.zeros(len(state.actuator_ids))
         )
 
+    # -- Safety layer --------------------------------------------------------
+
+    def _enforce_limits(
+        self,
+        name: str,
+        state: _ArmState,
+        q_cmd: np.ndarray,
+        lookahead: float,
+    ) -> np.ndarray:
+        """Check velocity and acceleration limits, apply the configured response.
+
+        Called once per arm per control cycle, after computing ``q_cmd``
+        and before writing to ``data.ctrl``. Returns (possibly clamped)
+        ``q_cmd``.
+        """
+        if state.velocity_limits is None:
+            return q_cmd
+        if state.faulted:
+            return self.data.qpos[state.joint_qpos_indices].copy()
+
+        response = self.config.safety_response
+        vel = state.target_velocity
+        prev_vel = state.prev_target_velocity
+        vel_limits = state.velocity_limits
+        acc_limits = state.acceleration_limits
+
+        # --- Velocity check ---
+        vel_violation = np.abs(vel) > vel_limits
+        any_vel_violation = np.any(vel_violation)
+
+        # --- Acceleration check ---
+        # Skip on the very first cycle after construction or fault-clear
+        # (prev_velocity is zeros from init, so any nonzero first command
+        # looks like infinite acceleration).
+        any_acc_violation = False
+        accel = np.zeros_like(vel)
+        if acc_limits is not None and prev_vel is not None and not state.first_step:
+            accel = (vel - prev_vel) / self.control_dt
+            acc_violation = np.abs(accel) > acc_limits
+            any_acc_violation = np.any(acc_violation)
+
+        if not any_vel_violation and not any_acc_violation:
+            return q_cmd
+
+        # --- Log the violation ---
+        if any_vel_violation:
+            for j in np.where(vel_violation)[0]:
+                logger.warning(
+                    "Safety: %s joint %d velocity %.2f rad/s exceeds limit %.2f",
+                    name,
+                    j,
+                    vel[j],
+                    vel_limits[j],
+                )
+        if any_acc_violation:
+            for j in np.where(acc_violation)[0]:
+                logger.warning(
+                    "Safety: %s joint %d acceleration %.1f rad/s² exceeds limit %.1f",
+                    name,
+                    j,
+                    accel[j],
+                    acc_limits[j],
+                )
+
+        # --- Apply response ---
+        if response == SafetyResponse.WARN:
+            return q_cmd
+
+        if response == SafetyResponse.FAULT:
+            state.faulted = True
+            state.target_velocity = np.zeros_like(vel)
+            state.target_position = self.data.qpos[state.joint_qpos_indices].copy()
+            logger.error("Safety FAULT: %s halted due to limit violation", name)
+            return state.target_position.copy()
+
+        # CLAMP: limit velocity, then limit acceleration
+        clamped_vel = np.clip(vel, -vel_limits, vel_limits)
+        if acc_limits is not None and prev_vel is not None and not state.first_step:
+            max_delta = acc_limits * self.control_dt
+            delta = clamped_vel - prev_vel
+            clamped_vel = prev_vel + np.clip(delta, -max_delta, max_delta)
+        state.target_velocity = clamped_vel
+        return state.target_position + lookahead * clamped_vel
+
+    def clear_fault(self, arm_name: str) -> None:
+        """Clear fault state for an arm, allowing motion to resume.
+
+        Resets the arm to hold its current position with zero velocity.
+        """
+        if arm_name not in self._arms:
+            raise ValueError(f"Unknown arm: {arm_name}")
+        state = self._arms[arm_name]
+        state.faulted = False
+        state.first_step = True  # skip accel check on the next cycle
+        state.target_position = self.data.qpos[state.joint_qpos_indices].copy()
+        state.target_velocity = np.zeros(len(state.actuator_ids))
+        state.prev_target_velocity = np.zeros(len(state.actuator_ids))
+        logger.info("Safety: %s fault cleared", arm_name)
+
     # -- Physics stepping ---------------------------------------------------
 
     def step(self) -> None:
@@ -380,12 +495,15 @@ class PhysicsController:
         streaming control, use :meth:`step_reactive` instead.
         """
         # Arm actuators: position + velocity feedforward (per-arm lookahead)
-        for state in self._arms.values():
+        for name, state in self._arms.items():
             la = state.lookahead if state.lookahead is not None else self.lookahead_time
             q_cmd = state.target_position + la * state.target_velocity
+            q_cmd = self._enforce_limits(name, state, q_cmd, la)
             self.data.ctrl[state.actuator_ids] = q_cmd
+            state.prev_target_velocity = state.target_velocity.copy()
+            state.first_step = False
 
-        # Entity actuators (bases, etc.): same feedforward
+        # Entity actuators (bases, etc.): same feedforward (no safety layer)
         for state in self._entities.values():
             q_cmd = state.target_position + self.lookahead_time * state.target_velocity
             self.data.ctrl[state.actuator_ids] = q_cmd
@@ -421,7 +539,10 @@ class PhysicsController:
         # Reactive arm: small lookahead
         reactive_lookahead = 2.0 * self.control_dt
         q_cmd = state.target_position + reactive_lookahead * state.target_velocity
+        q_cmd = self._enforce_limits(arm_name, state, q_cmd, reactive_lookahead)
         self.data.ctrl[state.actuator_ids] = q_cmd
+        state.prev_target_velocity = state.target_velocity.copy()
+        state.first_step = False
 
         # Other arms: hold position (no velocity feedforward)
         for other_name, other_state in self._arms.items():

--- a/tests/test_safety_limits.py
+++ b/tests/test_safety_limits.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Tests for the velocity/acceleration safety layer in PhysicsController.
+
+The safety layer enforces kinematic limits at the one chokepoint all
+code paths pass through — the ``step()`` / ``step_reactive()`` methods
+that write to ``data.ctrl``. Three response modes: WARN (log only),
+CLAMP (limit the command), FAULT (halt the arm).
+
+Uses a minimal MuJoCo model with a single revolute joint so the tests
+are fast and don't depend on any robot-specific assets.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import mujoco
+import numpy as np
+import pytest
+
+from mj_manipulator.config import (
+    KinematicLimits,
+    PhysicsExecutionConfig,
+    SafetyResponse,
+)
+from mj_manipulator.physics_controller import PhysicsController
+
+# ---------------------------------------------------------------------------
+# Minimal MuJoCo model: 2-DOF arm with position actuators
+# ---------------------------------------------------------------------------
+
+_MINIMAL_XML = """
+<mujoco>
+  <option timestep="0.001"/>
+  <worldbody>
+    <body>
+      <joint name="j0" type="hinge" axis="0 0 1"/>
+      <geom size="0.05 0.3" type="capsule"/>
+      <body pos="0 0 0.6">
+        <joint name="j1" type="hinge" axis="0 1 0"/>
+        <geom size="0.04 0.2" type="capsule"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <general name="a0" joint="j0" gainprm="100" biastype="affine" biasprm="0 -100 -5"/>
+    <general name="a1" joint="j1" gainprm="100" biastype="affine" biasprm="0 -100 -5"/>
+  </actuator>
+</mujoco>
+"""
+
+
+class _FakeArm:
+    """Minimal arm stub with kinematic limits for safety tests."""
+
+    class _Config:
+        def __init__(self, name, limits):
+            self.name = name
+            self.kinematic_limits = limits
+            self.joint_names = ["j0", "j1"]
+
+    def __init__(self, model, data, *, vel_limit=2.0, acc_limit=20.0):
+        self._model = model
+        self._data = data
+        self.config = self._Config(
+            "test_arm",
+            KinematicLimits(
+                velocity=np.array([vel_limit, vel_limit]),
+                acceleration=np.array([acc_limit, acc_limit]),
+            ),
+        )
+        self.joint_qpos_indices = [0, 1]
+        self.joint_qvel_indices = [0, 1]
+        self.actuator_ids = [0, 1]
+        self.dof = 2
+        self.gripper = None
+
+    def get_joint_positions(self):
+        return self._data.qpos[:2].copy()
+
+
+@pytest.fixture
+def model_and_data():
+    model = mujoco.MjModel.from_xml_string(_MINIMAL_XML)
+    data = mujoco.MjData(model)
+    mujoco.mj_forward(model, data)
+    return model, data
+
+
+@pytest.fixture
+def arm(model_and_data):
+    model, data = model_and_data
+    return _FakeArm(model, data)
+
+
+def _make_controller(model, data, arm, *, safety_response=SafetyResponse.CLAMP):
+    config = PhysicsExecutionConfig(safety_response=safety_response)
+    return PhysicsController(
+        model,
+        data,
+        {"test_arm": arm},
+        config=config,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestNoViolation:
+    def test_small_velocity_passes_through(self, model_and_data, arm):
+        model, data = model_and_data
+        ctrl = _make_controller(model, data, arm)
+        ctrl.set_arm_target("test_arm", np.array([0.1, 0.1]), np.array([1.0, 1.0]))
+        ctrl.step()
+        # q_cmd = 0.1 + 0.1 * 1.0 = 0.2 per joint
+        expected = np.array([0.1 + 0.1 * 1.0, 0.1 + 0.1 * 1.0])
+        np.testing.assert_allclose(data.ctrl[:2], expected, atol=1e-6)
+
+
+class TestVelocityClamp:
+    def test_velocity_clamped(self, model_and_data, arm, caplog):
+        model, data = model_and_data
+        ctrl = _make_controller(model, data, arm)
+        # Command 5.0 rad/s on joint 0, limit is 2.0
+        ctrl.set_arm_target("test_arm", np.array([0.0, 0.0]), np.array([5.0, 1.0]))
+        with caplog.at_level(logging.WARNING):
+            ctrl.step()
+        # Velocity should be clamped to 2.0, q_cmd = 0.0 + 0.1 * 2.0 = 0.2
+        assert data.ctrl[0] == pytest.approx(0.0 + 0.1 * 2.0, abs=1e-6)
+        # Joint 1 is within limits, q_cmd = 0.0 + 0.1 * 1.0 = 0.1
+        assert data.ctrl[1] == pytest.approx(0.0 + 0.1 * 1.0, abs=1e-6)
+        assert "velocity" in caplog.text.lower()
+
+
+class TestAccelerationClamp:
+    def test_acceleration_clamped(self, model_and_data, arm, caplog):
+        model, data = model_and_data
+        ctrl = _make_controller(model, data, arm)
+        # First step: establish a baseline (first_step flag clears)
+        ctrl.set_arm_target("test_arm", np.array([0.0, 0.0]), np.array([0.5, 0.0]))
+        ctrl.step()
+        # Second step: also non-zero, clears first_step
+        ctrl.set_arm_target("test_arm", np.array([0.0, 0.0]), np.array([0.5, 0.0]))
+        ctrl.step()
+        # Third step: velocity jumps from 0.5 to 2.0 (within vel limit)
+        # acceleration = (2.0 - 0.5) / 0.008 = 187.5 rad/s² (exceeds limit of 20)
+        ctrl.set_arm_target("test_arm", np.array([0.0, 0.0]), np.array([2.0, 0.0]))
+        with caplog.at_level(logging.WARNING):
+            ctrl.step()
+        # Acceleration clamped: max_delta = 20.0 * 0.008 = 0.16 rad/s
+        # Clamped velocity = 0.5 + 0.16 = 0.66
+        assert data.ctrl[0] == pytest.approx(0.0 + 0.1 * 0.66, abs=1e-3)
+        assert "acceleration" in caplog.text.lower()
+
+
+class TestWarnMode:
+    def test_warn_does_not_modify_command(self, model_and_data, arm, caplog):
+        model, data = model_and_data
+        ctrl = _make_controller(model, data, arm, safety_response=SafetyResponse.WARN)
+        ctrl.set_arm_target("test_arm", np.array([0.0, 0.0]), np.array([5.0, 5.0]))
+        with caplog.at_level(logging.WARNING):
+            ctrl.step()
+        # Command passes through unclamped: q_cmd = 0.0 + 0.1 * 5.0 = 0.5
+        assert data.ctrl[0] == pytest.approx(0.5, abs=1e-6)
+        assert data.ctrl[1] == pytest.approx(0.5, abs=1e-6)
+        assert "velocity" in caplog.text.lower()
+
+
+class TestFaultMode:
+    def test_fault_halts_arm(self, model_and_data, arm, caplog):
+        model, data = model_and_data
+        ctrl = _make_controller(model, data, arm, safety_response=SafetyResponse.FAULT)
+        ctrl.set_arm_target("test_arm", np.array([0.5, 0.5]), np.array([5.0, 5.0]))
+        with caplog.at_level(logging.ERROR):
+            ctrl.step()
+        # Arm should hold current qpos (≈0, since we haven't moved)
+        assert abs(data.ctrl[0]) < 0.01
+        assert abs(data.ctrl[1]) < 0.01
+        assert "FAULT" in caplog.text
+        # Verify faulted flag
+        state = ctrl._arms["test_arm"]
+        assert state.faulted is True
+
+    def test_faulted_arm_ignores_commands(self, model_and_data, arm):
+        model, data = model_and_data
+        ctrl = _make_controller(model, data, arm, safety_response=SafetyResponse.FAULT)
+        # Trigger fault
+        ctrl.set_arm_target("test_arm", np.array([0.0, 0.0]), np.array([5.0, 5.0]))
+        ctrl.step()
+        # Now send a normal command — should still hold
+        ctrl.set_arm_target("test_arm", np.array([1.0, 1.0]), np.array([0.5, 0.5]))
+        ctrl.step()
+        assert abs(data.ctrl[0]) < 0.01  # still holding ~0
+
+    def test_clear_fault_resumes(self, model_and_data, arm):
+        model, data = model_and_data
+        ctrl = _make_controller(model, data, arm, safety_response=SafetyResponse.FAULT)
+        # Trigger fault
+        ctrl.set_arm_target("test_arm", np.array([0.0, 0.0]), np.array([5.0, 5.0]))
+        ctrl.step()
+        assert ctrl._arms["test_arm"].faulted is True
+        # Clear fault
+        ctrl.clear_fault("test_arm")
+        assert ctrl._arms["test_arm"].faulted is False
+        # Normal command should work
+        ctrl.set_arm_target("test_arm", np.array([0.5, 0.5]), np.array([1.0, 1.0]))
+        ctrl.step()
+        expected = 0.5 + 0.1 * 1.0  # within limits
+        assert data.ctrl[0] == pytest.approx(expected, abs=0.1)
+
+
+class TestNoLimitsConfigured:
+    def test_mock_arm_without_limits_skips_check(self, model_and_data):
+        """Arms without kinematic_limits (test mocks) skip the safety check."""
+        model, data = model_and_data
+
+        class _BareArm:
+            class _Config:
+                name = "bare_arm"
+
+            config = _Config()
+            joint_qpos_indices = [0, 1]
+            joint_qvel_indices = [0, 1]
+            actuator_ids = [0, 1]
+            dof = 2
+            gripper = None
+
+            def get_joint_positions(self):
+                return data.qpos[:2].copy()
+
+        ctrl = _make_controller(model, data, _BareArm())
+        # Extreme velocity — should pass through unchecked
+        ctrl.set_arm_target("test_arm", np.array([0.0, 0.0]), np.array([100.0, 100.0]))
+        ctrl.step()
+        assert data.ctrl[0] == pytest.approx(0.0 + 0.1 * 100.0, abs=1e-6)
+
+
+class TestFirstCycleGraceful:
+    def test_first_step_with_nonzero_velocity(self, model_and_data, arm):
+        """First cycle has prev_velocity=0. A moderate velocity shouldn't
+        trigger acceleration violation if within velocity limits."""
+        model, data = model_and_data
+        # Use tight acceleration limit
+        arm_tight = _FakeArm(model, data, vel_limit=2.0, acc_limit=500.0)
+        ctrl = _make_controller(model, data, arm_tight)
+        ctrl.set_arm_target("test_arm", np.array([0.0, 0.0]), np.array([1.0, 1.0]))
+        ctrl.step()
+        # vel=1.0, accel=1.0/0.008=125 < 500 → no violation
+        assert data.ctrl[0] == pytest.approx(0.0 + 0.1 * 1.0, abs=1e-6)


### PR DESCRIPTION
Single enforcement point for kinematic limits inside PhysicsController. Every code path that moves an arm — trajectory execution, teleop, reactive control, direct \`set_arm_target\` — passes through \`_enforce_limits()\` before writing to \`data.ctrl\`.

## Why

Joint velocity and acceleration limits exist in \`ArmConfig.kinematic_limits\` and are used by TOPP-RA for trajectory retiming, but were **never enforced at execution time**. We already caught teleop commanding 4x the velocity limit (#105). On real hardware (UR5e, Franka), exceeding these limits triggers protective stops that brick the session.

## What it checks

Per joint, per control cycle:
- **Velocity**: \`|target_velocity[j]| > velocity_limits[j]\`
- **Acceleration**: \`|(target_velocity[j] - prev_velocity[j]) / dt| > acceleration_limits[j]\`

## Three response modes

| Mode | Behavior | Default for |
|------|----------|-------------|
| \`CLAMP\` | Limit the command, log warning | Sim (default) |
| \`WARN\` | Log warning, don't modify command | Debugging |
| \`FAULT\` | Halt arm (hold current position), set fault flag | Real hardware |

Configured via \`PhysicsExecutionConfig(safety_response=SafetyResponse.CLAMP)\`.

## First-cycle handling

The very first step after construction or \`clear_fault()\` skips the acceleration check. \`prev_velocity\` is zeros from init, so any nonzero first command would look like infinite acceleration. TOPP-RA trajectories start at zero velocity, so this is always safe.

## Graceful degradation

Arms without \`kinematic_limits\` (test mocks) skip the check entirely via \`getattr\` fallback. All 368 existing tests pass unchanged.

## Tests (9 new)

- No violation passes through unchanged
- Velocity violation: clamped to limit
- Acceleration violation: velocity scaled toward previous
- WARN mode: logged but not modified
- FAULT mode: arm halts, faulted flag set
- Faulted arm ignores commands
- \`clear_fault()\` resumes motion
- No limits configured → check skipped
- First-cycle graceful handling

**377 tests pass (368 + 9), lint + format clean.**

## Test plan

- [x] \`uv run pytest tests/ -q\` → 377 passed
- [x] \`uv run ruff check . && uv run ruff format --check .\` → clean
- [ ] CI
- [ ] Run recycling demo — TOPP-RA trajectories should never trigger violations
- [ ] Manually command over-limit velocity from REPL and verify CLAMP fires