### PR TITLE
CollisionChecker: support welded tool bodies and grasped descendants

### DIFF
--- a/src/mj_manipulator/arm.py
+++ b/src/mj_manipulator/arm.py
@@ -602,6 +602,7 @@ class Arm:
         # Collision checker with snapshot of current grasp state.
         # Only include objects grasped by THIS arm — objects held by other
         # arms are static obstacles, not part of this arm's robot model.
+        extra_bodies = self.config.extra_arm_body_names
         if self.grasp_manager is not None:
             arm_name = self.config.name
             grasped_objects = frozenset(
@@ -616,12 +617,14 @@ class Arm:
                 joint_names=self.config.joint_names,
                 grasped_objects=grasped_objects,
                 attachments=attachments,
+                extra_arm_body_names=extra_bodies,
             )
         else:
             collision_checker = CollisionChecker(
                 model=model,
                 data=data,
                 joint_names=self.config.joint_names,
+                extra_arm_body_names=extra_bodies,
             )
 
         # IK solver — use injected solver or a no-op stub

--- a/src/mj_manipulator/collision.py
+++ b/src/mj_manipulator/collision.py
@@ -57,6 +57,7 @@ class CollisionChecker:
         grasp_manager: GraspManager | None = None,
         grasped_objects: frozenset[tuple[str, str]] | None = None,
         attachments: dict[str, tuple[str, np.ndarray]] | None = None,
+        extra_arm_body_names: list[str] | None = None,
     ):
         """Initialize collision checker.
 
@@ -70,6 +71,9 @@ class CollisionChecker:
                 Frozenset of ``(object_name, arm_name)`` tuples.
             attachments: Frozen attachment state for thread-safe use.
                 Dict of ``{object_name: (gripper_body_name, T_gripper_object)}``.
+            extra_arm_body_names: Additional body names (and their descendants)
+                to treat as part of the arm for collision filtering. Use for
+                welded tool bodies that aren't children in the body tree.
         """
         self.model = model
         self._grasp_manager = grasp_manager
@@ -102,6 +106,30 @@ class CollisionChecker:
             body_id = model.jnt_bodyid[joint_id]
             self._arm_body_ids.add(body_id)
             self._add_child_bodies(body_id)
+
+        # Add extra bodies (e.g., welded tool not in the body tree)
+        for name in extra_arm_body_names or []:
+            bid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+            if bid >= 0:
+                self._arm_body_ids.add(bid)
+                self._add_child_bodies(bid)
+
+        # Build grasped body ID set (root + all descendants).
+        # _is_grasped checks body names, but child bodies of grasped
+        # objects also need to be recognized as grasped.
+        # Build grasped body ID set (root + all descendants).
+        # Contacts between grasped bodies and gripper/arm are filtered
+        # as gripper-object contacts, not counted as collisions.
+        self._grasped_body_ids: set[int] = set()
+        grasped_names: set[str] = set()
+        if grasp_manager is not None:
+            grasped_names = set(grasp_manager.grasped.keys())
+        else:
+            grasped_names = {obj for obj, _ in self._grasped_objects}
+        for name in grasped_names:
+            bid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+            if bid >= 0:
+                self._grasped_body_ids.update(self._get_body_and_descendants(bid))
 
     # -- Public API (pycbirrt CollisionChecker protocol) --
 
@@ -251,7 +279,11 @@ class CollisionChecker:
         return self.data
 
     def _is_grasped(self, body_name: str) -> bool:
-        """Check if a body is grasped (works in both modes)."""
+        """Check if a body (or any ancestor) is grasped."""
+        bid = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_BODY, body_name)
+        if bid >= 0 and bid in self._grasped_body_ids:
+            return True
+        # Fallback to name-based check for backward compat
         if self._grasp_manager is not None:
             return self._grasp_manager.is_grasped(body_name)
         return any(obj == body_name for obj, _ in self._grasped_objects)

--- a/src/mj_manipulator/config.py
+++ b/src/mj_manipulator/config.py
@@ -75,6 +75,7 @@ class ArmConfig(EntityConfig):
     tcp_offset: np.ndarray | None = None  # 4x4 SE3 from ee_site to tool center point
     ft_force_sensor: str | None = None  # MuJoCo force sensor name (3-axis)
     ft_torque_sensor: str | None = None  # MuJoCo torque sensor name (3-axis)
+    extra_arm_body_names: list[str] | None = None  # Additional bodies to treat as part of arm for collision
     planning_defaults: PlanningDefaults = field(default_factory=PlanningDefaults)
 
     def __post_init__(self):

--- a/src/mj_manipulator/teleop.py
+++ b/src/mj_manipulator/teleop.py
@@ -443,6 +443,11 @@ class TeleopController:
             jid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, jname)
             bid = model.jnt_bodyid[jid]
             my_body_ids.add(bid)
+        # Add extra arm bodies (e.g., welded tool)
+        for name in self._arm.config.extra_arm_body_names or []:
+            bid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+            if bid >= 0:
+                my_body_ids.add(bid)
         # Add all descendant bodies
         changed = True
         while changed:


### PR DESCRIPTION
## Summary

Adds support for welded tool bodies that aren't children in the MuJoCo body tree (e.g., freejoint objects connected via weld equality constraints).

**Changes:**
- `ArmConfig.extra_arm_body_names` — bodies (+ descendants) to include in arm's collision set
- `CollisionChecker` — accepts `extra_arm_body_names`, builds `_grasped_body_ids` set including all descendants of grasped objects
- `Arm.create_planner` — passes `extra_arm_body_names` through to CollisionChecker
- `TeleopController._check_live_collisions` — includes extra bodies in arm body set

**Problem:** ADA's articutool is a freejoint body on worldbody, welded to link_6. Its bodies aren't children of link_6 in the body tree. The collision checker treated tool-environment contacts as invalid, blocking planning and teleop.

**Fix:** `extra_arm_body_names=["articutool/fork_base"]` adds the tool root + all descendants to the arm's collision set. Combined with GraspManager attachment (which moves the tool with the arm in the planner's fork), all named pose transitions now work.

Fixes #138

## Test plan

- [ ] Existing geodude tests pass (no extra_arm_body_names = no behavior change)
- [ ] ADA: `robot.go_to()` plans all 4 named pose transitions under physics execution
- [ ] ADA: teleop no longer flags spurious collision on every step

🤖 Generated with [Claude Code](https://claude.com/claude-code)