### PR TITLE
Remove bilateral contact heuristic (fixes #80, #83)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -67,7 +67,7 @@ mj_manipulator/
     arm.py              # Generic Arm (FK, IK, planning, execution)
     adapters.py         # pycbirrt RobotModel/IKSolver/CollisionChecker adapters
     collision.py        # Unified grasp-aware CollisionChecker
-    grasp_manager.py    # GraspManager + detect_grasped_object
+    grasp_manager.py    # GraspManager + find_contacted_object
     cartesian.py        # QP solver, twist control, move_until_touch, execute_twist
     executor.py         # KinematicExecutor, PhysicsExecutor (sim-specific)
     controller.py       # PhysicsController (sim-specific, multi-arm physics stepping)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@
 
 - `safe_retract` no longer uses `CartesianController.move`; it's now IK-based via `plan_cartesian_path`. Signature unchanged but internal behaviour differs. (#121)
 
-- `detect_grasped_object` (bilateral contact heuristic) is deprecated in favour of `GraspVerifier`. Still present but logged as a warning. (#80, #83)
+- `detect_grasped_object` (bilateral contact heuristic) removed and replaced with `find_contacted_object` (simple contact-count, no finger groups). `GraspVerifier` handles all post-grasp validation. (#80, #83)
 
 - Teleop position step now derived from `arm.config.kinematic_limits.velocity * dt`, no longer a separate `max_joint_step` constant. (#105)
 
@@ -84,4 +84,4 @@
 
 - `CartesianController` in physics mode works correctly now (#84 fix) but accumulates drift if the physical state diverges far from `_q_ref` (e.g., external collision). Call `reset()` before changing direction.
 - Franka hand aperture is tight for 66 mm cans (~5 mm clearance per side). (#132)
-- Bilateral contact fallback (`detect_grasped_object`) is deprecated but not yet removed. (#80, #83)
+- Nameless grasp path (`find_contacted_object`) is sim-only; on hardware, perception identifies the object after close.

--- a/docs/grasp-aware-collision.md
+++ b/docs/grasp-aware-collision.md
@@ -149,7 +149,7 @@ This allows contacts with fingers, pads, and other gripper parts while still fla
 
 The BT and primitives path always passes an explicit object name to `ctx.arm().grasp("can_0")` — the caller knows what they're grasping. After close, the `GraspVerifier` confirms the hold using `LoadSignal` readings (gripper position, wrist F/T, joint torques). This works identically on sim and hardware.
 
-For the nameless interactive path (REPL `arm.grasp()` with no argument, or the teleop gripper button), the internal helper `mj_manipulator.grasp_manager.detect_grasped_object` uses MuJoCo contact inspection to identify what landed between the fingers. This is sim-only; on hardware the equivalent is a post-close perception query (see `HardwarePerceptionService` in `mj_manipulator_ros`).
+For the nameless interactive path (REPL `arm.grasp()` with no argument, or the teleop gripper button), the internal helper `mj_manipulator.grasp_manager.find_contacted_object` uses MuJoCo contact counting to identify the object with the most gripper contacts. This is sim-only; on hardware the equivalent is a post-close perception query (see `HardwarePerceptionService` in `mj_manipulator_ros`).
 
 ## Reactive Cartesian Control
 

--- a/src/mj_manipulator/grasp_manager.py
+++ b/src/mj_manipulator/grasp_manager.py
@@ -166,133 +166,60 @@ class GraspManager:
         data.qpos[qpos_adr + 3 : qpos_adr + 7] = quat
 
 
-def detect_grasped_object(
+def find_contacted_object(
     model: mujoco.MjModel,
     data: mujoco.MjData,
     gripper_body_names: list[str],
     candidate_objects: list[str] | None = None,
-    require_bilateral: bool = True,
-    finger_groups: dict[str, list[str]] | None = None,
-    debug: bool = False,
 ) -> str | None:
-    """Detect which object (if any) is being grasped by the gripper.
+    """Find the object with the most gripper contacts (sim only).
 
-    Checks MuJoCo contacts to find objects in contact with gripper bodies.
-    For realistic grasp detection, requires bilateral contact (both finger
-    groups touching the object).
+    Simple contact-count heuristic for the nameless grasp path
+    (REPL / teleop "close the gripper on whatever is there"). The
+    BT / primitives path always passes an explicit object name and
+    uses ``GraspVerifier`` for post-grasp validation. On hardware,
+    the nameless path is identified by ``PerceptionService`` after
+    gripper close.
 
     Args:
         model: MuJoCo model.
-        data: MuJoCo data (after mj_forward).
+        data: MuJoCo data (after ``mj_forward``).
         gripper_body_names: All gripper body names (pads, fingers, etc.).
         candidate_objects: Optional filter — only consider these objects.
-        require_bilateral: If True, requires contact with both finger groups.
-        finger_groups: Mapping of group name to body names for bilateral
-            detection. Example: ``{"left": ["gripper/left_pad"],
-            "right": ["gripper/right_pad"]}``. If None, infers from body
-            names containing "/left_" or "/right_".
-        debug: If True, log detailed contact info.
 
     Returns:
-        Name of grasped object, or None if nothing is grasped.
+        Name of the most-contacted object body, or None.
     """
-    # Build body ID sets
-    all_gripper_body_ids: set[int] = set()
-    group_body_ids: dict[str, set[int]] = {}
-
-    if finger_groups is not None:
-        # Explicit finger groups
-        for group_name, bodies in finger_groups.items():
-            group_body_ids[group_name] = set()
-            for name in bodies:
-                body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
-                if body_id != -1:
-                    all_gripper_body_ids.add(body_id)
-                    group_body_ids[group_name].add(body_id)
-        # Also add any gripper bodies not in explicit groups
-        for name in gripper_body_names:
-            body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
-            if body_id != -1:
-                all_gripper_body_ids.add(body_id)
-    else:
-        # Infer from naming convention (left/right)
-        group_body_ids = {"left": set(), "right": set()}
-        for name in gripper_body_names:
-            body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
-            if body_id != -1:
-                all_gripper_body_ids.add(body_id)
-                if "/left_" in name or name.endswith("/left_pad") or name.endswith("/left_follower"):
-                    group_body_ids["left"].add(body_id)
-                elif "/right_" in name or name.endswith("/right_pad") or name.endswith("/right_follower"):
-                    group_body_ids["right"].add(body_id)
-            elif debug:
-                logger.warning(f"Gripper body not found: {name}")
-
-    if not all_gripper_body_ids:
+    gripper_ids: set[int] = set()
+    for name in gripper_body_names:
+        bid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+        if bid != -1:
+            gripper_ids.add(bid)
+    if not gripper_ids:
         return None
 
-    # Get candidate object body IDs
-    candidate_body_ids: set[int] | None = None
+    candidate_ids: set[int] | None = None
     if candidate_objects is not None:
-        candidate_body_ids = set()
+        candidate_ids = set()
         for name in candidate_objects:
-            body_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
-            if body_id != -1:
-                candidate_body_ids.add(body_id)
+            bid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+            if bid != -1:
+                candidate_ids.add(bid)
 
-    # Track contacts per object: body_id -> {group_name: bool, ..., "count": int}
-    object_contacts: dict[int, dict] = {}
-
+    contact_counts: dict[int, int] = {}
     for body1, body2, _ in iter_contacts(model, data):
-        gripper_body = None
-        other_body = None
-        if body1 in all_gripper_body_ids:
-            gripper_body = body1
-            other_body = body2
-        elif body2 in all_gripper_body_ids:
-            gripper_body = body2
-            other_body = body1
-
-        if gripper_body is None or other_body in all_gripper_body_ids:
+        if body1 in gripper_ids and body2 not in gripper_ids:
+            other = body2
+        elif body2 in gripper_ids and body1 not in gripper_ids:
+            other = body1
+        else:
             continue
-
-        if candidate_body_ids is not None and other_body not in candidate_body_ids:
+        if candidate_ids is not None and other not in candidate_ids:
             continue
+        contact_counts[other] = contact_counts.get(other, 0) + 1
 
-        if other_body not in object_contacts:
-            entry: dict = {"count": 0}
-            for gname in group_body_ids:
-                entry[gname] = False
-            object_contacts[other_body] = entry
-
-        for gname, gids in group_body_ids.items():
-            if gripper_body in gids:
-                object_contacts[other_body][gname] = True
-        object_contacts[other_body]["count"] += 1
-
-    if not object_contacts:
+    if not contact_counts:
         return None
 
-    # Filter by bilateral contact requirement. This heuristic is
-    # sim-only: it's used by the nameless grasp fallback (REPL / teleop
-    # "close the gripper on whatever is there"). The BT / primitives
-    # path always passes an explicit object name and uses GraspVerifier
-    # for post-grasp validation. On hardware, the nameless path is
-    # identified by PerceptionService after gripper close.
-    non_empty_groups = [g for g, ids in group_body_ids.items() if ids]
-    if require_bilateral and len(non_empty_groups) < 2:
-        # Finger group inference failed — fall back to any-contact detection.
-        pass
-    if require_bilateral and len(non_empty_groups) >= 2:
-        bilateral = {
-            bid: info for bid, info in object_contacts.items() if all(info.get(g, False) for g in non_empty_groups)
-        }
-        if bilateral:
-            object_contacts = bilateral
-        else:
-            if debug:
-                logger.info("No bilateral contacts found")
-            return None
-
-    best_body_id = max(object_contacts, key=lambda x: object_contacts[x]["count"])
-    return mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, best_body_id)
+    best = max(contact_counts, key=contact_counts.get)
+    return mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, best)

--- a/src/mj_manipulator/sim_context.py
+++ b/src/mj_manipulator/sim_context.py
@@ -102,26 +102,24 @@ class SimArmController:
 
         # Resolve which object we think we're grasping. For the BT path
         # this is always the target name. For the nameless interactive
-        # path (REPL / teleop), we fall back to detect_grasped_object —
-        # an iter_contacts-based helper that's sim-only by design. On
-        # hardware the nameless path will be identified by the
+        # path (REPL / teleop), we fall back to find_contacted_object —
+        # a simple contact-count heuristic that's sim-only by design.
+        # On hardware the nameless path will be identified by the
         # PerceptionService after close (see HardwarePerceptionService
         # in mj_manipulator_ros). The bookkeeping below (grasp_manager
         # and verifier) sets up sim's kinematic weld; on hardware
         # there's no weld and the held-object pose comes from FK.
         target = object_name
         if target is None:
-            from mj_manipulator.grasp_manager import detect_grasped_object
+            from mj_manipulator.grasp_manager import find_contacted_object
 
             # Close the gripper first so the post-close contact state
             # reflects what we grabbed.
             self._run_close(candidates)
-            target = detect_grasped_object(
+            target = find_contacted_object(
                 self._arm.env.model,
                 self._arm.env.data,
                 gripper.gripper_body_names,
-                candidate_objects=None,
-                require_bilateral=True,
             )
             if target is None:
                 logger.info("Grasp (no target): no object detected between fingers")

--- a/tests/test_grasp_manager.py
+++ b/tests/test_grasp_manager.py
@@ -11,7 +11,7 @@ import mujoco
 import numpy as np
 import pytest
 
-from mj_manipulator.grasp_manager import GraspManager, detect_grasped_object
+from mj_manipulator.grasp_manager import GraspManager, find_contacted_object
 
 # Minimal MuJoCo model: 2-joint arm + freejoint box
 _MINIMAL_XML = """
@@ -207,65 +207,31 @@ class TestGraspManager:
             gm._get_body_pose("nonexistent")
 
 
-class TestDetectGraspedObject:
-    """Tests for detect_grasped_object function."""
+class TestFindContactedObject:
+    """Tests for find_contacted_object function."""
 
     def test_empty_gripper_bodies_returns_none(self, model_and_data):
         """Empty gripper body list returns None."""
         model, data = model_and_data
-        assert detect_grasped_object(model, data, []) is None
+        assert find_contacted_object(model, data, []) is None
 
     def test_no_contacts_returns_none(self, model_and_data):
         """No contacts returns None."""
         model, data = model_and_data
-        # Move arm away from objects
         j1_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, "joint1")
         data.qpos[model.jnt_qposadr[j1_id]] = 3.14
         mujoco.mj_forward(model, data)
-
-        result = detect_grasped_object(
-            model,
-            data,
-            ["left_finger", "right_finger"],
-            candidate_objects=["box1", "box2"],
-        )
+        result = find_contacted_object(model, data, ["left_finger", "right_finger"])
         assert result is None
 
     def test_candidate_filter(self, model_and_data):
         """candidate_objects filters to specific objects."""
         model, data = model_and_data
-        result = detect_grasped_object(
-            model,
-            data,
-            ["left_finger", "right_finger"],
-            candidate_objects=["nonexistent"],
-        )
+        result = find_contacted_object(model, data, ["left_finger", "right_finger"], candidate_objects=["nonexistent"])
         assert result is None
 
-    def test_explicit_finger_groups(self, model_and_data):
-        """finger_groups parameter works for bilateral detection."""
+    def test_returns_string_or_none(self, model_and_data):
+        """Result is a body name string or None."""
         model, data = model_and_data
-        # Even without contact, the function should accept the parameter
-        result = detect_grasped_object(
-            model,
-            data,
-            ["left_finger", "right_finger"],
-            finger_groups={"left": ["left_finger"], "right": ["right_finger"]},
-        )
-        # No contacts in this configuration, so None
-        # But this tests that the parameter is accepted without error
-        assert result is None
-
-    def test_name_based_finger_inference(self, model_and_data):
-        """Default name-based finger group inference works."""
-        model, data = model_and_data
-        # left_finger contains "left_" so should be categorized as left group
-        # right_finger contains "right_" so should be right group
-        # This just tests the path doesn't raise
-        result = detect_grasped_object(
-            model,
-            data,
-            ["left_finger", "right_finger"],
-        )
-        # Result depends on contacts
+        result = find_contacted_object(model, data, ["left_finger", "right_finger"])
         assert result is None or isinstance(result, str)


### PR DESCRIPTION
## Summary

Removes \`detect_grasped_object\` — the sim-only bilateral contact heuristic that used left/right finger group pattern matching to determine what was grasped. Replaced with \`find_contacted_object\` — a simple contact-count function (return the object with the most gripper contacts, no finger groups, no bilateral logic).

This is dead-code cleanup deferred from v2.0.0. \`GraspVerifier\` (shipped in v2.0) handles all post-grasp validation via real signals (gripper position, wrist F/T, joint torques). The bilateral heuristic was only used by the nameless REPL/teleop grasp path, and even there the bilateral check silently failed on every gripper except the Robotiq 2F-140 (name pattern didn't match).

## What was removed

- \`detect_grasped_object()\` — 130 lines of bilateral/unilateral logic, finger group inference, left_/right_ name patterns
- \`require_bilateral\` parameter
- \`finger_groups\` parameter
- All the fallback logic when finger group inference failed

## What replaced it

\`find_contacted_object()\` — 30 lines: iterate contacts, count per non-gripper body, return the most-contacted. This is exactly what the old function did after the bilateral check failed (line 297).

## Testing

- 421 tests pass (6 bilateral tests → 4 simpler contact tests, net -2)
- ruff check / format clean

Fixes #80, fixes #83.