### PR TITLE
Fix CartesianController physics mode: integrate internal q_ref (fixes #84)

### DIFF
--- a/src/mj_manipulator/cartesian.py
+++ b/src/mj_manipulator/cartesian.py
@@ -517,6 +517,7 @@ class CartesianController:
         self.grasp_manager = grasp_manager
         self._default_step_fn = step_fn
         self._q_dot_prev: np.ndarray | None = None
+        self._q_ref: np.ndarray | None = None
 
     @classmethod
     def from_arm(
@@ -542,8 +543,14 @@ class CartesianController:
         )
 
     def reset(self) -> None:
-        """Clear warm-start state. Call before starting a new motion."""
+        """Clear warm-start and internal reference state.
+
+        Call before starting a new motion direction. The internal
+        position reference (``_q_ref``) is lazily re-initialized from
+        ``data.qpos`` on the next ``step()`` call.
+        """
         self._q_dot_prev = None
+        self._q_ref = None
 
     def step(
         self,
@@ -553,11 +560,21 @@ class CartesianController:
     ) -> TwistStepResult:
         """Execute one Cartesian control step.
 
-        Computes joint velocities to achieve the desired twist, writes new
-        joint positions to ``data.qpos``, and updates warm-start state.
+        Computes joint velocities to achieve the desired twist, integrates
+        them into an internal position reference, and hands that reference
+        to the step function (PD target in physics mode, direct qpos in
+        kinematic mode).
+
+        The internal reference (``_q_ref``) is what makes physics mode
+        work: instead of re-reading the PD-lagged ``data.qpos`` every
+        cycle (which never accumulates more than one step of lead), the
+        reference integrates forward over time so the PD target keeps
+        marching ahead. The Jacobian is still computed at the *actual*
+        physics state (``data.qpos``), so the twist-to-joint-velocity
+        mapping reflects the real configuration.
 
         For teleop: call this once per control cycle from your loop. The
-        simulator (``mj_forward`` / ``mj_step``) handles kinematics update.
+        simulator (``mj_forward`` / ``mj_step``) handles kinematics.
 
         Args:
             twist: 6D desired twist [vx, vy, vz, wx, wy, wz].
@@ -567,7 +584,16 @@ class CartesianController:
         Returns:
             TwistStepResult with joint velocities and diagnostics.
         """
-        q_new, result = step_twist(
+        # Lazily seed the internal reference from the current physics state.
+        if self._q_ref is None:
+            self._q_ref = np.array([self.data.qpos[idx] for idx in self.joint_qpos_indices])
+
+        # step_twist computes the Jacobian at data.qpos (the actual
+        # physics state) so the linearization is correct. We only use
+        # the joint_velocities from the result — the q_new it returns
+        # is data.qpos + qd*dt, which we DON'T want (that's the old
+        # closed-loop-against-lagged-state bug).
+        _, result = step_twist(
             model=self.model,
             data=self.data,
             ee_site_id=self.ee_site_id,
@@ -584,14 +610,25 @@ class CartesianController:
         )
         self._q_dot_prev = result.joint_velocities
 
+        # Integrate the INTERNAL reference forward — this is the key fix.
+        # In kinematic mode this is equivalent to the old behaviour (qpos
+        # is written directly, so data.qpos == _q_ref after step_fn). In
+        # physics mode, _q_ref accumulates the intended position over time
+        # rather than being reset to the PD-lagged state each cycle.
+        self._q_ref = np.clip(
+            self._q_ref + result.joint_velocities * dt,
+            self.q_min,
+            self.q_max,
+        )
+
         # Route through step function (ctx.step_cartesian in physics mode,
         # direct qpos write + mj_forward in kinematic mode)
         step_fn = self._default_step_fn
         if step_fn is not None:
-            step_fn(q_new, result.joint_velocities)
+            step_fn(self._q_ref.copy(), result.joint_velocities)
         else:
             for i, idx in enumerate(self.joint_qpos_indices):
-                self.data.qpos[idx] = q_new[i]
+                self.data.qpos[idx] = self._q_ref[i]
             mujoco.mj_forward(self.model, self.data)
             if self.grasp_manager is not None:
                 self.grasp_manager.update_attached_poses(self.data)

--- a/tests/test_cartesian.py
+++ b/tests/test_cartesian.py
@@ -675,3 +675,181 @@ class TestCartesianController:
         assert result.success
         assert result.terminated_by == "contact"
         assert result.contact_geom == "obstacle"
+
+
+# ---------------------------------------------------------------------------
+# Physics-mode regression test for #84: internal q_ref integration
+# ---------------------------------------------------------------------------
+
+# 2-DOF arm WITH actuators so we can run physics mode (mj_step).
+_PHYSICS_CART_XML = """
+<mujoco model="test_cartesian_physics">
+  <option gravity="0 0 0"/>
+  <worldbody>
+    <body name="link1" pos="0 0 0.5">
+      <joint name="joint1" type="hinge" axis="0 0 1"
+             range="-3.14 3.14" damping="0.1"/>
+      <geom name="link1_geom" type="capsule" size="0.04"
+            fromto="0 0 0 0.3 0 0"/>
+      <body name="link2" pos="0.3 0 0">
+        <joint name="joint2" type="hinge" axis="0 1 0"
+               range="-3.14 3.14" damping="0.1"/>
+        <geom name="link2_geom" type="capsule" size="0.04"
+              fromto="0 0 0 0.3 0 0"/>
+        <site name="ee_site" pos="0.3 0 0"/>
+      </body>
+    </body>
+  </worldbody>
+  <actuator>
+    <position name="act1" joint="joint1" kp="500" kv="50"/>
+    <position name="act2" joint="joint2" kp="500" kv="50"/>
+  </actuator>
+</mujoco>
+"""
+
+
+class TestCartesianControllerPhysicsMode:
+    """Regression tests for #84: CartesianController in physics mode.
+
+    The old code re-read data.qpos every cycle, which in physics mode
+    is the PD-lagged state — the target never accumulated more than one
+    step of lead, so the arm barely moved. The fix adds an internal
+    q_ref that integrates forward independently of the physics lag.
+    """
+
+    @pytest.fixture
+    def physics_setup(self):
+        model = mujoco.MjModel.from_xml_string(_PHYSICS_CART_XML)
+        data = mujoco.MjData(model)
+        mujoco.mj_forward(model, data)
+
+        qpos_idx = []
+        qvel_idx = []
+        for name in JOINT_NAMES:
+            jid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
+            qpos_idx.append(int(model.jnt_qposadr[jid]))
+            qvel_idx.append(int(model.jnt_dofadr[jid]))
+        ee_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SITE, "ee_site")
+
+        return model, data, qpos_idx, qvel_idx, ee_id
+
+    def _make_physics_step_fn(self, model, data, qpos_idx):
+        """Return a step_fn that writes PD targets and runs mj_step."""
+        n_substeps = int(0.008 / model.opt.timestep)
+
+        def step_fn(q_target, qd_target):
+            # Write position targets to actuator ctrl
+            for i, idx in enumerate(qpos_idx):
+                aid = i  # act1, act2 map to joint1, joint2
+                data.ctrl[aid] = q_target[i]
+            for _ in range(n_substeps):
+                mujoco.mj_step(model, data)
+
+        return step_fn
+
+    def test_move_produces_correct_direction(self, physics_setup):
+        """EE should move in the commanded direction, not drift or reverse.
+
+        This is the core #84 regression: the old code produced *wrong-
+        direction* motion in physics mode because the PD target never
+        accumulated past one step of lead.
+        """
+        model, data, qpos_idx, qvel_idx, ee_id = physics_setup
+        dt = 0.008
+        step_fn = self._make_physics_step_fn(model, data, qpos_idx)
+
+        controller = CartesianController(
+            model,
+            data,
+            ee_id,
+            qpos_idx,
+            qvel_idx,
+            q_min=np.array([-3.14, -3.14]),
+            q_max=np.array([3.14, 3.14]),
+            qd_max=np.array([2.0, 2.0]),
+            config=CartesianControlConfig(length_scale=10.0, min_progress=0.0),
+            step_fn=step_fn,
+        )
+
+        # Record start EE position
+        start_pos = data.site_xpos[ee_id].copy()
+
+        # Command +y twist for 1 second
+        twist = np.array([0, 0.05, 0, 0, 0, 0])
+        n_steps = int(1.0 / dt)
+        for _ in range(n_steps):
+            controller.step(twist, dt)
+
+        end_pos = data.site_xpos[ee_id].copy()
+        displacement = end_pos - start_pos
+
+        # The EE should have moved primarily in +y.
+        # With PD lag we won't get the full 50 mm, but we should get
+        # at least 60% of it and definitely in the right direction.
+        y_travel = displacement[1]
+        assert y_travel > 0.025, (
+            f"EE should move in +y but traveled only {y_travel * 1000:.1f} mm. "
+            f"Full displacement: {displacement * 1000} mm. "
+            f"This is the #84 regression — the old code would produce ~0 or negative y travel."
+        )
+
+    def test_q_ref_accumulates_ahead_of_physics(self, physics_setup):
+        """The internal _q_ref should lead data.qpos after several steps."""
+        model, data, qpos_idx, qvel_idx, ee_id = physics_setup
+        dt = 0.008
+        step_fn = self._make_physics_step_fn(model, data, qpos_idx)
+
+        controller = CartesianController(
+            model,
+            data,
+            ee_id,
+            qpos_idx,
+            qvel_idx,
+            q_min=np.array([-3.14, -3.14]),
+            q_max=np.array([3.14, 3.14]),
+            qd_max=np.array([2.0, 2.0]),
+            config=CartesianControlConfig(length_scale=10.0, min_progress=0.0),
+            step_fn=step_fn,
+        )
+
+        twist = np.array([0, 0.05, 0, 0, 0, 0])
+        for _ in range(50):
+            controller.step(twist, dt)
+
+        # _q_ref should be ahead of data.qpos (PD hasn't caught up)
+        q_actual = np.array([data.qpos[idx] for idx in qpos_idx])
+        q_ref = controller._q_ref
+        gap = np.linalg.norm(q_ref - q_actual)
+        assert gap > 1e-4, (
+            f"q_ref should lead data.qpos by a PD-lag gap but gap={gap:.6f}. q_ref={q_ref}, q_actual={q_actual}"
+        )
+
+    def test_kinematic_mode_unchanged(self, physics_setup):
+        """In kinematic mode (no step_fn), behaviour should be identical.
+
+        _q_ref == data.qpos after each step because we write directly.
+        """
+        model, data, qpos_idx, qvel_idx, ee_id = physics_setup
+
+        controller = CartesianController(
+            model,
+            data,
+            ee_id,
+            qpos_idx,
+            qvel_idx,
+            q_min=np.array([-3.14, -3.14]),
+            q_max=np.array([3.14, 3.14]),
+            qd_max=np.array([2.0, 2.0]),
+            config=CartesianControlConfig(length_scale=10.0, min_progress=0.0),
+            # No step_fn → kinematic mode (writes qpos directly)
+        )
+
+        twist = np.array([0, 0.05, 0, 0, 0, 0])
+        for _ in range(20):
+            controller.step(twist, 0.004)
+
+        q_actual = np.array([data.qpos[idx] for idx in qpos_idx])
+        q_ref = controller._q_ref
+        assert np.allclose(q_ref, q_actual, atol=1e-10), (
+            f"In kinematic mode, q_ref should exactly equal data.qpos. gap={np.linalg.norm(q_ref - q_actual):.2e}"
+        )


### PR DESCRIPTION
## Summary

\`CartesianController.step()\` re-read \`data.qpos\` every cycle. In physics mode that's the PD-lagged state — the target never accumulated more than one step of lead, so the arm barely moved (or moved in the wrong direction as uncommanded joint drift dominated). Detailed in #84 with repro, root-cause analysis, and open-loop confirmation.

## Fix

Add an internal \`_q_ref\` that integrates forward independently of the physics lag:

\`\`\`python
if self._q_ref is None:
    self._q_ref = read from data.qpos  # seed once
_, result = step_twist(...)             # Jacobian at actual physics state
self._q_ref += result.joint_velocities * dt   # integrate the ref
step_fn(self._q_ref, ...)              # hand off to PD
\`\`\`

- **Physics mode**: \`_q_ref\` marches ahead; PD chases it. Arm moves in the correct direction at the correct speed (minus PD lag).
- **Kinematic mode**: \`step_fn\` writes qpos directly, so \`_q_ref == data.qpos\` after each step. Identical to the old behaviour.

## Tests

Three new regression tests in \`TestCartesianControllerPhysicsMode\` (2-DOF arm with PD position actuators, zero gravity):

| Test | What it checks |
|---|---|
| \`test_move_produces_correct_direction\` | Command +y twist for 1s via PD; assert EE moved >25 mm in +y (old code: ~0 or negative) |
| \`test_q_ref_accumulates_ahead_of_physics\` | After 50 steps, \`_q_ref\` leads \`data.qpos\` by a measurable gap |
| \`test_kinematic_mode_unchanged\` | In kinematic mode, \`_q_ref == data.qpos\` exactly (no regression) |

## Verification

- 406 tests pass (+3 new)
- ruff check + format clean
- Existing kinematic-mode tests all pass unchanged

Fixes #84.