### PR TITLE
E-Stop UI: rename, CLI commands, prompt indicator, logging

### DIFF
--- a/src/mj_manipulator/console.py
+++ b/src/mj_manipulator/console.py
@@ -103,12 +103,8 @@ def start_console(
         gui = viser_viewer._server.gui
 
         # E-Stop / Resume — above tabs so they're always visible
-        estop_btn = gui.add_button(
-            "E-Stop", color="red", icon=_viser.Icon.ALERT_OCTAGON
-        )
-        resume_btn = gui.add_button(
-            "Resume", color="green", icon=_viser.Icon.PLAYER_PLAY, visible=False
-        )
+        estop_btn = gui.add_button("E-Stop", color="red", icon=_viser.Icon.ALERT_OCTAGON)
+        resume_btn = gui.add_button("Resume", color="green", icon=_viser.Icon.PLAYER_PLAY, visible=False)
 
         @estop_btn.on_click
         def _on_estop(event):

--- a/src/mj_manipulator/console.py
+++ b/src/mj_manipulator/console.py
@@ -207,8 +207,9 @@ def start_console(
         # -- IPython shell -----------------------------------------------------
         class _Prompts(Prompts):
             def in_prompt_tokens(self, cli=None):
+                stopped = " E-STOPPED" if robot.is_abort_requested() else ""
                 return [
-                    (Token.Prompt, f"{robot_name} [{mode}] [{self.shell.execution_count}]: "),
+                    (Token.Prompt, f"{robot_name} [{mode}]{stopped} [{self.shell.execution_count}]: "),
                 ]
 
             def out_prompt_tokens(self, cli=None):

--- a/src/mj_manipulator/console.py
+++ b/src/mj_manipulator/console.py
@@ -60,12 +60,22 @@ def start_console(
     mode = "physics" if physics else "kinematic"
 
     # -- Build namespace -------------------------------------------------------
+    def stop():
+        """E-Stop: halt all execution. Call resume() to clear."""
+        robot.request_abort()
+
+    def resume():
+        """Clear E-Stop and allow execution again."""
+        robot.clear_abort()
+
     user_ns: dict = {
         "robot": robot,
         "np": np,
         "pickup": lambda target=None, **kw: pickup(robot, target, **kw),
         "place": lambda dest=None, **kw: place(robot, dest, **kw),
         "go_home": lambda **kw: go_home(robot, **kw),
+        "stop": stop,
+        "resume": resume,
     }
     if extra_ns:
         user_ns.update(extra_ns)
@@ -82,6 +92,8 @@ def start_console(
         f"  pickup('object')  — pick up an object\n"
         f"  place('dest')     — place held object\n"
         f"  go_home()         — return to ready\n"
+        f"  stop()            — E-Stop: halt everything\n"
+        f"  resume()          — clear E-Stop\n"
         f"  robot.<tab>       — tab completion\n"
     )
 

--- a/src/mj_manipulator/console.py
+++ b/src/mj_manipulator/console.py
@@ -59,15 +59,25 @@ def start_console(
 
     mode = "physics" if physics else "kinematic"
 
-    # -- Build namespace -------------------------------------------------------
+    # -- E-Stop / Resume (shared by CLI and browser) ----------------------------
+    _estop_btn = None
+    _resume_btn = None
+
     def stop():
         """E-Stop: halt all execution. Call resume() to clear."""
         robot.request_abort()
+        if _estop_btn is not None:
+            _estop_btn.visible = False
+            _resume_btn.visible = True
 
     def resume():
         """Clear E-Stop and allow execution again."""
         robot.clear_abort()
+        if _estop_btn is not None:
+            _estop_btn.visible = True
+            _resume_btn.visible = False
 
+    # -- Build namespace -------------------------------------------------------
     user_ns: dict = {
         "robot": robot,
         "np": np,
@@ -115,20 +125,11 @@ def start_console(
         gui = viser_viewer._server.gui
 
         # E-Stop / Resume — above tabs so they're always visible
-        estop_btn = gui.add_button("E-Stop", color="red", icon=_viser.Icon.ALERT_OCTAGON)
-        resume_btn = gui.add_button("Resume", color="green", icon=_viser.Icon.PLAYER_PLAY, visible=False)
+        _estop_btn = gui.add_button("E-Stop", color="red", icon=_viser.Icon.ALERT_OCTAGON)
+        _resume_btn = gui.add_button("Resume", color="green", icon=_viser.Icon.PLAYER_PLAY, visible=False)
 
-        @estop_btn.on_click
-        def _on_estop(event):
-            robot.request_abort()
-            estop_btn.visible = False
-            resume_btn.visible = True
-
-        @resume_btn.on_click
-        def _on_resume(event):
-            robot.clear_abort()
-            resume_btn.visible = False
-            estop_btn.visible = True
+        _estop_btn.on_click(lambda _: stop())
+        _resume_btn.on_click(lambda _: resume())
 
         tabs = gui.add_tab_group()
 

--- a/src/mj_manipulator/console.py
+++ b/src/mj_manipulator/console.py
@@ -89,6 +89,7 @@ def start_console(
     viser_viewer = None
     tabs = None
     if viser:
+        import viser as _viser
         from mj_viser import MujocoViewer
 
         viser_viewer = MujocoViewer(
@@ -101,12 +102,25 @@ def start_console(
 
         gui = viser_viewer._server.gui
 
-        # Stop button — above tabs so it's always visible
-        stop_btn = gui.add_button("Stop", color="red")
+        # E-Stop / Resume — above tabs so they're always visible
+        estop_btn = gui.add_button(
+            "E-Stop", color="red", icon=_viser.Icon.ALERT_OCTAGON
+        )
+        resume_btn = gui.add_button(
+            "Resume", color="green", icon=_viser.Icon.PLAYER_PLAY, visible=False
+        )
 
-        @stop_btn.on_click
-        def _on_stop(event):
+        @estop_btn.on_click
+        def _on_estop(event):
             robot.request_abort()
+            estop_btn.visible = False
+            resume_btn.visible = True
+
+        @resume_btn.on_click
+        def _on_resume(event):
+            robot.clear_abort()
+            resume_btn.visible = False
+            estop_btn.visible = True
 
         tabs = gui.add_tab_group()
 

--- a/src/mj_manipulator/console.py
+++ b/src/mj_manipulator/console.py
@@ -63,15 +63,15 @@ def start_console(
     _estop_btn = None
     _resume_btn = None
 
-    def stop():
-        """E-Stop: halt all execution. Call resume() to clear."""
+    def estop():
+        """E-Stop: halt all execution. Call release_estop() to clear."""
         robot.request_abort()
         if _estop_btn is not None:
             _estop_btn.visible = False
             _resume_btn.visible = True
 
-    def resume():
-        """Clear E-Stop and allow execution again."""
+    def release_estop():
+        """Release E-Stop and allow execution again."""
         robot.clear_abort()
         if _estop_btn is not None:
             _estop_btn.visible = True
@@ -84,8 +84,8 @@ def start_console(
         "pickup": lambda target=None, **kw: pickup(robot, target, **kw),
         "place": lambda dest=None, **kw: place(robot, dest, **kw),
         "go_home": lambda **kw: go_home(robot, **kw),
-        "stop": stop,
-        "resume": resume,
+        "estop": estop,
+        "release_estop": release_estop,
     }
     if extra_ns:
         user_ns.update(extra_ns)
@@ -102,8 +102,8 @@ def start_console(
         f"  pickup('object')  — pick up an object\n"
         f"  place('dest')     — place held object\n"
         f"  go_home()         — return to ready\n"
-        f"  stop()            — E-Stop: halt everything\n"
-        f"  resume()          — clear E-Stop\n"
+        f"  estop()           — E-Stop: halt everything\n"
+        f"  release_estop()   — release E-Stop\n"
         f"  robot.<tab>       — tab completion\n"
     )
 
@@ -126,10 +126,10 @@ def start_console(
 
         # E-Stop / Resume — above tabs so they're always visible
         _estop_btn = gui.add_button("E-Stop", color="red", icon=_viser.Icon.ALERT_OCTAGON)
-        _resume_btn = gui.add_button("Resume", color="green", icon=_viser.Icon.PLAYER_PLAY, visible=False)
+        _resume_btn = gui.add_button("Release E-Stop", color="green", icon=_viser.Icon.PLAYER_PLAY, visible=False)
 
-        _estop_btn.on_click(lambda _: stop())
-        _resume_btn.on_click(lambda _: resume())
+        _estop_btn.on_click(lambda _: estop())
+        _resume_btn.on_click(lambda _: release_estop())
 
         tabs = gui.add_tab_group()
 

--- a/src/mj_manipulator/console.py
+++ b/src/mj_manipulator/console.py
@@ -216,7 +216,7 @@ def start_console(
                 ]
 
         shell = InteractiveShellEmbed(
-            header=banner,
+            banner1=banner,
             user_ns=user_ns,
             colors="neutral",
         )

--- a/src/mj_manipulator/primitives.py
+++ b/src/mj_manipulator/primitives.py
@@ -38,6 +38,14 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+def _estop_active(robot) -> bool:
+    """Check if E-Stop is active. Logs a warning so the user knows why the primitive was skipped."""
+    if robot.is_abort_requested():
+        logger.warning("⛔ E-Stop is active — command ignored. Click Resume to clear.")
+        return True
+    return False
+
+
 def _tick_tree(root: py_trees.behaviour.Behaviour, verbose: bool = False) -> bool:
     """Reset and tick a tree to completion. Returns True if SUCCESS."""
     for node in root.iterate():
@@ -342,7 +350,7 @@ def pickup(
     if ctx is None:
         raise RuntimeError("No active execution context. Use 'with robot.sim() as ctx:'")
 
-    if robot.is_abort_requested():
+    if _estop_active(robot):
         return False
     try:
         return _pickup_inner(robot, ctx, target, arm=arm, verbose=verbose)
@@ -454,7 +462,7 @@ def place(
             logger.warning("Place failed: no arm is holding an object")
             return False
 
-    if robot.is_abort_requested():
+    if _estop_active(robot):
         return False
     try:
         return _place_inner(robot, ctx, destination, arm=arm, verbose=verbose)
@@ -521,7 +529,7 @@ def go_home(
     if ctx is None:
         raise RuntimeError("No active execution context. Use 'with robot.sim() as ctx:'")
 
-    if robot.is_abort_requested():
+    if _estop_active(robot):
         return False
     try:
         return _go_home_inner(robot, ctx, arm=arm, verbose=verbose)

--- a/src/mj_manipulator/robot.py
+++ b/src/mj_manipulator/robot.py
@@ -25,11 +25,14 @@ Usage::
 
 from __future__ import annotations
 
+import logging
 import threading
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 import mujoco
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from mj_manipulator.arm import Arm
@@ -159,11 +162,15 @@ class RobotBase:
     # -- Abort -----------------------------------------------------------------
 
     def request_abort(self):
+        if not self._abort_event.is_set():
+            logger.warning("⛔ E-Stop activated — all execution halted")
         if self._context is not None and hasattr(self._context, "ownership") and self._context.ownership is not None:
             self._context.ownership.abort_all()
         self._abort_event.set()
 
     def clear_abort(self):
+        if self._abort_event.is_set():
+            logger.info("✓ E-Stop cleared — resuming")
         if self._context is not None and hasattr(self._context, "ownership") and self._context.ownership is not None:
             self._context.ownership.clear_all()
         self._abort_event.clear()

--- a/src/mj_manipulator/robot.py
+++ b/src/mj_manipulator/robot.py
@@ -170,7 +170,7 @@ class RobotBase:
 
     def clear_abort(self):
         if self._abort_event.is_set():
-            logger.info("✓ E-Stop cleared — resuming")
+            logger.warning("✓ E-Stop cleared — resuming")
         if self._context is not None and hasattr(self._context, "ownership") and self._context.ownership is not None:
             self._context.ownership.clear_all()
         self._abort_event.clear()


### PR DESCRIPTION
## Summary
- Rename global "Stop" button to **E-Stop** (`ALERT_OCTAGON` icon), with **Release E-Stop** button to clear
- Add `estop()` and `release_estop()` CLI commands — browser buttons and CLI stay in sync
- Show **E-STOPPED** in the IPython prompt when active
- Log activation, clearing, and blocked commands at WARNING level
- `_estop_active()` helper replaces bare `is_abort_requested()` checks in pickup/place/go_home
- Fix `banner1` (was `header`) so startup banner always shows

Closes personalrobotics/mj_viser#22

## Test plan
- [ ] Launch console — verify banner shows with `estop()` / `release_estop()` listed
- [ ] `estop()` in CLI → prompt shows `E-STOPPED`, browser swaps to Release button
- [ ] Click Release E-Stop in browser → prompt clears, E-Stop button reappears
- [ ] `robot.pickup()` while E-STOPPED → warning logged, returns False
- [ ] `release_estop()` → works again

🤖 Generated with [Claude Code](https://claude.com/claude-code)