### PR TITLE
Franka: place grasp_site at hand forward edge (fixes #129)

### DIFF
--- a/scripts/visualize_grasps.py
+++ b/scripts/visualize_grasps.py
@@ -161,15 +161,17 @@ GRIPPERS: dict[str, GripperSpec] = {
         grasp_site_name="grasp_site",
     ),
     "franka": GripperSpec(
-        # Franka hand.xml has no site. Palm is at [0,0,0.0584] relative
-        # to the hand body (finger-joint origin). Hand frame already has
-        # z=approach, y=opening, so identity rotation.
+        # Franka hand.xml has no site. Palm = forward edge of the hand
+        # body (the metal collar) = hand + [0, 0, 0.0753] = finger-joint
+        # origin + 17 mm forward. Hand frame already has z=approach,
+        # y=opening, so identity rotation. Must match add_franka_ee_site
+        # in arms/franka.py exactly.
         xml_path_resolver=_franka_hand_xml,
         hand_type="franka",
         add_grasp_site=True,
         grasp_site_name="grasp_site",
         grasp_site_base_body="hand",
-        grasp_site_pos=(0.0, 0.0, 0.0584),
+        grasp_site_pos=(0.0, 0.0, 0.0753),  # = FrankaHand.PALM_OFFSET_FROM_HAND
         grasp_site_quat=(1.0, 0.0, 0.0, 0.0),
         # Open the fingers for visualization (default qpos leaves them
         # closed, which is unhelpful for eyeballing aperture).

--- a/src/mj_manipulator/arms/franka.py
+++ b/src/mj_manipulator/arms/franka.py
@@ -151,24 +151,34 @@ def add_franka_ee_site(
     """Add a grasp_site to the Franka hand body in an MjSpec.
 
     The site is placed at the canonical TSR EE frame (z=approach toward
-    fingertips, y=finger-opening). The Franka hand frame already has this
-    orientation, so no rotation is needed — only a position offset.
+    fingertips, y=finger-opening). The Franka hand frame already has
+    this orientation, so no rotation is needed — only a position offset.
 
-    The default position [0, 0, 0.0584] is the finger-joint origin (palm),
-    matching the TSR convention used by FrankaHand: EE at the palm so that
-    finger_length (44.5 mm) gives the correct fingertip standoff.
+    The default position is ``[0, 0, FrankaHand.PALM_OFFSET_FROM_HAND]``
+    = ``[0, 0, 0.0753]`` — the forward edge of the ``hand`` body's
+    collision mesh (the metal collar around the finger mounts). That
+    matches the TSR convention: EE at the palm where the finger
+    mechanism attaches, nothing except fingers forward of it.
 
-    Call this before compiling the spec if the Franka model doesn't have
-    an EE site (the menagerie model doesn't include one).
+    Before this was aligned with the 2F-85 convention (#129), the
+    default was ``[0, 0, 0.0584]`` (the finger-joint origin), which
+    buried the grasp_site inside the 17 mm-deep collar and caused
+    deep-grasp TSR templates to drive the collar into the object. See
+    ``docs/grippers.md`` §1 for the palm–housing story.
+
+    Call this before compiling the spec if the Franka model doesn't
+    have an EE site (the menagerie model doesn't include one).
 
     Args:
         spec: MjSpec loaded from a Franka scene XML.
-        site_name: Name for the new site (default: "grasp_site").
-        pos: Position relative to hand body. Defaults to [0, 0, 0.0584]
-             (finger-joint origin = palm, 44.5 mm from fingertip contact).
+        site_name: Name for the new site (default: ``"grasp_site"``).
+        pos: Position relative to hand body. Defaults to the new
+            palm convention ``[0, 0, 0.0753]`` (collar forward edge).
     """
     if pos is None:
-        pos = [0.0, 0.0, 0.0584]
+        from tsr.hands import FrankaHand
+
+        pos = [0.0, 0.0, FrankaHand.PALM_OFFSET_FROM_HAND]
     hand = spec.worldbody.find_child("hand")
     site = hand.add_site()
     site.name = site_name


### PR DESCRIPTION
## Summary

Paired with personalrobotics/tsr#48 (FrankaHand FL 0.054 → 0.037, adds \`PALM_OFFSET_FROM_HAND = 0.0753\`). Both changes must land together.

Symmetrical fix to PR #128's Robotiq2F85 work. The menagerie Franka hand's \`hand\` body extends 16.9 mm past the finger-joint origin along the approach axis (the metal collar around the finger mounts). Our previous default placed \`grasp_site\` at \`[0, 0, 0.0584]\` (the finger-joint origin), which buried it inside the collar. TSR's deep-grasp templates then drove the collar into the object — 33 % of sampled grasps in collision.

## Changes

- \`add_franka_ee_site\` default \`pos\` changes from \`[0, 0, 0.0584]\` to \`[0, 0, FrankaHand.PALM_OFFSET_FROM_HAND]\` (= \`[0, 0, 0.0753]\`). Reads from the TSR class constant so the value has a single source of truth.
- \`scripts/visualize_grasps.py\` registry entry for \`franka\` updated to match so the viz and validator exercise the fixed setup.

## Net motion change

Zero. Palm moves forward 17 mm, \`FINGER_LENGTH\` shrinks by 17 mm — fingertip world pose stays identical, only the *label* "palm" on the gripper moves. The arm's IK retracts the flange by 17 mm to put the new grasp_site at the same world location as the old one.

## Verification

Automated:

| | Before | After |
|---|---|---|
| \`validate_gripper.py --gripper franka\` | 100/300 = 33.3% | **0/300 = 0.0% ✓** |
| \`validate_gripper.py --gripper robotiq_2f85\` | PASS ✓ | PASS ✓ (unchanged) |
| \`validate_gripper.py --gripper robotiq_2f140\` | PASS ✓ | PASS ✓ (unchanged) |
| 403 mj_manipulator pytests | pass | pass |
| ruff check / format --check | clean | clean |

Integration:
- \`build_franka_robot(scene)\` instantiates cleanly with the new offset.
- Franka recycling demo should continue working as-is (net motion unchanged).

## Merge ordering

1. Merge personalrobotics/tsr#48 first (so \`FrankaHand.PALM_OFFSET_FROM_HAND\` is on tsr main).
2. Then this PR.

Fixes #129.