### PR TITLE
Unify kinematic + physics under shared Controller base

### DIFF
--- a/src/mj_manipulator/__init__.py
+++ b/src/mj_manipulator/__init__.py
@@ -27,6 +27,7 @@ from mj_manipulator.collision import CollisionChecker
 from mj_manipulator.config import (
     ArmConfig,
     EntityConfig,
+    ExecutionConfig,
     GripperPhysicsConfig,
     KinematicLimits,
     PhysicsConfig,
@@ -34,6 +35,7 @@ from mj_manipulator.config import (
     PlanningDefaults,
     RecoveryConfig,
 )
+from mj_manipulator.controller import ArmExecutor, Controller, EntityExecutor
 from mj_manipulator.executor import KinematicExecutor, PhysicsExecutor
 from mj_manipulator.grasp_manager import GraspManager
 from mj_manipulator.grasp_verifier import (
@@ -51,6 +53,7 @@ from mj_manipulator.load_signals import (
 )
 from mj_manipulator.ownership import OwnerKind, OwnershipRegistry
 from mj_manipulator.perception import SimPerceptionService
+from mj_manipulator.kinematic_controller import KinematicController
 from mj_manipulator.physics_controller import ArmPhysicsExecutor, PhysicsController
 from mj_manipulator.planning import PlanResult
 from mj_manipulator.protocols import (
@@ -113,12 +116,16 @@ __all__ = [
     "FrankaGripper",
     # Collision checking
     "CollisionChecker",
-    # Executors
+    # Executors (standalone, no-event-loop usage)
     "KinematicExecutor",
     "PhysicsExecutor",
-    # Physics controller (simulation)
+    # Controller hierarchy
+    "Controller",
     "PhysicsController",
-    "ArmPhysicsExecutor",
+    "KinematicController",
+    "ArmExecutor",
+    "EntityExecutor",
+    "ArmPhysicsExecutor",  # backwards compat alias for ArmExecutor
     # Robot protocol and base class
     "ManipulationRobot",
     "RobotBase",
@@ -147,6 +154,7 @@ __all__ = [
     "KinematicLimits",
     "PlanningDefaults",
     "PhysicsConfig",
+    "ExecutionConfig",
     "PhysicsExecutionConfig",
     "GripperPhysicsConfig",
     "RecoveryConfig",

--- a/src/mj_manipulator/__init__.py
+++ b/src/mj_manipulator/__init__.py
@@ -45,6 +45,7 @@ from mj_manipulator.grasp_verifier import (
     VerifierParams,
 )
 from mj_manipulator.grippers import FrankaGripper, RobotiqGripper
+from mj_manipulator.kinematic_controller import KinematicController
 from mj_manipulator.load_signals import (
     GripperPositionSignal,
     JointTorqueSignal,
@@ -53,7 +54,6 @@ from mj_manipulator.load_signals import (
 )
 from mj_manipulator.ownership import OwnerKind, OwnershipRegistry
 from mj_manipulator.perception import SimPerceptionService
-from mj_manipulator.kinematic_controller import KinematicController
 from mj_manipulator.physics_controller import ArmPhysicsExecutor, PhysicsController
 from mj_manipulator.planning import PlanResult
 from mj_manipulator.protocols import (

--- a/src/mj_manipulator/config.py
+++ b/src/mj_manipulator/config.py
@@ -84,8 +84,17 @@ class ArmConfig(EntityConfig):
 
 
 @dataclass
-class PhysicsExecutionConfig:
-    """Parameters for physics-based trajectory execution."""
+class ExecutionConfig:
+    """Parameters for trajectory execution (all modes).
+
+    Used by both PhysicsController and KinematicController. In kinematic
+    mode, convergence is immediate (qpos matches target exactly after one
+    step), so tolerance/timeout values are effectively unused but kept
+    for interface uniformity.
+
+    ``lookahead_time`` is only used by PhysicsController for velocity
+    feedforward; kinematic mode ignores it.
+    """
 
     control_dt: float = 0.008  # 125 Hz
     lookahead_time: float = 0.1  # Velocity feedforward gain (seconds)
@@ -95,13 +104,17 @@ class PhysicsExecutionConfig:
     base_settling_steps: int = 50
 
     @classmethod
-    def tight(cls) -> "PhysicsExecutionConfig":
+    def tight(cls) -> "ExecutionConfig":
         """Tighter convergence for precision tasks."""
         return cls(
             position_tolerance=0.02,
             velocity_tolerance=0.05,
             convergence_timeout_steps=1000,
         )
+
+
+# Backwards compatibility alias
+PhysicsExecutionConfig = ExecutionConfig
 
 
 @dataclass

--- a/src/mj_manipulator/console.py
+++ b/src/mj_manipulator/console.py
@@ -146,10 +146,7 @@ def start_console(
     with robot.sim(physics=physics, headless=show_viewer, viewer=sim_viewer, event_loop=event_loop) as ctx:
         user_ns["ctx"] = ctx
 
-        # Wire event loop
-        event_loop._idle_step_fn = lambda: ctx.step()
-        if viser_viewer is not None:
-            event_loop._viewer_sync_fn = lambda: viser_viewer.sync()
+        # Event loop is wired to the controller in SimContext.__enter__
 
         # -- Teleop panels (needs ctx) -----------------------------------------
         if viser and viser_viewer is not None and tabs is not None:
@@ -224,20 +221,19 @@ def start_console(
         )
         shell.prompts = _Prompts(shell)
 
-        # -- Physics inputhook -------------------------------------------------
-        if physics:
-            control_dt = ctx.control_dt
+        # -- Inputhook (drives event loop while REPL waits for input) ----------
+        control_dt = ctx.control_dt
 
-            def _inputhook(context):
-                t_next = time.monotonic() + control_dt
-                while not context.input_is_ready():
-                    now = time.monotonic()
-                    if now >= t_next:
-                        event_loop.tick()
-                        t_next = now + control_dt
-                    else:
-                        time.sleep(min(t_next - now, 0.001))
+        def _inputhook(context):
+            t_next = time.monotonic() + control_dt
+            while not context.input_is_ready():
+                now = time.monotonic()
+                if now >= t_next:
+                    event_loop.tick()
+                    t_next = now + control_dt
+                else:
+                    time.sleep(min(t_next - now, 0.001))
 
-            shell._inputhook = _inputhook
+        shell._inputhook = _inputhook
 
         shell()

--- a/src/mj_manipulator/controller.py
+++ b/src/mj_manipulator/controller.py
@@ -365,6 +365,11 @@ class Controller(ABC):
         # Active non-blocking trajectory runners (entity_name → TrajectoryRunner)
         self._runners: dict[str, TrajectoryRunner] = {}
 
+        # Deferred hold: when True, step() calls hold_all() before applying
+        # targets. This lets callers modify qpos after reset_state() and have
+        # the controller pick up whatever's there on the next tick.
+        self._hold_pending: bool = False
+
         # Initialize qpos/qvel to targets (prevents violent jumps on first step)
         for state in self._arms.values():
             data.qpos[state.joint_qpos_indices] = state.target_position
@@ -376,6 +381,7 @@ class Controller(ABC):
 
     def hold_all(self) -> None:
         """Update all targets (arms, entities, grippers) to current positions."""
+        self._hold_pending = False
         for state in self._arms.values():
             state.target_position = self.data.qpos[state.joint_qpos_indices].copy()
             state.target_velocity = np.zeros(len(state.actuator_ids))
@@ -387,6 +393,16 @@ class Controller(ABC):
         for name, gs in self._grippers.items():
             gs.target_ctrl = gs.ctrl_open
             self.data.ctrl[gs.actuator_id] = gs.ctrl_open
+
+    def request_hold(self) -> None:
+        """Request that the next step() captures current qpos as targets.
+
+        Use instead of :meth:`hold_all` when qpos will be modified after
+        the call (e.g. scene setup after a reset). The hold is deferred
+        to the next :meth:`step`, so whatever qpos state exists at
+        tick-time gets captured — including post-reset modifications.
+        """
+        self._hold_pending = True
 
     def set_arm_target(
         self,
@@ -415,9 +431,12 @@ class Controller(ABC):
     def step(self) -> None:
         """Apply current targets and advance one control cycle.
 
-        Delegates to :meth:`_apply_targets_and_step` which subclasses
-        implement with mode-specific stepping logic.
+        If a deferred hold is pending (from :meth:`request_hold` or
+        :meth:`reset_state`), captures current qpos as targets first.
+        Then delegates to :meth:`_apply_targets_and_step`.
         """
+        if self._hold_pending:
+            self.hold_all()
         self._apply_targets_and_step()
 
     @abstractmethod

--- a/src/mj_manipulator/controller.py
+++ b/src/mj_manipulator/controller.py
@@ -1,0 +1,721 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Base controller for multi-arm MuJoCo manipulation.
+
+Provides the shared orchestration layer for physics, kinematic, and (future)
+hardware controllers. Owns target state management, non-blocking trajectory
+runners, blocking trajectory execution, and executor wrappers.
+
+Subclasses implement :meth:`_apply_targets_and_step` (one control cycle),
+:meth:`close_gripper`, and :meth:`open_gripper`.
+
+Architecture::
+
+    Controller (ABC)
+    ├── PhysicsController       — ctrl writes + mj_step + verifier ticks
+    ├── KinematicController     — qpos writes + mj_forward + grasp manager update
+    └── (future) HardwareController — RTDE/ROS commands + encoder reads
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from abc import ABC, abstractmethod
+from concurrent.futures import Future
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable
+
+import mujoco
+import numpy as np
+
+if TYPE_CHECKING:
+    from mj_manipulator.arm import Arm
+    from mj_manipulator.config import ExecutionConfig
+    from mj_manipulator.protocols import Gripper
+    from mj_manipulator.trajectory import Trajectory
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Internal per-arm / per-gripper state
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _ArmState:
+    """Per-arm state managed by Controller."""
+
+    arm: Arm
+    actuator_ids: np.ndarray  # int array for vectorized ctrl writes
+    joint_qpos_indices: np.ndarray
+    joint_qvel_indices: np.ndarray
+    target_position: np.ndarray
+    target_velocity: np.ndarray
+    lookahead: float | None = None  # None = use controller default
+
+
+@dataclass
+class _EntityState:
+    """Per-entity state for non-arm controllable entities (e.g. linear bases)."""
+
+    actuator_ids: np.ndarray
+    joint_qpos_indices: np.ndarray
+    joint_qvel_indices: np.ndarray
+    target_position: np.ndarray
+    target_velocity: np.ndarray
+
+
+@dataclass
+class _GripperState:
+    """Per-gripper state managed by Controller."""
+
+    gripper: Gripper
+    actuator_id: int
+    ctrl_open: float
+    ctrl_closed: float
+    target_ctrl: float
+
+
+# ---------------------------------------------------------------------------
+# TrajectoryRunner
+# ---------------------------------------------------------------------------
+
+
+class TrajectoryRunner:
+    """Non-blocking trajectory target provider.
+
+    Advances one waypoint per call to :meth:`advance`, writing targets to
+    the arm's ``_ArmState``. Does NOT call ``mj_step`` — the event loop
+    owns stepping.
+
+    This is the "update method" pattern from game programming: the game
+    loop calls ``runner.advance()`` each frame, then steps once with all
+    arms' targets applied.
+
+    Created via :meth:`Controller.start_trajectory`.
+    """
+
+    def __init__(
+        self,
+        controller: Controller,
+        entity_name: str,
+        trajectory: Trajectory,
+        abort_fn: Callable[[], bool] | None = None,
+    ):
+        self._controller = controller
+        self._entity_name = entity_name
+        self._trajectory = trajectory
+        self._abort_fn = abort_fn
+        self._waypoint_index = 0
+        self._done = False
+        self._converging = False
+        self._convergence_steps = 0
+        self._future: Future[bool] = Future()
+        self._realtime = controller.viewer is not None
+        self._t_start = time.time() if self._realtime else 0.0
+
+        # Resolve state from arms or entities
+        if entity_name in controller._arms:
+            self._state = controller._arms[entity_name]
+            self._is_arm = True
+        elif entity_name in controller._entities:
+            self._state = controller._entities[entity_name]
+            self._is_arm = False
+        else:
+            raise ValueError(f"Unknown arm or entity: {entity_name}")
+
+    @property
+    def entity_name(self) -> str:
+        """Which arm or entity this runner controls."""
+        return self._entity_name
+
+    @property
+    def done(self) -> bool:
+        """Whether the trajectory has completed (success or abort)."""
+        return self._done
+
+    @property
+    def future(self) -> Future[bool]:
+        """Future that resolves when the trajectory completes."""
+        return self._future
+
+    def advance(self) -> None:
+        """Write next waypoint target to arm state.
+
+        Call once per tick. After the last waypoint, enters convergence
+        mode (checking position/velocity error each tick).
+        """
+        if self._done:
+            return
+
+        if self._abort_fn is not None and self._abort_fn():
+            self._state.target_velocity = np.zeros(len(self._state.actuator_ids))
+            self._finish(False)
+            logger.info(
+                "Trajectory aborted at waypoint %d/%d",
+                self._waypoint_index,
+                self._trajectory.num_waypoints,
+            )
+            return
+
+        if self._converging:
+            self._advance_convergence()
+            return
+
+        state = self._state
+        traj = self._trajectory
+
+        state.target_position = traj.positions[self._waypoint_index]
+        state.target_velocity = traj.velocities[self._waypoint_index]
+
+        self._waypoint_index += 1
+
+        if self._waypoint_index >= traj.num_waypoints:
+            state.target_position = traj.positions[-1].copy()
+            state.target_velocity = np.zeros(len(state.actuator_ids))
+            if self._is_arm:
+                # Arms need convergence settling (PD dynamics in physics,
+                # instant in kinematic — tolerance check passes immediately)
+                self._converging = True
+            else:
+                # Entities (bases) don't need convergence
+                self._finish(True)
+
+    def _advance_convergence(self) -> None:
+        """Check convergence one step at a time."""
+        cfg = self._controller.config
+        state = self._state
+        data = self._controller.data
+
+        current_pos = data.qpos[state.joint_qpos_indices]
+        pos_error = np.abs(state.target_position - current_pos)
+        current_vel = data.qvel[state.joint_qvel_indices]
+
+        if np.all(pos_error < cfg.position_tolerance) and np.all(np.abs(current_vel) < cfg.velocity_tolerance):
+            self._finish(True)
+            return
+
+        self._convergence_steps += 1
+        if self._convergence_steps >= cfg.convergence_timeout_steps:
+            logger.warning(
+                "Convergence timeout for %s: max_pos_err=%.2f° (limit %.2f°)",
+                self._entity_name,
+                np.rad2deg(float(np.max(pos_error))),
+                np.rad2deg(cfg.position_tolerance),
+            )
+            self._finish(True)  # timed out but close enough
+
+    def _finish(self, success: bool) -> None:
+        self._done = True
+        if not self._future.done():
+            self._future.set_result(success)
+
+
+# ---------------------------------------------------------------------------
+# Executor wrappers
+# ---------------------------------------------------------------------------
+
+
+class ArmExecutor:
+    """Executor interface for one arm, backed by a Controller.
+
+    Provides the standard ``Executor.execute(trajectory)`` interface while
+    ensuring all other actuators hold their positions during execution.
+    Obtained via :meth:`Controller.get_executor`.
+    """
+
+    def __init__(self, controller: Controller, arm_name: str):
+        self.controller = controller
+        self.arm_name = arm_name
+
+    def execute(self, trajectory: Trajectory) -> bool:
+        """Execute trajectory on this arm."""
+        return self.controller.execute(self.arm_name, trajectory)
+
+
+class EntityExecutor:
+    """Executor interface for a non-arm entity, backed by a Controller.
+
+    Same pattern as ArmExecutor but routes to execute_entity().
+    Obtained via :meth:`Controller.get_entity_executor`.
+    """
+
+    def __init__(self, controller: Controller, entity_name: str):
+        self.controller = controller
+        self.entity_name = entity_name
+
+    def execute(self, trajectory: Trajectory) -> bool:
+        """Execute trajectory on this entity."""
+        return self.controller.execute_entity(self.entity_name, trajectory)
+
+
+# ---------------------------------------------------------------------------
+# Controller base class
+# ---------------------------------------------------------------------------
+
+
+class Controller(ABC):
+    """Base controller for multi-arm MuJoCo manipulation.
+
+    Coordinates all arms, entities, and grippers. Provides target state
+    management, non-blocking trajectory runners (driven by the event loop),
+    blocking trajectory execution (for no-event-loop usage), and per-arm
+    executor wrappers.
+
+    Subclasses override :meth:`_apply_targets_and_step` to define how
+    targets become motion:
+
+    - **PhysicsController**: writes ``data.ctrl`` with lookahead feedforward,
+      calls ``mj_step``, ticks grasp verifiers, syncs viewer.
+    - **KinematicController**: writes ``data.qpos`` directly, calls
+      ``mj_forward``, updates grasp manager attached poses, syncs viewer.
+    - **(future) HardwareController**: sends to RTDE/ROS, reads encoders.
+
+    Args:
+        model: MuJoCo model.
+        data: MuJoCo data (modified during execution).
+        arms: Dict mapping arm names to Arm instances.
+        config: Execution parameters (control_dt, convergence tolerances, etc.).
+        gripper_config: Gripper control parameters (physics-mode close steps, etc.).
+        viewer: Optional viewer to sync during execution.
+        viewer_sync_interval: Minimum seconds between viewer syncs.
+        initial_positions: Optional per-arm initial joint positions.
+        entities: Optional dict of non-arm controllable entities.
+        abort_fn: Optional global abort predicate.
+    """
+
+    def __init__(
+        self,
+        model: mujoco.MjModel,
+        data: mujoco.MjData,
+        arms: dict[str, Arm],
+        *,
+        config: ExecutionConfig | None = None,
+        gripper_config: object | None = None,
+        viewer=None,
+        viewer_sync_interval: float = 0.033,
+        initial_positions: dict[str, np.ndarray] | None = None,
+        entities: dict[str, object] | None = None,
+        abort_fn=None,
+    ):
+        from mj_manipulator.config import ExecutionConfig as _ExecutionConfig
+
+        self.model = model
+        self.data = data
+        self.viewer = viewer
+        self._abort_fn = abort_fn
+
+        self.config = config or _ExecutionConfig()
+        self.gripper_config = gripper_config
+
+        self.control_dt = self.config.control_dt
+        self.lookahead_time = self.config.lookahead_time
+
+        self._last_viewer_sync = 0.0
+        self._viewer_sync_interval = viewer_sync_interval
+
+        # Build per-arm state
+        self._arms: dict[str, _ArmState] = {}
+        self._grippers: dict[str, _GripperState] = {}
+
+        for name, arm in arms.items():
+            if initial_positions and name in initial_positions:
+                target_pos = np.asarray(initial_positions[name]).copy()
+            else:
+                target_pos = arm.get_joint_positions().copy()
+
+            self._arms[name] = _ArmState(
+                arm=arm,
+                actuator_ids=np.array(arm.actuator_ids, dtype=np.intp),
+                joint_qpos_indices=np.array(arm.joint_qpos_indices, dtype=np.intp),
+                joint_qvel_indices=np.array(arm.joint_qvel_indices, dtype=np.intp),
+                target_position=target_pos,
+                target_velocity=np.zeros(arm.dof),
+            )
+
+            gripper = arm.gripper
+            if gripper is not None and gripper.actuator_id is not None:
+                self._grippers[name] = _GripperState(
+                    gripper=gripper,
+                    actuator_id=gripper.actuator_id,
+                    ctrl_open=gripper.ctrl_open,
+                    ctrl_closed=gripper.ctrl_closed,
+                    target_ctrl=data.ctrl[gripper.actuator_id],
+                )
+
+        # Build per-entity state (linear bases, etc.)
+        self._entities: dict[str, _EntityState] = {}
+        for name, entity in (entities or {}).items():
+            qpos_idx = np.array(entity.joint_qpos_indices, dtype=np.intp)
+            target_pos = data.qpos[qpos_idx].copy()
+            self._entities[name] = _EntityState(
+                actuator_ids=np.array(entity.actuator_ids, dtype=np.intp),
+                joint_qpos_indices=qpos_idx,
+                joint_qvel_indices=np.array(
+                    entity.joint_qvel_indices,
+                    dtype=np.intp,
+                ),
+                target_position=target_pos,
+                target_velocity=np.zeros(len(qpos_idx)),
+            )
+
+        # Active non-blocking trajectory runners (entity_name → TrajectoryRunner)
+        self._runners: dict[str, TrajectoryRunner] = {}
+
+        # Initialize qpos/qvel to targets (prevents violent jumps on first step)
+        for state in self._arms.values():
+            data.qpos[state.joint_qpos_indices] = state.target_position
+            data.qvel[state.joint_qvel_indices] = 0.0
+
+        mujoco.mj_forward(model, data)
+
+    # -- Target management --------------------------------------------------
+
+    def hold_all(self) -> None:
+        """Update all targets (arms, entities, grippers) to current positions."""
+        for state in self._arms.values():
+            state.target_position = self.data.qpos[state.joint_qpos_indices].copy()
+            state.target_velocity = np.zeros(len(state.actuator_ids))
+
+        for state in self._entities.values():
+            state.target_position = self.data.qpos[state.joint_qpos_indices].copy()
+            state.target_velocity = np.zeros(len(state.target_velocity))
+
+        for name, gs in self._grippers.items():
+            gs.target_ctrl = gs.ctrl_open
+            self.data.ctrl[gs.actuator_id] = gs.ctrl_open
+
+    def set_arm_target(
+        self,
+        arm_name: str,
+        position: np.ndarray,
+        velocity: np.ndarray | None = None,
+    ) -> None:
+        """Set target position and velocity for an arm.
+
+        Args:
+            arm_name: Arm identifier.
+            position: Target joint positions (rad).
+            velocity: Target joint velocities (rad/s), or None for zero.
+        """
+        if arm_name not in self._arms:
+            raise ValueError(f"Unknown arm: {arm_name}")
+
+        state = self._arms[arm_name]
+        state.target_position = np.asarray(position).copy()
+        state.target_velocity = (
+            np.asarray(velocity).copy() if velocity is not None else np.zeros(len(state.actuator_ids))
+        )
+
+    # -- Stepping (template method) -----------------------------------------
+
+    def step(self) -> None:
+        """Apply current targets and advance one control cycle.
+
+        Delegates to :meth:`_apply_targets_and_step` which subclasses
+        implement with mode-specific stepping logic.
+        """
+        self._apply_targets_and_step()
+
+    @abstractmethod
+    def _apply_targets_and_step(self) -> None:
+        """Apply current arm/entity/gripper targets and advance one control cycle.
+
+        Read from ``_ArmState.target_position/target_velocity``,
+        ``_EntityState.target_position/target_velocity``, and
+        ``_GripperState.target_ctrl``. Advance the simulation by one
+        control cycle, then sync the viewer (throttled).
+
+        Physics: write data.ctrl with lookahead → mj_step × N → tick
+            verifiers → viewer sync.
+        Kinematic: write data.qpos → mj_forward → update grasp managers
+            → viewer sync.
+        """
+
+    def step_reactive(
+        self,
+        arm_name: str,
+        position: np.ndarray,
+        velocity: np.ndarray | None = None,
+    ) -> None:
+        """Reactive single-arm step for cartesian streaming control.
+
+        Sets targets and steps. In physics mode, overridden with small
+        lookahead and hold-others behavior. In kinematic mode, the default
+        (set + step) gives instant tracking.
+
+        Args:
+            arm_name: Which arm to control reactively.
+            position: Target joint positions.
+            velocity: Target joint velocities for feedforward.
+        """
+        self.set_arm_target(arm_name, position, velocity)
+        self.step()
+
+    def _throttled_viewer_sync(self) -> None:
+        """Sync viewer if present, throttled to viewer_sync_interval."""
+        if self.viewer is not None:
+            now = time.time()
+            if now - self._last_viewer_sync >= self._viewer_sync_interval:
+                self.viewer.sync()
+                self._last_viewer_sync = now
+
+    # -- Non-blocking trajectory execution ----------------------------------
+
+    def start_trajectory(
+        self,
+        entity_name: str,
+        trajectory: Trajectory,
+        abort_fn: Callable[[], bool] | None = None,
+    ) -> Future[bool]:
+        """Start a non-blocking trajectory on an arm or entity.
+
+        Returns a Future that resolves to True when the trajectory completes
+        (and the arm converges, if applicable), or False if aborted. The
+        caller blocks on the Future while :meth:`advance_all` (called by
+        the event loop's tick) drives the trajectory forward one waypoint
+        per cycle.
+
+        Args:
+            entity_name: Which arm or entity to execute on.
+            trajectory: Time-parameterized trajectory.
+            abort_fn: Per-entity abort check. Runner stops when this returns True.
+
+        Returns:
+            Future[bool] — resolves when trajectory finishes.
+        """
+        # Resolve state for DOF validation
+        if entity_name in self._arms:
+            state = self._arms[entity_name]
+        elif entity_name in self._entities:
+            state = self._entities[entity_name]
+        else:
+            raise ValueError(f"Unknown arm or entity: {entity_name}")
+
+        if trajectory.dof != len(state.joint_qpos_indices):
+            raise ValueError(
+                f"Trajectory DOF {trajectory.dof} doesn't match joint count {len(state.joint_qpos_indices)}"
+            )
+
+        runner = TrajectoryRunner(self, entity_name, trajectory, abort_fn)
+        self._runners[entity_name] = runner
+        logger.debug(
+            "Started trajectory on %s (%d waypoints)",
+            entity_name,
+            trajectory.num_waypoints,
+        )
+        return runner.future
+
+    def advance_all(self) -> None:
+        """Advance all active trajectory runners one waypoint each.
+
+        Called by the event loop's tick() before :meth:`step`. Runners that
+        are done are automatically removed.
+        """
+        if not self._runners:
+            return
+
+        done_arms = []
+        for arm_name, runner in self._runners.items():
+            runner.advance()
+            if runner.done:
+                done_arms.append(arm_name)
+
+        for arm_name in done_arms:
+            del self._runners[arm_name]
+
+    def has_active_runner(self, arm_name: str | None = None) -> bool:
+        """Check if any (or a specific) arm has an active trajectory runner."""
+        if arm_name is not None:
+            return arm_name in self._runners
+        return bool(self._runners)
+
+    # -- Blocking trajectory execution --------------------------------------
+
+    def execute(self, arm_name: str, trajectory: Trajectory) -> bool:
+        """Execute trajectory on one arm while others hold position.
+
+        After the trajectory completes, waits for the arm to converge to
+        the final target (convergence-based settling in physics mode,
+        immediate in kinematic mode).
+
+        Args:
+            arm_name: Which arm to execute on.
+            trajectory: Time-parameterized trajectory.
+
+        Returns:
+            True if execution completed and arm converged.
+        """
+        if arm_name not in self._arms:
+            raise ValueError(f"Unknown arm: {arm_name}")
+
+        state = self._arms[arm_name]
+
+        if trajectory.dof != len(state.joint_qpos_indices):
+            raise ValueError(
+                f"Trajectory DOF {trajectory.dof} doesn't match arm joint count {len(state.joint_qpos_indices)}"
+            )
+
+        # Follow trajectory at real-time rate
+        realtime = self.viewer is not None
+        t_start = time.time() if realtime else 0.0
+        for i in range(trajectory.num_waypoints):
+            if self._abort_fn is not None and self._abort_fn():
+                logger.info("Trajectory aborted at waypoint %d/%d", i, trajectory.num_waypoints)
+                # Zero velocity so arm holds position while other arms move
+                state.target_velocity = np.zeros(len(state.actuator_ids))
+                return False
+            state.target_position = trajectory.positions[i]
+            state.target_velocity = trajectory.velocities[i]
+            self.step()
+            if realtime:
+                t_target = t_start + (i + 1) * self.control_dt
+                t_remaining = t_target - time.time()
+                if t_remaining > 0:
+                    time.sleep(t_remaining)
+
+        # Hold final position (zero velocity)
+        state.target_position = trajectory.positions[-1].copy()
+        state.target_velocity = np.zeros(len(state.actuator_ids))
+
+        return self._wait_for_convergence(arm_name)
+
+    def execute_entity(self, entity_name: str, trajectory: Trajectory) -> bool:
+        """Execute trajectory on an entity while arms and other entities hold.
+
+        Args:
+            entity_name: Entity identifier (e.g. "left_base").
+            trajectory: Time-parameterized trajectory.
+
+        Returns:
+            True if execution completed.
+        """
+        if entity_name not in self._entities:
+            raise ValueError(f"Unknown entity: {entity_name}")
+
+        state = self._entities[entity_name]
+
+        if trajectory.dof != len(state.joint_qpos_indices):
+            raise ValueError(
+                f"Trajectory DOF {trajectory.dof} doesn't match entity joint count {len(state.joint_qpos_indices)}"
+            )
+
+        realtime = self.viewer is not None
+        t_start = time.time() if realtime else 0.0
+        for i in range(trajectory.num_waypoints):
+            if self._abort_fn is not None and self._abort_fn():
+                logger.info("Entity trajectory aborted at waypoint %d/%d", i, trajectory.num_waypoints)
+                return False
+            state.target_position = trajectory.positions[i]
+            state.target_velocity = trajectory.velocities[i]
+            self.step()
+            if realtime:
+                t_target = t_start + (i + 1) * self.control_dt
+                t_remaining = t_target - time.time()
+                if t_remaining > 0:
+                    time.sleep(t_remaining)
+
+        state.target_position = trajectory.positions[-1].copy()
+        state.target_velocity = np.zeros(len(state.actuator_ids))
+        return True
+
+    def _wait_for_convergence(
+        self,
+        arm_name: str,
+        position_tolerance: float | None = None,
+        velocity_tolerance: float | None = None,
+        timeout_steps: int | None = None,
+    ) -> bool:
+        """Wait for arm to converge to target position.
+
+        In physics mode, the arm's PD controller drives it to the target
+        over multiple steps. In kinematic mode, targets are written directly
+        to qpos, so convergence succeeds on the first check.
+
+        Returns True if converged, False on timeout.
+        """
+        cfg = self.config
+        if position_tolerance is None:
+            position_tolerance = cfg.position_tolerance
+        if velocity_tolerance is None:
+            velocity_tolerance = cfg.velocity_tolerance
+        if timeout_steps is None:
+            timeout_steps = cfg.convergence_timeout_steps
+
+        state = self._arms[arm_name]
+        pos_error = np.zeros(len(state.joint_qpos_indices))
+        current_vel = np.zeros(len(state.joint_qvel_indices))
+
+        for _ in range(timeout_steps):
+            self.step()
+
+            current_pos = self.data.qpos[state.joint_qpos_indices]
+            pos_error = np.abs(state.target_position - current_pos)
+
+            current_vel = self.data.qvel[state.joint_qvel_indices]
+
+            if np.all(pos_error < position_tolerance) and np.all(np.abs(current_vel) < velocity_tolerance):
+                return True
+
+        logger.warning(
+            "Convergence timeout for %s: max_pos_err=%.2f° (limit %.2f°), max_vel=%.3f rad/s (limit %.3f)",
+            arm_name,
+            np.rad2deg(np.max(pos_error)),
+            np.rad2deg(position_tolerance),
+            np.max(np.abs(current_vel)),
+            velocity_tolerance,
+        )
+        return False
+
+    # -- Gripper control (abstract) -----------------------------------------
+
+    @abstractmethod
+    def close_gripper(
+        self,
+        arm_name: str,
+        candidate_objects: list[str] | None = None,
+        steps: int | None = None,
+    ) -> bool:
+        """Close the gripper for the specified arm.
+
+        Args:
+            arm_name: Which arm's gripper to close.
+            candidate_objects: Optional list of expected grasp targets.
+            steps: Number of close steps (mode-specific default if None).
+
+        Returns:
+            True if the close sequence completed, False if no gripper.
+        """
+
+    @abstractmethod
+    def open_gripper(self, arm_name: str, steps: int | None = None) -> None:
+        """Open the gripper for the specified arm.
+
+        Args:
+            arm_name: Which arm's gripper to open.
+            steps: Number of open steps (mode-specific default if None).
+        """
+
+    # -- Executor wrappers --------------------------------------------------
+
+    def get_executor(self, arm_name: str) -> ArmExecutor:
+        """Get Executor interface for a single arm.
+
+        Returns an object with the standard ``Executor.execute(trajectory)``
+        interface that internally delegates to this controller.
+
+        Args:
+            arm_name: Which arm to create an executor for.
+        """
+        if arm_name not in self._arms:
+            raise ValueError(f"Unknown arm: {arm_name}")
+        return ArmExecutor(self, arm_name)
+
+    def get_entity_executor(self, entity_name: str) -> EntityExecutor:
+        """Get Executor interface for an entity (base, etc.)."""
+        if entity_name not in self._entities:
+            raise ValueError(f"Unknown entity: {entity_name}")
+        return EntityExecutor(self, entity_name)

--- a/src/mj_manipulator/demos/franka_setup.py
+++ b/src/mj_manipulator/demos/franka_setup.py
@@ -189,14 +189,9 @@ class FrankaDemoRobot(RobotBase):
         if gripper and gripper.actuator_id is not None:
             self.data.ctrl[gripper.actuator_id] = gripper.ctrl_open
 
+        # Deactivate teleop, release grasps, abort runners, hold at new qpos
         if self._context is not None:
-            self._context.hold()
-
-        # Release any active grasps
-        for arm_name in list(self.arms.keys()):
-            for obj in list(self.grasp_manager.get_grasped_by(arm_name)):
-                self.grasp_manager.mark_released(obj)
-                self.grasp_manager.detach_object(obj)
+            self._context.reset_state()
 
         # Hide everything currently active
         if self._env.registry is not None:

--- a/src/mj_manipulator/demos/iiwa14_setup.py
+++ b/src/mj_manipulator/demos/iiwa14_setup.py
@@ -264,13 +264,9 @@ class IIWA14DemoRobot(RobotBase):
         if gripper and gripper.actuator_id is not None:
             self.data.ctrl[gripper.actuator_id] = gripper.ctrl_open
 
+        # Deactivate teleop, release grasps, abort runners, hold at new qpos
         if self._context is not None:
-            self._context.hold()
-
-        for arm_name in list(self.arms.keys()):
-            for obj in list(self.grasp_manager.get_grasped_by(arm_name)):
-                self.grasp_manager.mark_released(obj)
-                self.grasp_manager.detach_object(obj)
+            self._context.reset_state()
 
         if self._env.registry is not None:
             for obj_type in list(self._env.registry.objects.keys()):

--- a/src/mj_manipulator/event_loop.py
+++ b/src/mj_manipulator/event_loop.py
@@ -8,11 +8,11 @@ This module provides a PhysicsEventLoop that ensures all MuJoCo access
 happens on one thread. Other threads submit work via Futures.
 
 Design follows the game loop / update method pattern: tick() is the single
-owner of the physics step. Trajectory runners and teleop controllers are
-target providers that write to arm state each tick. One mj_step per cycle
-with all arms' targets applied.
+owner of the step. Trajectory runners and teleop controllers are target
+providers that write to arm state each tick. One step per cycle with all
+arms' targets applied. Works identically for physics and kinematic modes.
 
-Usage (from geodude console.py)::
+Usage (from console.py)::
 
     loop = PhysicsEventLoop()
     # ... pass loop to SimContext ...
@@ -35,7 +35,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
-    from mj_manipulator.physics_controller import PhysicsController
+    from mj_manipulator.controller import Controller
 
 logger = logging.getLogger(__name__)
 
@@ -58,12 +58,10 @@ class PhysicsEventLoop:
     The owner thread calls tick() in a loop (typically an IPython inputhook).
     Each tick:
 
-    1. Processes queued commands (fast — e.g. starting a trajectory runner)
-    2. Advances active trajectory runners (writes targets)
+    1. Advances active trajectory runners (writes targets)
+    2. Processes queued commands (fast — e.g. starting a trajectory runner)
     3. Steps active teleop controllers (writes targets)
-    4. Calls controller.step() — ONE mj_step with all arms
-    5. Syncs the viewer
-    6. Falls back to idle step if nothing else ran
+    4. Calls controller.step() — one control cycle with all arms
     """
 
     def __init__(self) -> None:
@@ -71,18 +69,16 @@ class PhysicsEventLoop:
         self._owner_thread: int = threading.get_ident()
         self._teleop_entries: list[tuple[Any, Any]] = []  # (controller, panel)
         self._teleop_lock = threading.Lock()  # protects _teleop_entries
-        self._controller: PhysicsController | None = None
-        self._idle_step_fn: Callable[[], None] | None = None
-        self._viewer_sync_fn: Callable[[], None] | None = None
+        self._controller: Controller | None = None
         self._in_tick: bool = False  # reentrancy guard
 
     # -- Controller setup (called from SimContext.__enter__) ------------------
 
-    def set_controller(self, controller: PhysicsController | None) -> None:
-        """Set the PhysicsController that tick() drives.
+    def set_controller(self, controller: Controller | None) -> None:
+        """Set the Controller that tick() drives.
 
         When set, tick() calls controller.advance_all() and controller.step()
-        each cycle. When None, falls back to idle_step_fn.
+        each cycle. When None, tick() is a no-op.
         """
         self._controller = controller
 
@@ -144,33 +140,26 @@ class PhysicsEventLoop:
     def tick(self) -> None:
         """Process one event loop cycle. Called from the inputhook.
 
-        When a PhysicsController is set (tick-driven mode):
+        Requires a controller to be set via :meth:`set_controller`.
+        Each tick:
 
-        1. Process all queued commands (fast — start runners, etc.)
-        2. Advance active trajectory runners (write targets)
+        1. Advance active trajectory runners (write targets)
+        2. Process all queued commands (fast — start runners, etc.)
         3. Step active teleop controllers (write targets)
-        4. controller.step() — ONE mj_step with all arms
-        5. Sync viewer
-
-        When no controller is set (legacy mode):
-
-        1. Process one queued command (may block — e.g. execute)
-        2. Step active teleop controllers
-        3. Idle physics step
+        4. controller.step() — one control cycle with all arms
         """
         if self._in_tick:
             return  # prevent recursion (e.g. teleop → step_cartesian → tick)
+        if self._controller is None:
+            return
         self._in_tick = True
         try:
-            if self._controller is not None:
-                self._tick_driven()
-            else:
-                self._tick_legacy()
+            self._tick_driven()
         finally:
             self._in_tick = False
 
     def _tick_driven(self) -> None:
-        """Tick-driven mode: controller owns physics, runners provide targets."""
+        """Controller-driven tick: runners provide targets, controller steps."""
         # 1. Advance active trajectory runners (writes targets)
         #    Runs BEFORE commands so that abort flags set by preempt()
         #    are seen before _do_activate clears them.
@@ -188,7 +177,7 @@ class PhysicsEventLoop:
             except Exception as e:
                 cmd.future.set_exception(e)
 
-        # 3. Step active teleop controllers (writes targets, no mj_step)
+        # 3. Step active teleop controllers (writes targets, no step)
         with self._teleop_lock:
             entries = list(self._teleop_entries)
         for controller, panel in entries:
@@ -203,55 +192,6 @@ class PhysicsEventLoop:
                     if panel is not None:
                         panel._on_teleop_error()
 
-        # 4. Single physics step for ALL arms
-        # (PhysicsController.step → _step_physics handles throttled viewer sync)
+        # 4. Single control step for ALL arms
+        # (Controller.step → _apply_targets_and_step handles mode-specific logic)
         self._controller.step()
-
-    def _tick_legacy(self) -> None:
-        """Legacy mode: backwards compatible with blocking execute()."""
-        stepped = False
-
-        # 1. Process one queued command (may block for seconds — e.g. execute)
-        try:
-            cmd = self._queue.get_nowait()
-        except queue.Empty:
-            pass
-        else:
-            self._deactivate_all_teleop()
-            try:
-                result = cmd.fn()
-                cmd.future.set_result(result)
-            except Exception as e:
-                cmd.future.set_exception(e)
-            stepped = True
-            return
-
-        # 2. Step active teleop controllers
-        with self._teleop_lock:
-            entries = list(self._teleop_entries)
-        for controller, panel in entries:
-            if controller.is_active:
-                try:
-                    state = controller.step()
-                    if panel is not None:
-                        panel._update_status(state)
-                except Exception as e:
-                    logger.warning("Teleop step error: %s", e)
-                    controller.deactivate()
-                    if panel is not None:
-                        panel._on_teleop_error()
-                stepped = True
-
-        if stepped and self._viewer_sync_fn is not None:
-            try:
-                self._viewer_sync_fn()
-            except Exception:
-                pass
-            return
-
-        # 3. Idle physics step (gravity, contacts, F/T sensors)
-        if self._idle_step_fn is not None:
-            try:
-                self._idle_step_fn()
-            except Exception:
-                pass

--- a/src/mj_manipulator/kinematic_controller.py
+++ b/src/mj_manipulator/kinematic_controller.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Kinematic-mode controller for MuJoCo simulation.
+
+Subclass of :class:`Controller` that writes joint positions directly
+to ``data.qpos`` and calls ``mj_forward`` (no physics dynamics). Used
+for fast planning visualization, testing, and as the fallback on the
+real robot when perception data is unavailable.
+
+Provides the same orchestration as PhysicsController (non-blocking
+trajectory runners, per-arm ownership, concurrent multi-arm control)
+but with instant, exact tracking instead of PD convergence.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import mujoco
+import numpy as np
+
+from mj_manipulator.config import ExecutionConfig
+from mj_manipulator.controller import Controller
+
+if TYPE_CHECKING:
+    from mj_manipulator.arm import Arm
+
+logger = logging.getLogger(__name__)
+
+# Default kinematic control_dt: 250 Hz (faster than physics 125 Hz since
+# there's no simulation cost, just mj_forward)
+_KINEMATIC_CONTROL_DT = 0.004
+
+
+class KinematicController(Controller):
+    """Kinematic controller — direct qpos writes with mj_forward.
+
+    Targets are written directly to ``data.qpos`` each step, giving
+    instant and exact tracking. No physics dynamics, no actuator ctrl
+    writes, no convergence settling needed.
+
+    Attached objects (kinematic welds via GraspManager) are updated
+    each step since there's no physics solver to maintain them.
+
+    Args:
+        model: MuJoCo model.
+        data: MuJoCo data (modified during execution).
+        arms: Dict mapping arm names to Arm instances.
+        config: Execution parameters. Defaults to 250 Hz control_dt.
+        viewer: Optional viewer to sync during execution.
+        viewer_sync_interval: Minimum seconds between viewer syncs.
+        initial_positions: Optional per-arm initial joint positions.
+        entities: Optional dict of non-arm controllable entities.
+        abort_fn: Optional global abort predicate.
+    """
+
+    def __init__(
+        self,
+        model: mujoco.MjModel,
+        data: mujoco.MjData,
+        arms: dict[str, Arm],
+        *,
+        config: ExecutionConfig | None = None,
+        viewer=None,
+        viewer_sync_interval: float = 0.033,
+        initial_positions: dict[str, np.ndarray] | None = None,
+        entities: dict[str, object] | None = None,
+        abort_fn=None,
+    ):
+        if config is None:
+            config = ExecutionConfig(control_dt=_KINEMATIC_CONTROL_DT)
+        super().__init__(
+            model,
+            data,
+            arms,
+            config=config,
+            gripper_config=None,
+            viewer=viewer,
+            viewer_sync_interval=viewer_sync_interval,
+            initial_positions=initial_positions,
+            entities=entities,
+            abort_fn=abort_fn,
+        )
+
+    # -- Stepping (kinematic-specific) --------------------------------------
+
+    def _apply_targets_and_step(self) -> None:
+        """Write targets to qpos, run mj_forward, update grasp attachments.
+
+        No actuator ctrl writes, no mj_step, no verifier ticks. Just
+        direct position setting followed by forward kinematics and
+        grasp manager updates for kinematic welds.
+        """
+        # Write arm targets directly to qpos
+        for state in self._arms.values():
+            self.data.qpos[state.joint_qpos_indices] = state.target_position
+            self.data.qvel[state.joint_qvel_indices] = 0.0
+
+        # Write entity targets directly to qpos
+        for state in self._entities.values():
+            self.data.qpos[state.joint_qpos_indices] = state.target_position
+            self.data.qvel[state.joint_qvel_indices] = 0.0
+
+        # Forward kinematics (computes site/body poses from qpos)
+        mujoco.mj_forward(self.model, self.data)
+
+        # Update attached object poses (kinematic welds). In physics mode,
+        # MuJoCo contacts/constraints maintain the grasp. In kinematic mode
+        # there's no solver, so we must manually update attached poses.
+        has_grasp_managers = False
+        for astate in self._arms.values():
+            gm = astate.arm.grasp_manager
+            if gm is not None:
+                gm.update_attached_poses()
+                has_grasp_managers = True
+
+        # Second mj_forward needed if any grasp manager modified object qpos
+        if has_grasp_managers:
+            mujoco.mj_forward(self.model, self.data)
+
+        self._throttled_viewer_sync()
+
+    # -- Gripper control (kinematic-specific) -------------------------------
+
+    def close_gripper(
+        self,
+        arm_name: str,
+        candidate_objects: list[str] | None = None,
+        steps: int | None = None,
+    ) -> bool:
+        """Close the gripper kinematically.
+
+        Delegates to the gripper's ``kinematic_close()`` method which
+        interpolates joint positions and scans contacts to detect when
+        to stop. No physics stepping, no ctrl ramp.
+
+        Args:
+            arm_name: Which arm's gripper to close.
+            candidate_objects: Objects the gripper should try to grasp.
+            steps: Unused (kinematic close has its own step count).
+
+        Returns:
+            True if the close sequence completed, False if no gripper.
+        """
+        del steps  # kinematic_close manages its own steps
+
+        if arm_name not in self._grippers:
+            logger.warning("No gripper found for %s", arm_name)
+            return False
+
+        gripper = self._arms[arm_name].arm.gripper
+        gripper.set_candidate_objects(candidate_objects)
+        gripper.kinematic_close()
+        self._apply_targets_and_step()  # sync state after gripper move
+        return True
+
+    def open_gripper(self, arm_name: str, steps: int | None = None) -> None:
+        """Open the gripper kinematically.
+
+        Delegates to the gripper's ``kinematic_open()`` method which
+        directly sets joint positions to the open configuration.
+
+        Args:
+            arm_name: Which arm's gripper to open.
+            steps: Unused (kinematic open is instant).
+        """
+        del steps  # kinematic_open is instant
+
+        if arm_name not in self._grippers:
+            logger.warning("No gripper found for %s", arm_name)
+            return
+
+        gripper = self._arms[arm_name].arm.gripper
+        gripper.kinematic_open()
+        self._apply_targets_and_step()  # sync state after gripper move

--- a/src/mj_manipulator/physics_controller.py
+++ b/src/mj_manipulator/physics_controller.py
@@ -1,12 +1,12 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2025 Siddhartha Srinivasa
 
-"""Multi-arm physics controller for MuJoCo simulation.
+"""Physics-mode controller for MuJoCo simulation.
 
-Coordinates all arm and gripper actuators each physics step to prevent
-gravity collapse on idle arms. Provides trajectory execution with
-convergence-based settling, gripper actuation with contact detection,
-and reactive streaming for cartesian control.
+Subclass of :class:`Controller` that steps MuJoCo physics each control
+cycle. Coordinates all arm and gripper actuators to prevent gravity
+collapse on idle arms. Provides velocity feedforward, convergence-based
+settling, gradual gripper control ramps, and reactive streaming.
 
 This is a simulation-only component. On real hardware, the robot's own
 controller (RTDE, ROS, libfranka) handles actuator coordination.
@@ -16,203 +16,34 @@ from __future__ import annotations
 
 import logging
 import time
-from concurrent.futures import Future
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 import mujoco
 import numpy as np
 
 from mj_manipulator.config import GripperPhysicsConfig, PhysicsExecutionConfig
+from mj_manipulator.controller import (
+    ArmExecutor,
+    Controller,
+    EntityExecutor,
+    TrajectoryRunner,
+    _ArmState,
+    _EntityState,
+    _GripperState,
+)
 
 if TYPE_CHECKING:
     from mj_manipulator.arm import Arm
-    from mj_manipulator.protocols import Gripper
     from mj_manipulator.trajectory import Trajectory
 
 logger = logging.getLogger(__name__)
 
-
-# ---------------------------------------------------------------------------
-# Internal per-arm / per-gripper state
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class _ArmState:
-    """Per-arm state managed by PhysicsController."""
-
-    arm: Arm
-    actuator_ids: np.ndarray  # int array for vectorized ctrl writes
-    joint_qpos_indices: np.ndarray
-    joint_qvel_indices: np.ndarray
-    target_position: np.ndarray
-    target_velocity: np.ndarray
-    lookahead: float | None = None  # None = use controller default
+# Backwards compatibility aliases — these classes moved to controller.py
+ArmPhysicsExecutor = ArmExecutor
+EntityPhysicsExecutor = EntityExecutor
 
 
-@dataclass
-class _EntityState:
-    """Per-entity state for non-arm controllable entities (e.g. linear bases)."""
-
-    actuator_ids: np.ndarray
-    joint_qpos_indices: np.ndarray
-    joint_qvel_indices: np.ndarray
-    target_position: np.ndarray
-    target_velocity: np.ndarray
-
-
-@dataclass
-class _GripperState:
-    """Per-gripper state managed by PhysicsController."""
-
-    gripper: Gripper
-    actuator_id: int
-    ctrl_open: float
-    ctrl_closed: float
-    target_ctrl: float
-
-
-# ---------------------------------------------------------------------------
-# TrajectoryRunner
-# ---------------------------------------------------------------------------
-
-
-class TrajectoryRunner:
-    """Non-blocking trajectory target provider.
-
-    Advances one waypoint per call to :meth:`advance`, writing targets to
-    the arm's ``_ArmState``. Does NOT call ``mj_step`` — the event loop
-    owns physics stepping.
-
-    This is the "update method" pattern from game programming: the game
-    loop calls ``runner.advance()`` each frame, then steps physics once
-    with all arms' targets applied.
-
-    Created via :meth:`PhysicsController.start_trajectory`.
-    """
-
-    def __init__(
-        self,
-        controller: PhysicsController,
-        entity_name: str,
-        trajectory: Trajectory,
-        abort_fn: Callable[[], bool] | None = None,
-    ):
-        self._controller = controller
-        self._entity_name = entity_name
-        self._trajectory = trajectory
-        self._abort_fn = abort_fn
-        self._waypoint_index = 0
-        self._done = False
-        self._converging = False
-        self._convergence_steps = 0
-        self._future: Future[bool] = Future()
-        self._realtime = controller.viewer is not None
-        self._t_start = time.time() if self._realtime else 0.0
-
-        # Resolve state from arms or entities
-        if entity_name in controller._arms:
-            self._state = controller._arms[entity_name]
-            self._is_arm = True
-        elif entity_name in controller._entities:
-            self._state = controller._entities[entity_name]
-            self._is_arm = False
-        else:
-            raise ValueError(f"Unknown arm or entity: {entity_name}")
-
-    @property
-    def entity_name(self) -> str:
-        """Which arm or entity this runner controls."""
-        return self._entity_name
-
-    @property
-    def done(self) -> bool:
-        """Whether the trajectory has completed (success or abort)."""
-        return self._done
-
-    @property
-    def future(self) -> Future[bool]:
-        """Future that resolves when the trajectory completes."""
-        return self._future
-
-    def advance(self) -> None:
-        """Write next waypoint target to arm state.
-
-        Call once per tick. After the last waypoint, enters convergence
-        mode (checking position/velocity error each tick).
-        """
-        if self._done:
-            return
-
-        if self._abort_fn is not None and self._abort_fn():
-            self._state.target_velocity = np.zeros(len(self._state.actuator_ids))
-            self._finish(False)
-            logger.info(
-                "Trajectory aborted at waypoint %d/%d",
-                self._waypoint_index,
-                self._trajectory.num_waypoints,
-            )
-            return
-
-        if self._converging:
-            self._advance_convergence()
-            return
-
-        state = self._state
-        traj = self._trajectory
-
-        state.target_position = traj.positions[self._waypoint_index]
-        state.target_velocity = traj.velocities[self._waypoint_index]
-
-        self._waypoint_index += 1
-
-        if self._waypoint_index >= traj.num_waypoints:
-            state.target_position = traj.positions[-1].copy()
-            state.target_velocity = np.zeros(len(state.actuator_ids))
-            if self._is_arm:
-                # Arms need convergence settling (PD dynamics)
-                self._converging = True
-            else:
-                # Entities (bases) don't need convergence
-                self._finish(True)
-
-    def _advance_convergence(self) -> None:
-        """Check convergence one step at a time."""
-        cfg = self._controller.config
-        state = self._state
-        data = self._controller.data
-
-        current_pos = data.qpos[state.joint_qpos_indices]
-        pos_error = np.abs(state.target_position - current_pos)
-        current_vel = data.qvel[state.joint_qvel_indices]
-
-        if np.all(pos_error < cfg.position_tolerance) and np.all(np.abs(current_vel) < cfg.velocity_tolerance):
-            self._finish(True)
-            return
-
-        self._convergence_steps += 1
-        if self._convergence_steps >= cfg.convergence_timeout_steps:
-            logger.warning(
-                "Convergence timeout for %s: max_pos_err=%.2f° (limit %.2f°)",
-                self._entity_name,
-                np.rad2deg(float(np.max(pos_error))),
-                np.rad2deg(cfg.position_tolerance),
-            )
-            self._finish(True)  # timed out but close enough
-
-    def _finish(self, success: bool) -> None:
-        self._done = True
-        if not self._future.done():
-            self._future.set_result(success)
-
-
-# ---------------------------------------------------------------------------
-# PhysicsController
-# ---------------------------------------------------------------------------
-
-
-class PhysicsController:
+class PhysicsController(Controller):
     """Multi-arm physics controller for MuJoCo simulation.
 
     In physics simulation, ALL actuators must be controlled — otherwise
@@ -259,73 +90,25 @@ class PhysicsController:
         entities: dict[str, object] | None = None,
         abort_fn=None,
     ):
-        self.model = model
-        self.data = data
-        self.viewer = viewer
-        self._abort_fn = abort_fn
+        gripper_config = gripper_config or GripperPhysicsConfig()
+        super().__init__(
+            model,
+            data,
+            arms,
+            config=config,
+            gripper_config=gripper_config,
+            viewer=viewer,
+            viewer_sync_interval=viewer_sync_interval,
+            initial_positions=initial_positions,
+            entities=entities,
+            abort_fn=abort_fn,
+        )
 
-        self.config = config or PhysicsExecutionConfig()
-        self.gripper_config = gripper_config or GripperPhysicsConfig()
-
-        self.control_dt = self.config.control_dt
-        self.lookahead_time = self.config.lookahead_time
+        self.gripper_config: GripperPhysicsConfig  # narrow the type
         self.steps_per_control = max(1, int(self.control_dt / model.opt.timestep))
 
-        self._last_viewer_sync = 0.0
-        self._viewer_sync_interval = viewer_sync_interval
-
-        # Build per-arm state
-        self._arms: dict[str, _ArmState] = {}
-        self._grippers: dict[str, _GripperState] = {}
-
-        for name, arm in arms.items():
-            if initial_positions and name in initial_positions:
-                target_pos = np.asarray(initial_positions[name]).copy()
-            else:
-                target_pos = arm.get_joint_positions().copy()
-
-            self._arms[name] = _ArmState(
-                arm=arm,
-                actuator_ids=np.array(arm.actuator_ids, dtype=np.intp),
-                joint_qpos_indices=np.array(arm.joint_qpos_indices, dtype=np.intp),
-                joint_qvel_indices=np.array(arm.joint_qvel_indices, dtype=np.intp),
-                target_position=target_pos,
-                target_velocity=np.zeros(arm.dof),
-            )
-
-            gripper = arm.gripper
-            if gripper is not None and gripper.actuator_id is not None:
-                self._grippers[name] = _GripperState(
-                    gripper=gripper,
-                    actuator_id=gripper.actuator_id,
-                    ctrl_open=gripper.ctrl_open,
-                    ctrl_closed=gripper.ctrl_closed,
-                    target_ctrl=data.ctrl[gripper.actuator_id],
-                )
-
-        # Build per-entity state (linear bases, etc.)
-        self._entities: dict[str, _EntityState] = {}
-        for name, entity in (entities or {}).items():
-            qpos_idx = np.array(entity.joint_qpos_indices, dtype=np.intp)
-            target_pos = data.qpos[qpos_idx].copy()
-            self._entities[name] = _EntityState(
-                actuator_ids=np.array(entity.actuator_ids, dtype=np.intp),
-                joint_qpos_indices=qpos_idx,
-                joint_qvel_indices=np.array(
-                    entity.joint_qvel_indices,
-                    dtype=np.intp,
-                ),
-                target_position=target_pos,
-                target_velocity=np.zeros(len(qpos_idx)),
-            )
-
-        # Active non-blocking trajectory runners (arm_name → TrajectoryRunner)
-        self._runners: dict[str, TrajectoryRunner] = {}
-
-        # Initialize qpos/qvel/ctrl to targets (prevents violent jumps)
+        # Physics-specific: initialize ctrl to targets (prevents gravity collapse)
         for state in self._arms.values():
-            data.qpos[state.joint_qpos_indices] = state.target_position
-            data.qvel[state.joint_qvel_indices] = 0.0
             data.ctrl[state.actuator_ids] = state.target_position
 
         for state in self._entities.values():
@@ -333,51 +116,14 @@ class PhysicsController:
 
         mujoco.mj_forward(model, data)
 
-    # -- Target management --------------------------------------------------
+    # -- Stepping (physics-specific) ----------------------------------------
 
-    def hold_all(self) -> None:
-        """Update all targets (arms, entities, grippers) to current positions."""
-        for state in self._arms.values():
-            state.target_position = self.data.qpos[state.joint_qpos_indices].copy()
-            state.target_velocity = np.zeros(len(state.actuator_ids))
-
-        for state in self._entities.values():
-            state.target_position = self.data.qpos[state.joint_qpos_indices].copy()
-            state.target_velocity = np.zeros(len(state.target_velocity))
-
-        for name, gs in self._grippers.items():
-            gs.target_ctrl = gs.ctrl_open
-            self.data.ctrl[gs.actuator_id] = gs.ctrl_open
-
-    def set_arm_target(
-        self,
-        arm_name: str,
-        position: np.ndarray,
-        velocity: np.ndarray | None = None,
-    ) -> None:
-        """Set target position and velocity for an arm.
-
-        Args:
-            arm_name: Arm identifier.
-            position: Target joint positions (rad).
-            velocity: Target joint velocities (rad/s), or None for zero.
-        """
-        if arm_name not in self._arms:
-            raise ValueError(f"Unknown arm: {arm_name}")
-
-        state = self._arms[arm_name]
-        state.target_position = np.asarray(position).copy()
-        state.target_velocity = (
-            np.asarray(velocity).copy() if velocity is not None else np.zeros(len(state.actuator_ids))
-        )
-
-    # -- Physics stepping ---------------------------------------------------
-
-    def step(self) -> None:
+    def _apply_targets_and_step(self) -> None:
         """Apply control to all actuators and step physics.
 
-        Uses full ``lookahead_time`` for velocity feedforward. For reactive
-        streaming control, use :meth:`step_reactive` instead.
+        Uses full ``lookahead_time`` for velocity feedforward, applies
+        gripper ctrl, calls ``mj_step``, ticks grasp verifiers, and
+        syncs the viewer (throttled).
         """
         # Arm actuators: position + velocity feedforward (per-arm lookahead)
         for state in self._arms.values():
@@ -390,7 +136,27 @@ class PhysicsController:
             q_cmd = state.target_position + self.lookahead_time * state.target_velocity
             self.data.ctrl[state.actuator_ids] = q_cmd
 
-        self._step_physics()
+        # Gripper ctrl
+        for gstate in self._grippers.values():
+            self.data.ctrl[gstate.actuator_id] = gstate.target_ctrl
+
+        # Step MuJoCo physics
+        for _ in range(self.steps_per_control):
+            mujoco.mj_step(self.model, self.data)
+
+        # Tick every configured GraspVerifier exactly once per control
+        # cycle. This is the single "advance time by one control cycle"
+        # primitive in physics mode, so every execution path
+        # (ctx.step, ctx.execute, gripper close sequences, trajectory
+        # runners) transitively runs verifier ticks through here. No
+        # consumer needs to remember to tick. Arms without a verifier
+        # are no-ops.
+        for astate in self._arms.values():
+            gripper = astate.arm.gripper
+            if gripper is not None and gripper.grasp_verifier is not None:
+                gripper.grasp_verifier.tick()
+
+        self._throttled_viewer_sync()
 
     def step_reactive(
         self,
@@ -428,172 +194,21 @@ class PhysicsController:
             if other_name != arm_name:
                 self.data.ctrl[other_state.actuator_ids] = other_state.target_position
 
-        self._step_physics()
+        # Gripper ctrl + mj_step + verifiers + viewer sync
+        for gstate in self._grippers.values():
+            self.data.ctrl[gstate.actuator_id] = gstate.target_ctrl
 
-    # -- Trajectory execution -----------------------------------------------
+        for _ in range(self.steps_per_control):
+            mujoco.mj_step(self.model, self.data)
 
-    def execute(self, arm_name: str, trajectory: Trajectory) -> bool:
-        """Execute trajectory on one arm while others hold position.
+        for astate in self._arms.values():
+            gripper = astate.arm.gripper
+            if gripper is not None and gripper.grasp_verifier is not None:
+                gripper.grasp_verifier.tick()
 
-        After the trajectory completes, waits for the arm to converge to
-        the final target (convergence-based settling, not fixed steps).
+        self._throttled_viewer_sync()
 
-        Args:
-            arm_name: Which arm to execute on.
-            trajectory: Time-parameterized trajectory.
-
-        Returns:
-            True if execution completed and arm converged.
-        """
-        if arm_name not in self._arms:
-            raise ValueError(f"Unknown arm: {arm_name}")
-
-        state = self._arms[arm_name]
-
-        if trajectory.dof != len(state.joint_qpos_indices):
-            raise ValueError(
-                f"Trajectory DOF {trajectory.dof} doesn't match arm joint count {len(state.joint_qpos_indices)}"
-            )
-
-        # Follow trajectory at real-time rate
-        realtime = self.viewer is not None
-        t_start = time.time() if realtime else 0.0
-        for i in range(trajectory.num_waypoints):
-            if self._abort_fn is not None and self._abort_fn():
-                logger.info("Trajectory aborted at waypoint %d/%d", i, trajectory.num_waypoints)
-                # Zero velocity so arm holds position while other arms move
-                state.target_velocity = np.zeros(len(state.actuator_ids))
-                return False
-            state.target_position = trajectory.positions[i]
-            state.target_velocity = trajectory.velocities[i]
-            self.step()
-            if realtime:
-                t_target = t_start + (i + 1) * self.control_dt
-                t_remaining = t_target - time.time()
-                if t_remaining > 0:
-                    time.sleep(t_remaining)
-
-        # Hold final position (zero velocity)
-        state.target_position = trajectory.positions[-1].copy()
-        state.target_velocity = np.zeros(len(state.actuator_ids))
-
-        return self._wait_for_convergence(arm_name)
-
-    def _wait_for_convergence(
-        self,
-        arm_name: str,
-        position_tolerance: float | None = None,
-        velocity_tolerance: float | None = None,
-        timeout_steps: int | None = None,
-    ) -> bool:
-        """Wait for arm to converge to target position.
-
-        Returns True if converged, False on timeout.
-        """
-        cfg = self.config
-        if position_tolerance is None:
-            position_tolerance = cfg.position_tolerance
-        if velocity_tolerance is None:
-            velocity_tolerance = cfg.velocity_tolerance
-        if timeout_steps is None:
-            timeout_steps = cfg.convergence_timeout_steps
-
-        state = self._arms[arm_name]
-        pos_error = np.zeros(len(state.joint_qpos_indices))
-        current_vel = np.zeros(len(state.joint_qvel_indices))
-
-        for _ in range(timeout_steps):
-            self.step()
-
-            current_pos = self.data.qpos[state.joint_qpos_indices]
-            pos_error = np.abs(state.target_position - current_pos)
-
-            current_vel = self.data.qvel[state.joint_qvel_indices]
-
-            if np.all(pos_error < position_tolerance) and np.all(np.abs(current_vel) < velocity_tolerance):
-                return True
-
-        logger.warning(
-            "Convergence timeout for %s: max_pos_err=%.2f° (limit %.2f°), max_vel=%.3f rad/s (limit %.3f)",
-            arm_name,
-            np.rad2deg(np.max(pos_error)),
-            np.rad2deg(position_tolerance),
-            np.max(np.abs(current_vel)),
-            velocity_tolerance,
-        )
-        return False
-
-    # -- Non-blocking trajectory execution ------------------------------------
-
-    def start_trajectory(
-        self,
-        entity_name: str,
-        trajectory: Trajectory,
-        abort_fn: Callable[[], bool] | None = None,
-    ) -> Future[bool]:
-        """Start a non-blocking trajectory on an arm or entity.
-
-        Returns a Future that resolves to True when the trajectory completes
-        (and the arm converges, if applicable), or False if aborted. The
-        caller blocks on the Future while :meth:`advance_all` (called by
-        the event loop's tick) drives the trajectory forward one waypoint
-        per cycle.
-
-        Args:
-            entity_name: Which arm or entity to execute on.
-            trajectory: Time-parameterized trajectory.
-            abort_fn: Per-entity abort check. Runner stops when this returns True.
-
-        Returns:
-            Future[bool] — resolves when trajectory finishes.
-        """
-        # Resolve state for DOF validation
-        if entity_name in self._arms:
-            state = self._arms[entity_name]
-        elif entity_name in self._entities:
-            state = self._entities[entity_name]
-        else:
-            raise ValueError(f"Unknown arm or entity: {entity_name}")
-
-        if trajectory.dof != len(state.joint_qpos_indices):
-            raise ValueError(
-                f"Trajectory DOF {trajectory.dof} doesn't match joint count {len(state.joint_qpos_indices)}"
-            )
-
-        runner = TrajectoryRunner(self, entity_name, trajectory, abort_fn)
-        self._runners[entity_name] = runner
-        logger.debug(
-            "Started trajectory on %s (%d waypoints)",
-            entity_name,
-            trajectory.num_waypoints,
-        )
-        return runner.future
-
-    def advance_all(self) -> None:
-        """Advance all active trajectory runners one waypoint each.
-
-        Called by the event loop's tick() before :meth:`step`. Runners that
-        are done are automatically removed.
-        """
-        if not self._runners:
-            return
-
-        done_arms = []
-        for arm_name, runner in self._runners.items():
-            runner.advance()
-            if runner.done:
-                done_arms.append(arm_name)
-
-        for arm_name in done_arms:
-            del self._runners[arm_name]
-
-    def has_active_runner(self, arm_name: str | None = None) -> bool:
-        """Check if any (or a specific) arm has an active trajectory runner."""
-        if arm_name is not None:
-            return arm_name in self._runners
-        return bool(self._runners)
-
-    # -- Gripper control ----------------------------------------------------
+    # -- Gripper control (physics-specific) ---------------------------------
 
     def close_gripper(
         self,
@@ -689,131 +304,3 @@ class PhysicsController:
             self.step()
             if sleep_dt > 0:
                 time.sleep(sleep_dt)
-
-    # -- Entity trajectory execution ----------------------------------------
-
-    def execute_entity(self, entity_name: str, trajectory: Trajectory) -> bool:
-        """Execute trajectory on an entity while arms and other entities hold.
-
-        Args:
-            entity_name: Entity identifier (e.g. "left_base").
-            trajectory: Time-parameterized trajectory.
-
-        Returns:
-            True if execution completed.
-        """
-        if entity_name not in self._entities:
-            raise ValueError(f"Unknown entity: {entity_name}")
-
-        state = self._entities[entity_name]
-
-        if trajectory.dof != len(state.joint_qpos_indices):
-            raise ValueError(
-                f"Trajectory DOF {trajectory.dof} doesn't match entity joint count {len(state.joint_qpos_indices)}"
-            )
-
-        realtime = self.viewer is not None
-        t_start = time.time() if realtime else 0.0
-        for i in range(trajectory.num_waypoints):
-            if self._abort_fn is not None and self._abort_fn():
-                logger.info("Entity trajectory aborted at waypoint %d/%d", i, trajectory.num_waypoints)
-                return False
-            state.target_position = trajectory.positions[i]
-            state.target_velocity = trajectory.velocities[i]
-            self.step()
-            if realtime:
-                t_target = t_start + (i + 1) * self.control_dt
-                t_remaining = t_target - time.time()
-                if t_remaining > 0:
-                    time.sleep(t_remaining)
-
-        state.target_position = trajectory.positions[-1].copy()
-        state.target_velocity = np.zeros(len(state.actuator_ids))
-        return True
-
-    def get_entity_executor(self, entity_name: str) -> EntityPhysicsExecutor:
-        """Get Executor interface for an entity (base, etc.)."""
-        if entity_name not in self._entities:
-            raise ValueError(f"Unknown entity: {entity_name}")
-        return EntityPhysicsExecutor(self, entity_name)
-
-    # -- Executor interface -------------------------------------------------
-
-    def get_executor(self, arm_name: str) -> ArmPhysicsExecutor:
-        """Get Executor interface for a single arm.
-
-        Returns an object with the standard ``Executor.execute(trajectory)``
-        interface that internally delegates to this controller.
-
-        Args:
-            arm_name: Which arm to create an executor for.
-        """
-        if arm_name not in self._arms:
-            raise ValueError(f"Unknown arm: {arm_name}")
-        return ArmPhysicsExecutor(self, arm_name)
-
-    # -- Internal -----------------------------------------------------------
-
-    def _step_physics(self) -> None:
-        """Apply gripper ctrl, step MuJoCo, tick grasp verifiers, sync viewer."""
-        for gstate in self._grippers.values():
-            self.data.ctrl[gstate.actuator_id] = gstate.target_ctrl
-
-        for _ in range(self.steps_per_control):
-            mujoco.mj_step(self.model, self.data)
-
-        # Tick every configured GraspVerifier exactly once per control
-        # cycle. This is the single \"advance time by one control cycle\"
-        # primitive in physics mode, so every execution path
-        # (ctx.step, ctx.execute, gripper close sequences, trajectory
-        # runners) transitively runs verifier ticks through here. No
-        # consumer needs to remember to tick. Arms without a verifier
-        # are no-ops.
-        for astate in self._arms.values():
-            gripper = astate.arm.gripper
-            if gripper is not None and gripper.grasp_verifier is not None:
-                gripper.grasp_verifier.tick()
-
-        if self.viewer is not None:
-            now = time.time()
-            if now - self._last_viewer_sync >= self._viewer_sync_interval:
-                self.viewer.sync()
-                self._last_viewer_sync = now
-
-
-# ---------------------------------------------------------------------------
-# ArmPhysicsExecutor
-# ---------------------------------------------------------------------------
-
-
-class ArmPhysicsExecutor:
-    """Executor interface for one arm, backed by PhysicsController.
-
-    Provides the standard ``Executor.execute(trajectory)`` interface while
-    ensuring all other actuators hold their positions during execution.
-    Obtained via :meth:`PhysicsController.get_executor`.
-    """
-
-    def __init__(self, controller: PhysicsController, arm_name: str):
-        self.controller = controller
-        self.arm_name = arm_name
-
-    def execute(self, trajectory: Trajectory) -> bool:
-        """Execute trajectory on this arm."""
-        return self.controller.execute(self.arm_name, trajectory)
-
-
-class EntityPhysicsExecutor:
-    """Executor interface for a non-arm entity, backed by PhysicsController.
-
-    Same pattern as ArmPhysicsExecutor but routes to execute_entity().
-    Obtained via :meth:`PhysicsController.get_entity_executor`.
-    """
-
-    def __init__(self, controller: PhysicsController, entity_name: str):
-        self.controller = controller
-        self.entity_name = entity_name
-
-    def execute(self, trajectory: Trajectory) -> bool:
-        """Execute trajectory on this entity."""
-        return self.controller.execute_entity(self.entity_name, trajectory)

--- a/src/mj_manipulator/physics_controller.py
+++ b/src/mj_manipulator/physics_controller.py
@@ -26,15 +26,10 @@ from mj_manipulator.controller import (
     ArmExecutor,
     Controller,
     EntityExecutor,
-    TrajectoryRunner,
-    _ArmState,
-    _EntityState,
-    _GripperState,
 )
 
 if TYPE_CHECKING:
     from mj_manipulator.arm import Arm
-    from mj_manipulator.trajectory import Trajectory
 
 logger = logging.getLogger(__name__)
 

--- a/src/mj_manipulator/sim_context.py
+++ b/src/mj_manipulator/sim_context.py
@@ -38,9 +38,9 @@ import numpy as np
 if TYPE_CHECKING:
     from mj_manipulator.arm import Arm
     from mj_manipulator.config import PhysicsConfig
+    from mj_manipulator.controller import Controller
     from mj_manipulator.event_loop import PhysicsEventLoop
     from mj_manipulator.ownership import OwnershipRegistry
-    from mj_manipulator.physics_controller import PhysicsController
 
 logger = logging.getLogger(__name__)
 
@@ -165,13 +165,9 @@ class SimArmController:
         return target
 
     def _run_close(self, candidates: list[str] | None) -> None:
-        """Dispatch to the physics or kinematic close routine."""
-        gripper = self._arm.gripper
+        """Close the gripper via the controller (physics or kinematic)."""
         arm_name = self._arm.config.name
-        if self._context._controller is not None:
-            self._context._controller.close_gripper(arm_name, candidate_objects=candidates)
-        else:
-            gripper.kinematic_close()  # type: ignore[union-attr]
+        self._context._controller.close_gripper(arm_name, candidate_objects=candidates)
 
     def release(self, object_name: str | None = None) -> None:
         """Open gripper and release held object(s).
@@ -207,10 +203,7 @@ class SimArmController:
         if gripper.grasp_verifier is not None:
             gripper.grasp_verifier.mark_released()
 
-        if self._context._controller is not None:
-            self._context._controller.open_gripper(arm_name)
-        else:
-            gripper.kinematic_open()
+        self._context._controller.open_gripper(arm_name)
 
         self._context.sync()
 
@@ -287,7 +280,7 @@ class SimContext:
         self._viewer_fps = viewer_fps
         self._event_loop = event_loop
 
-        self._controller: PhysicsController | None = None
+        self._controller: Controller | None = None
         self._executors: dict[str, object] = {}
         self._arm_controllers: dict[str, SimArmController] = {}
         self._owns_viewer = False
@@ -334,8 +327,8 @@ class SimContext:
         for arm in self._arms.values():
             arm.ft_valid = self._physics
 
-        # Wire event loop to controller for tick-driven mode
-        if self._event_loop is not None and self._controller is not None:
+        # Wire event loop to controller (both physics and kinematic modes)
+        if self._event_loop is not None:
             self._event_loop.set_controller(self._controller)
 
             # Create ownership registry for all arms + entities
@@ -429,11 +422,6 @@ class SimContext:
         """
         if self._event_loop is not None and self._controller is not None:
             return self._execute_tick_driven(item, abort_fn=abort_fn)
-
-        if self._event_loop is not None:
-            # Kinematic with event loop: legacy blocking dispatch
-            self._event_loop._deactivate_all_teleop()
-            return self._event_loop.run_on_physics_thread(lambda: self._execute_impl(item, abort_fn=abort_fn))
 
         return self._execute_impl(item, abort_fn=abort_fn)
 
@@ -629,11 +617,7 @@ class SimContext:
                     self._controller.set_arm_target(name, q)
             self._controller.step()
         else:
-            if targets:
-                for name, q in targets.items():
-                    executor = self._executors.get(name)
-                    if executor is not None:
-                        executor.set_position(np.asarray(q))
+            # Fallback: no controller (shouldn't happen in normal usage)
             mujoco.mj_forward(self._model, self._data)
             self._throttled_viewer_sync()
 
@@ -657,14 +641,12 @@ class SimContext:
         position = np.asarray(position)
 
         if self._event_loop is not None and self._controller is not None:
-            # Tick-driven: set targets and step physics.
+            # Tick-driven: set targets, let tick() do the step.
             # On the owner thread (e.g. CartesianMove inside a BT tree),
             # we must pump tick() ourselves — nobody else will.
             self._event_loop.run_on_physics_thread(lambda: self._set_reactive_target(arm_name, position, velocity))
             if threading.get_ident() == self._event_loop._owner_thread:
                 self._event_loop.tick()
-        elif self._event_loop is not None:
-            self._event_loop.run_on_physics_thread(lambda: self._step_cartesian_impl(arm_name, position, velocity))
         else:
             self._step_cartesian_impl(arm_name, position, velocity)
 
@@ -681,10 +663,9 @@ class SimContext:
         if self._controller is not None:
             self._controller.step_reactive(arm_name, position, velocity)
         else:
-            executor = self._executors.get(arm_name)
-            if executor is not None:
-                executor.set_position(position)
-                executor.step()
+            # Fallback: no controller (shouldn't happen in normal usage)
+            mujoco.mj_forward(self._model, self._data)
+            self._throttled_viewer_sync()
 
     def set_arm_target(
         self,
@@ -703,6 +684,7 @@ class SimContext:
         """
         if self._controller is not None:
             self._controller.set_arm_target(arm_name, position, velocity)
+        # When no controller, this is a no-op (shouldn't happen in normal usage)
 
     def sync(self) -> None:
         """Synchronize state with simulation (mj_forward + viewer sync)."""
@@ -871,31 +853,26 @@ class SimContext:
             mujoco.mj_step(self._model, self._data)
 
     def _setup_kinematic(self, viewer_sync_interval: float) -> None:
-        """Create per-arm and per-entity KinematicExecutors."""
-        from mj_manipulator.executor import KinematicExecutor
+        """Create KinematicController and per-arm executor wrappers."""
+        from mj_manipulator.kinematic_controller import KinematicController
 
-        for name, arm in self._arms.items():
-            self._executors[name] = KinematicExecutor(
-                self._model,
-                self._data,
-                arm.joint_qpos_indices,
-                viewer=self._viewer,
-                grasp_manager=arm.grasp_manager,
-                viewer_sync_interval=viewer_sync_interval,
-                abort_fn=self._abort_fn,
-            )
+        self._controller = KinematicController(
+            self._model,
+            self._data,
+            self._arms,
+            viewer=self._viewer,
+            viewer_sync_interval=viewer_sync_interval,
+            initial_positions=self._initial_positions,
+            entities=self._entities,
+            abort_fn=self._abort_fn,
+        )
 
-        for name, entity in self._entities.items():
-            gm = getattr(entity, "grasp_manager", None)
-            self._executors[name] = KinematicExecutor(
-                self._model,
-                self._data,
-                entity.joint_qpos_indices,
-                viewer=self._viewer,
-                grasp_manager=gm,
-                viewer_sync_interval=viewer_sync_interval,
-                abort_fn=self._abort_fn,
-            )
+        # Executor wrappers for the no-event-loop legacy path
+        for name in self._arms:
+            self._executors[name] = self._controller.get_executor(name)
+
+        for name in self._entities:
+            self._executors[name] = self._controller.get_entity_executor(name)
 
     def _execute_trajectory(self, trajectory) -> bool:
         """Route a single trajectory to its executor."""

--- a/src/mj_manipulator/sim_context.py
+++ b/src/mj_manipulator/sim_context.py
@@ -748,10 +748,11 @@ class SimContext:
                 if gripper.grasp_verifier is not None:
                     gripper.grasp_verifier.mark_released()
 
-        # 4. Tell the controller to hold at the new qpos (includes
-        #    resetting gripper targets to open)
+        # 4. Defer hold to the next tick — the caller may modify qpos
+        #    after this call (e.g. setup_scene, base height changes).
+        #    Whatever qpos exists at tick-time gets captured.
         if self._controller is not None:
-            self._controller.hold_all()
+            self._controller.request_hold()
 
         # 5. Sync viewer to show the new state
         self.sync()

--- a/src/mj_manipulator/sim_context.py
+++ b/src/mj_manipulator/sim_context.py
@@ -708,13 +708,16 @@ class SimContext:
             self._controller.hold_all()
 
     def reset_state(self) -> None:
-        """Deactivate teleop, abort runners, and hold at current qpos.
+        """Deactivate teleop, release grasps, abort runners, hold at current qpos.
 
         Call after modifying ``data.qpos`` (e.g. ``mj_resetDataKeyframe``)
-        so the controller, event loop, and ownership registry all agree
-        on the new state. This is the safe way to reset during interactive
-        sessions — it ensures teleop gizmos are hidden, running trajectories
-        are stopped, and the controller won't fight the new positions.
+        so the controller, event loop, ownership registry, grasp manager,
+        and grasp verifiers all agree on the new state.
+
+        This is the safe way to reset during interactive sessions — it
+        ensures teleop gizmos are hidden, running trajectories are stopped,
+        held objects are released, and the controller won't fight the new
+        positions.
 
         Typical usage::
 
@@ -728,15 +731,29 @@ class SimContext:
         # 2. Clear ownership (abort any running trajectories, release all arms)
         if self._ownership is not None:
             self._ownership.abort_all()
-            # Let one tick process the aborts so runners see them
-            # (not needed — abort_all sets flags, runners check on next advance_all)
             self._ownership.clear_all()
 
-        # 3. Tell the controller to hold at the new qpos
+        # 3. Release all grasps: clear grasp manager bookkeeping, detach
+        #    kinematic welds, and reset grasp verifiers to IDLE.
+        for arm in self._arms.values():
+            arm_name = arm.config.name
+            gm = arm.grasp_manager
+            if gm is not None:
+                for obj in list(gm.get_grasped_by(arm_name)):
+                    gm.mark_released(obj)
+                    gm.detach_object(obj)
+
+            gripper = arm.gripper
+            if gripper is not None:
+                if gripper.grasp_verifier is not None:
+                    gripper.grasp_verifier.mark_released()
+
+        # 4. Tell the controller to hold at the new qpos (includes
+        #    resetting gripper targets to open)
         if self._controller is not None:
             self._controller.hold_all()
 
-        # 4. Sync viewer to show the new state
+        # 5. Sync viewer to show the new state
         self.sync()
 
     def is_running(self) -> bool:

--- a/src/mj_manipulator/sim_context.py
+++ b/src/mj_manipulator/sim_context.py
@@ -756,6 +756,26 @@ class SimContext:
         # 5. Sync viewer to show the new state
         self.sync()
 
+    def reset_to_keyframe(self, keyframe: str) -> None:
+        """Reset MuJoCo state to a named keyframe and clean up.
+
+        Single entry point for resetting — handles the MuJoCo state reset
+        AND all the cleanup (teleop, grasps, ownership, controller targets).
+        Robots should call this instead of ``mj_resetDataKeyframe`` +
+        ``reset_state()`` separately.
+
+        Args:
+            keyframe: MuJoCo keyframe name (must exist in the model).
+
+        Raises:
+            ValueError: If the keyframe is not found in the model.
+        """
+        key_id = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_KEY, keyframe)
+        if key_id == -1:
+            raise ValueError(f"Keyframe '{keyframe}' not found in model")
+        mujoco.mj_resetDataKeyframe(self._model, self._data, key_id)
+        self.reset_state()
+
     def is_running(self) -> bool:
         """Check if context is still active.
 

--- a/src/mj_manipulator/sim_context.py
+++ b/src/mj_manipulator/sim_context.py
@@ -707,6 +707,38 @@ class SimContext:
         if self._controller is not None:
             self._controller.hold_all()
 
+    def reset_state(self) -> None:
+        """Deactivate teleop, abort runners, and hold at current qpos.
+
+        Call after modifying ``data.qpos`` (e.g. ``mj_resetDataKeyframe``)
+        so the controller, event loop, and ownership registry all agree
+        on the new state. This is the safe way to reset during interactive
+        sessions — it ensures teleop gizmos are hidden, running trajectories
+        are stopped, and the controller won't fight the new positions.
+
+        Typical usage::
+
+            mujoco.mj_resetDataKeyframe(model, data, key_id)
+            ctx.reset_state()
+        """
+        # 1. Deactivate all teleop controllers and reset their panels
+        if self._event_loop is not None:
+            self._event_loop._deactivate_all_teleop()
+
+        # 2. Clear ownership (abort any running trajectories, release all arms)
+        if self._ownership is not None:
+            self._ownership.abort_all()
+            # Let one tick process the aborts so runners see them
+            # (not needed — abort_all sets flags, runners check on next advance_all)
+            self._ownership.clear_all()
+
+        # 3. Tell the controller to hold at the new qpos
+        if self._controller is not None:
+            self._controller.hold_all()
+
+        # 4. Sync viewer to show the new state
+        self.sync()
+
     def is_running(self) -> bool:
         """Check if context is still active.
 

--- a/src/mj_manipulator/teleop.py
+++ b/src/mj_manipulator/teleop.py
@@ -545,11 +545,13 @@ class TeleopController:
         if angle < 1e-6:
             rot_err = np.zeros(3)
         else:
-            axis = np.array([
-                R_err[2, 1] - R_err[1, 2],
-                R_err[0, 2] - R_err[2, 0],
-                R_err[1, 0] - R_err[0, 1],
-            ]) / (2 * np.sin(angle))
+            axis = np.array(
+                [
+                    R_err[2, 1] - R_err[1, 2],
+                    R_err[0, 2] - R_err[2, 0],
+                    R_err[1, 0] - R_err[0, 1],
+                ]
+            ) / (2 * np.sin(angle))
             rot_err = axis * angle
 
         gain = 1.0

--- a/tests/test_kinematic_controller.py
+++ b/tests/test_kinematic_controller.py
@@ -1,0 +1,270 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Tests for KinematicController and tick-driven kinematic execution.
+
+Mirrors key tests from test_physics_controller.py and test_event_loop.py
+but with KinematicController, verifying that kinematic mode gets the
+same capabilities: non-blocking runners, per-arm abort, concurrent
+multi-arm control, and event-loop integration.
+"""
+
+import threading
+
+import numpy as np
+import pytest
+from conftest import MockArm, make_trajectory
+
+from mj_manipulator.config import ExecutionConfig
+from mj_manipulator.event_loop import PhysicsEventLoop
+from mj_manipulator.kinematic_controller import KinematicController
+from mj_manipulator.ownership import OwnerKind, OwnershipRegistry
+
+
+@pytest.fixture
+def controller(model_and_data, mock_arm):
+    model, data = model_and_data
+    return KinematicController(
+        model,
+        data,
+        {"test_arm": mock_arm},
+    )
+
+
+@pytest.fixture
+def loop():
+    return PhysicsEventLoop()
+
+
+class TestKinematicControllerConstruction:
+    def test_constructs(self, model_and_data, mock_arm):
+        model, data = model_and_data
+        ctrl = KinematicController(model, data, {"arm": mock_arm})
+        assert ctrl is not None
+        assert ctrl.control_dt == 0.004  # kinematic default
+
+    def test_constructs_with_initial_positions(self, model_and_data, mock_arm):
+        model, data = model_and_data
+        init_pos = {"arm": np.array([0.5, -0.5])}
+        KinematicController(model, data, {"arm": mock_arm}, initial_positions=init_pos)
+        for i, idx in enumerate(mock_arm.joint_qpos_indices):
+            assert abs(data.qpos[idx] - init_pos["arm"][i]) < 1e-6
+
+    def test_custom_control_dt(self, model_and_data, mock_arm):
+        model, data = model_and_data
+        ctrl = KinematicController(
+            model, data, {"arm": mock_arm},
+            config=ExecutionConfig(control_dt=0.01),
+        )
+        assert ctrl.control_dt == 0.01
+
+
+class TestKinematicStepping:
+    def test_step_writes_qpos_exactly(self, controller, model_and_data, mock_arm):
+        """Kinematic step writes targets directly to qpos — exact tracking."""
+        _, data = model_and_data
+        controller.set_arm_target("test_arm", np.array([0.5, -0.3]))
+        controller.step()
+
+        for i, idx in enumerate(mock_arm.joint_qpos_indices):
+            expected = [0.5, -0.3][i]
+            assert abs(data.qpos[idx] - expected) < 1e-10
+
+    def test_step_zeros_velocity(self, controller, model_and_data, mock_arm):
+        """Kinematic step always zeros velocity (no dynamics)."""
+        _, data = model_and_data
+        controller.set_arm_target("test_arm", np.array([0.5, -0.3]))
+        controller.step()
+
+        for idx in mock_arm.joint_qvel_indices:
+            assert data.qvel[idx] == 0.0
+
+    def test_step_reactive_is_exact(self, controller, model_and_data, mock_arm):
+        """Kinematic step_reactive is the same as set + step (instant tracking)."""
+        _, data = model_and_data
+        controller.step_reactive("test_arm", np.array([0.7, 0.2]))
+
+        for i, idx in enumerate(mock_arm.joint_qpos_indices):
+            expected = [0.7, 0.2][i]
+            assert abs(data.qpos[idx] - expected) < 1e-10
+
+
+class TestKinematicExecution:
+    def test_execute_trajectory(self, controller, model_and_data, mock_arm):
+        _, data = model_and_data
+        positions = np.array([[0.0, 0.0], [0.1, 0.1], [0.3, 0.3]])
+        traj = make_trajectory(positions, entity="test_arm")
+        result = controller.execute("test_arm", traj)
+        assert result is True
+
+        # Final position should be exact
+        for i, idx in enumerate(mock_arm.joint_qpos_indices):
+            assert abs(data.qpos[idx] - 0.3) < 1e-6
+
+    def test_execute_aborts(self, model_and_data, mock_arm):
+        model, data = model_and_data
+        ctrl = KinematicController(model, data, {"arm": mock_arm}, abort_fn=lambda: True)
+        positions = np.array([[0.0, 0.0], [0.1, 0.1]])
+        traj = make_trajectory(positions, entity="arm")
+        result = ctrl.execute("arm", traj)
+        assert result is False
+
+
+class TestTickDrivenKinematic:
+    """Test that the event loop drives kinematic trajectory runners."""
+
+    def test_tick_advances_runner(self, loop, controller):
+        loop.set_controller(controller)
+
+        positions = np.array([[0.0, 0.0], [0.1, 0.1], [0.2, 0.2]])
+        traj = make_trajectory(positions, entity="test_arm")
+        future = controller.start_trajectory("test_arm", traj)
+
+        loop.tick()
+        # After first tick: waypoint 0 written + step applied + convergence checked
+        assert not future.done() or future.result() is True
+
+    def test_tick_completes_trajectory(self, loop, controller):
+        """Kinematic convergence is immediate — trajectory completes quickly."""
+        loop.set_controller(controller)
+
+        positions = np.array([[0.0, 0.0], [0.1, 0.1]])
+        traj = make_trajectory(positions, entity="test_arm")
+        future = controller.start_trajectory("test_arm", traj)
+
+        # Should complete in a few ticks (waypoints + 1 convergence check)
+        for _ in range(10):
+            loop.tick()
+            if future.done():
+                break
+
+        assert future.done()
+        assert future.result() is True
+
+    def test_queued_commands_processed(self, loop, controller):
+        loop.set_controller(controller)
+
+        results = []
+
+        def cmd():
+            results.append("ran")
+            return 42
+
+        future = loop.submit(cmd)
+        loop.tick()
+
+        assert results == ["ran"]
+        assert future.result() == 42
+
+
+class TestTickDrivenBimanualKinematic:
+    """Test concurrent trajectory + teleop target writing in kinematic mode."""
+
+    @pytest.fixture
+    def two_arm_controller(self, model_and_data):
+        model, data = model_and_data
+        arm1 = MockArm("arm1", model, data)
+        arm2 = MockArm("arm2", model, data)
+        return KinematicController(
+            model,
+            data,
+            {"arm1": arm1, "arm2": arm2},
+        )
+
+    def test_trajectory_and_manual_targets(self, loop, two_arm_controller):
+        """One arm runs a trajectory, other arm has targets set externally."""
+        ctrl = two_arm_controller
+        loop.set_controller(ctrl)
+
+        positions = np.array([[0.0, 0.0], [0.1, 0.1], [0.2, 0.2]])
+        traj = make_trajectory(positions, entity="arm1")
+        future = ctrl.start_trajectory("arm1", traj)
+
+        # Simulate teleop setting targets on arm2 each tick
+        for i in range(3):
+            target = np.array([0.5 + i * 0.1, 0.5 + i * 0.1])
+            ctrl.set_arm_target("arm2", target)
+            loop.tick()
+
+        # arm2 should have the last target we set — exact in kinematic
+        np.testing.assert_allclose(
+            ctrl.data.qpos[ctrl._arms["arm2"].joint_qpos_indices],
+            [0.7, 0.7],
+            atol=1e-10,
+        )
+
+    def test_per_arm_abort_only_affects_target(self, loop, two_arm_controller):
+        """Aborting one arm doesn't stop the other."""
+        ctrl = two_arm_controller
+        loop.set_controller(ctrl)
+        registry = OwnershipRegistry(["arm1", "arm2"])
+
+        positions = np.array([[0.0, 0.0], [0.1, 0.1], [0.2, 0.2], [0.3, 0.3], [0.4, 0.4]])
+        traj1 = make_trajectory(positions, entity="arm1")
+        traj2 = make_trajectory(positions, entity="arm2")
+
+        future1 = ctrl.start_trajectory("arm1", traj1, abort_fn=lambda: registry.is_aborted("arm1"))
+        future2 = ctrl.start_trajectory("arm2", traj2, abort_fn=lambda: registry.is_aborted("arm2"))
+
+        loop.tick()
+        loop.tick()
+
+        # Abort only arm1
+        registry.set_abort("arm1")
+        loop.tick()
+
+        assert future1.done()
+        assert future1.result() is False  # aborted
+        assert not future2.done()  # still running
+
+    def test_preempt_aborts_runner_same_tick(self, loop, two_arm_controller):
+        """Preempt sets abort, runner sees it on the same tick before command runs."""
+        ctrl = two_arm_controller
+        loop.set_controller(ctrl)
+        registry = OwnershipRegistry(["arm1", "arm2"])
+
+        positions = np.array([[0.0, 0.0], [0.1, 0.1], [0.2, 0.2], [0.3, 0.3], [0.4, 0.4]])
+        traj = make_trajectory(positions, entity="arm1")
+
+        registry.acquire("arm1", OwnerKind.TRAJECTORY, traj)
+        future = ctrl.start_trajectory("arm1", traj, abort_fn=lambda: registry.is_aborted("arm1"))
+
+        loop.tick()
+        assert not future.done()
+
+        teleop_owner = object()
+        registry.preempt("arm1", OwnerKind.TELEOP, teleop_owner)
+        cleared = []
+
+        def do_activate():
+            registry.clear_abort("arm1")
+            cleared.append(True)
+
+        loop.submit(do_activate)
+
+        loop.tick()
+
+        assert future.done()
+        assert future.result() is False  # runner aborted
+        assert cleared == [True]  # command also ran
+        assert not registry.is_aborted("arm1")
+
+
+class TestBackgroundThreadKinematic:
+    """Test that background threads can submit work to kinematic mode."""
+
+    def test_submit_from_background_thread(self, loop, controller):
+        loop.set_controller(controller)
+
+        result_holder = []
+
+        def bg_work():
+            future = loop.submit(lambda: 42)
+            result_holder.append(future)
+
+        t = threading.Thread(target=bg_work)
+        t.start()
+        t.join()
+
+        loop.tick()
+        assert result_holder[0].result() == 42

--- a/tests/test_kinematic_controller.py
+++ b/tests/test_kinematic_controller.py
@@ -53,7 +53,9 @@ class TestKinematicControllerConstruction:
     def test_custom_control_dt(self, model_and_data, mock_arm):
         model, data = model_and_data
         ctrl = KinematicController(
-            model, data, {"arm": mock_arm},
+            model,
+            data,
+            {"arm": mock_arm},
             config=ExecutionConfig(control_dt=0.01),
         )
         assert ctrl.control_dt == 0.01

--- a/tests/test_kinematic_controller.py
+++ b/tests/test_kinematic_controller.py
@@ -178,7 +178,7 @@ class TestTickDrivenBimanualKinematic:
 
         positions = np.array([[0.0, 0.0], [0.1, 0.1], [0.2, 0.2]])
         traj = make_trajectory(positions, entity="arm1")
-        future = ctrl.start_trajectory("arm1", traj)
+        ctrl.start_trajectory("arm1", traj)
 
         # Simulate teleop setting targets on arm2 each tick
         for i in range(3):


### PR DESCRIPTION
## Summary

- Extract orchestration from `PhysicsController` into a `Controller` ABC so physics, kinematic, and future hardware modes share the same control path
- `KinematicController(Controller)` gives kinematic mode the same capabilities as physics: non-blocking trajectory runners, per-arm ownership, concurrent multi-arm control, inputhook-driven viewer updates
- Remove `_tick_legacy` from the event loop — single `_tick_driven` path for both modes
- Collapse 8 physics/kinematic branches in `SimContext`
- Always install the IPython inputhook (was physics-only — fixes frozen viewer in kinematic mode)

## Test plan

- [ ] `uv run pytest tests/ -v` — 419 pass, 17 pre-existing teleop MockArm failures
- [ ] `uv run python -m ada_mj --viser` (kinematic) — teleop gizmo tracks, sliders update, `go_to("above_plate")` animates, status HUD shows ownership
- [ ] `uv run python -m ada_mj --viser --physics` — unchanged behavior (regression)
- [ ] Kinematic concurrent: teleop one arm while executing trajectory on another
- [ ] Per-arm preemption: activating teleop aborts running trajectory on same arm

Closes #143
Fixes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)