### PR TITLE
validate_gripper: move 2F-140 out, add graceful skip (fixes #130)

### DIFF
--- a/scripts/validate_gripper.py
+++ b/scripts/validate_gripper.py
@@ -169,7 +169,20 @@ def _sweep(spec, obj, model, data, ids, samples_per_template: int, rng_seed: int
 def validate(gripper_name: str, object_name: str, samples: int, seed: int) -> bool:
     spec = vg.GRIPPERS[gripper_name]
     obj = vg.load_object(object_name)
-    model, data, ids = vg.build_scene(spec, obj)
+    try:
+        model, data, ids = vg.build_scene(spec, obj)
+    except (FileNotFoundError, ModuleNotFoundError) as e:
+        # The gripper's XML resolver couldn't find its model. Common
+        # cause: the gripper lives in another workspace package (e.g.
+        # geodude_assets) that isn't installed in this environment.
+        # Skip gracefully rather than crashing the whole --all run.
+        banner = f" {gripper_name} × {object_name} "
+        print(f"\n{banner:=^70}")
+        print(f"\nSKIPPED: couldn't load gripper model — {type(e).__name__}: {e}")
+        print("  Cause: the resolver in visualize_grasps.GRIPPERS can't locate its XML.")
+        print("  Either install the package owning the model, or run this validator")
+        print("  from the workspace that does (e.g. geodude/scripts/validate_2f140.py).")
+        return True  # Not a failure — we just couldn't evaluate this gripper.
 
     # Declared params from the TSR hand class.
     from mj_manipulator.grasp_sources.prl_assets import _get_hand

--- a/scripts/visualize_grasps.py
+++ b/scripts/visualize_grasps.py
@@ -123,20 +123,28 @@ def _2f85_xml() -> Path:
     return find_menagerie() / "robotiq_2f85" / "2f85.xml"
 
 
-def _2f140_xml() -> Path:
-    # geodude_assets 2F-140 is the only one we have; no menagerie equivalent.
-    import importlib
-
-    ga = importlib.import_module("geodude_assets")
-    return Path(ga.__file__).parent / "models" / "robotiq_2f140" / "2f140.xml"
-
-
 def _franka_hand_xml() -> Path:
     from mj_manipulator.menagerie import find_menagerie
 
     return find_menagerie() / "franka_emika_panda" / "hand.xml"
 
 
+# Registry of gripper specs the visualizer / validator can target.
+#
+# This is a plain mutable dict so downstream packages can register
+# their own grippers without forking this file:
+#
+#     import visualize_grasps as vg
+#     vg.GRIPPERS["my_gripper"] = vg.GripperSpec(
+#         xml_path_resolver=lambda: Path("/path/to/my_gripper.xml"),
+#         hand_type="my_gripper",
+#         ...
+#     )
+#
+# Bundled entries only reference packages mj_manipulator already
+# depends on (mujoco_menagerie). Grippers that live in other
+# workspace packages (e.g. the geodude_assets 2F-140) are registered
+# by those packages — see geodude/scripts/validate_2f140.py.
 GRIPPERS: dict[str, GripperSpec] = {
     "robotiq_2f85": GripperSpec(
         xml_path_resolver=_2f85_xml,
@@ -151,14 +159,6 @@ GRIPPERS: dict[str, GripperSpec] = {
         # iiwa14_setup.py's grasp_site definition exactly.
         grasp_site_pos=(0.0, 0.0, 0.094),  # = Robotiq2F85.PALM_OFFSET_FROM_BASE_MOUNT
         grasp_site_quat=(0.7071, 0.0, 0.0, -0.7071),
-    ),
-    "robotiq_2f140": GripperSpec(
-        # grasp_site is already baked into the geodude_assets 2f140.xml
-        # at pos=[0,0,0.1] with the same -90° z rotation.
-        xml_path_resolver=_2f140_xml,
-        hand_type="robotiq_2f140",
-        add_grasp_site=False,
-        grasp_site_name="grasp_site",
     ),
     "franka": GripperSpec(
         # Franka hand.xml has no site. Palm is at [0,0,0.0584] relative


### PR DESCRIPTION
## Summary

\`scripts/validate_gripper.py --all\` crashed with \`ModuleNotFoundError: No module named 'geodude_assets'\` in mj_manipulator-only environments because the 2F-140 entry in the \`GRIPPERS\` registry lazily imported \`geodude_assets\` inside its XML resolver. This is an architectural layering bug — mj_manipulator shouldn't reference a workspace-only sibling package, not even optionally.

Two coordinated changes fix it.

### 1. Remove 2F-140 from mj_manipulator's registry

The 2F-140 model lives in \`geodude_assets\`. It shouldn't appear in mj_manipulator's \`GRIPPERS\` dict. Removed the entry and the \`_2f140_xml()\` resolver. Added a comment documenting \`GRIPPERS\` as a mutable registration point for downstream packages.

Companion: a new \`geodude/scripts/validate_2f140.py\` (separate PR against geodude) registers the 2F-140 at runtime and delegates to the same \`validate(...)\` function. That's where the dependency on \`geodude_assets\` belongs — in the package that actually ships the model.

### 2. Graceful skip for missing XMLs

\`validate()\` now wraps \`build_scene\` in a \`try\` / \`except (FileNotFoundError, ModuleNotFoundError)\`. If a gripper's resolver fails, it prints a SKIPPED message and returns True (not a failure — we just couldn't evaluate this gripper). Keeps \`--all\` going across any third-party registrations that may break in a given environment.

## Verification

\`\`\`
$ uv run python scripts/validate_gripper.py --all
=== franka × can ===
  ✗ overall: 300/300 = 100.0%  (pending #129 fix)
=== robotiq_2f85 × can ===
  ✓ overall: 0/300 = 0.0%
======================================================================
\`\`\`

No crash — before it would abort on the 2F-140 entry.

Graceful-skip path also verified with a synthetic broken resolver:

\`\`\`
=== bogus × can ===
SKIPPED: couldn't load gripper model — ModuleNotFoundError: No module named 'pretend_missing_package'
\`\`\`

- 403 pytests pass
- ruff check / format --check clean

## Related

- personalrobotics/geodude (new PR) — adds \`geodude/scripts/validate_2f140.py\` so the 2F-140 can still be validated end-to-end from the geodude-side tooling.

Fixes #130.