### PR TITLE
Outcome, ForceThresholds, SpeedProfile, servo primitives

### DIFF
--- a/src/mj_manipulator/__init__.py
+++ b/src/mj_manipulator/__init__.py
@@ -37,6 +37,7 @@ from mj_manipulator.config import (
 )
 from mj_manipulator.controller import ArmExecutor, Controller, EntityExecutor
 from mj_manipulator.executor import KinematicExecutor, PhysicsExecutor
+from mj_manipulator.force_control import ForceThresholds, SpeedProfile
 from mj_manipulator.grasp_manager import GraspManager
 from mj_manipulator.grasp_verifier import (
     GraspState,
@@ -52,6 +53,7 @@ from mj_manipulator.load_signals import (
     LoadSignal,
     WristFTSignal,
 )
+from mj_manipulator.outcome import FailureKind, Outcome, failure, success
 from mj_manipulator.ownership import OwnerKind, OwnershipRegistry
 from mj_manipulator.perception import SimPerceptionService
 from mj_manipulator.physics_controller import ArmPhysicsExecutor, PhysicsController
@@ -66,6 +68,7 @@ from mj_manipulator.protocols import (
 )
 from mj_manipulator.robot import ManipulationRobot, RobotBase
 from mj_manipulator.safe_retract import safe_retract
+from mj_manipulator.servo import ft_guarded_move, servo_to_pose
 from mj_manipulator.sim_context import SimArmController, SimContext
 from mj_manipulator.status_hud import StatusHud
 from mj_manipulator.teleop import (
@@ -138,6 +141,17 @@ __all__ = [
     "TwistStepResult",
     "MoveUntilTouchResult",
     "TwistExecutionResult",
+    # Outcome (structured behavior returns)
+    "Outcome",
+    "FailureKind",
+    "success",
+    "failure",
+    # Force control
+    "ForceThresholds",
+    "SpeedProfile",
+    # Servo primitives (contact-rich manipulation)
+    "servo_to_pose",
+    "ft_guarded_move",
     # Safe retract
     "safe_retract",
     # Teleop

--- a/src/mj_manipulator/arm.py
+++ b/src/mj_manipulator/arm.py
@@ -488,6 +488,18 @@ class Arm:
         mujoco.mj_forward(self.env.model, self.env.data)
         return _read_site_pose(self.env.data, self.ee_site_id, self.config.tcp_offset)
 
+    def get_ee_jacobian(self) -> np.ndarray:
+        """6xN end-effector Jacobian in world frame.
+
+        Rows 0-2 are linear velocity, rows 3-5 are angular velocity.
+        Columns correspond to arm joints in joint_qvel_indices order.
+        """
+        if self.ee_site_id == -1:
+            raise RuntimeError("No ee_site configured")
+        from mj_manipulator.cartesian import get_ee_jacobian
+
+        return get_ee_jacobian(self.env.model, self.env.data, self.ee_site_id, self.joint_qvel_indices)
+
     def get_joint_limits(self) -> tuple[np.ndarray, np.ndarray]:
         """Joint position limits as (lower, upper) arrays.
 

--- a/src/mj_manipulator/force_control.py
+++ b/src/mj_manipulator/force_control.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Force/torque monitoring types for contact-rich manipulation.
+
+Provides ``ForceThresholds`` for abort conditions and ``SpeedProfile``
+for distance-based deceleration. Used by ``servo_to_pose`` and
+``ft_guarded_move`` in the servo module.
+
+These are general types — not feeding-specific. Any contact-rich task
+(guarded placement, surface following, insertion) uses the same patterns.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class ForceThresholds:
+    """Force/torque thresholds for motion abort.
+
+    When the measured wrench exceeds these thresholds, the motion
+    aborts with ``FailureKind.SAFETY_ABORTED``.
+
+    Args:
+        force_n: Maximum allowed force magnitude (N).
+        torque_nm: Maximum allowed torque magnitude (N·m).
+    """
+
+    force_n: float
+    torque_nm: float
+
+    def exceeded(self, wrench: np.ndarray) -> bool:
+        """Check if a 6D wrench [fx, fy, fz, tx, ty, tz] exceeds thresholds."""
+        force_mag = float(np.linalg.norm(wrench[:3]))
+        torque_mag = float(np.linalg.norm(wrench[3:]))
+        return force_mag > self.force_n or torque_mag > self.torque_nm
+
+    def check(self, wrench: np.ndarray) -> tuple[bool, float, float]:
+        """Check thresholds and return (exceeded, force_mag, torque_mag)."""
+        force_mag = float(np.linalg.norm(wrench[:3]))
+        torque_mag = float(np.linalg.norm(wrench[3:]))
+        return (
+            force_mag > self.force_n or torque_mag > self.torque_nm,
+            force_mag,
+            torque_mag,
+        )
+
+
+@dataclass(frozen=True)
+class SpeedProfile:
+    """Distance-based speed profile for Cartesian servo.
+
+    Linearly interpolates between max and min speeds based on distance
+    to target. At distances >= ``ramp_distance``, uses max speed. At
+    distance 0, uses min speed.
+
+    Used by ``servo_to_pose`` for smooth deceleration near targets
+    (e.g., approaching a person's mouth, precision placement).
+
+    Args:
+        max_linear: Maximum linear speed (m/s) at full distance.
+        min_linear: Minimum linear speed (m/s) near target.
+        max_angular: Maximum angular speed (rad/s) at full distance.
+        min_angular: Minimum angular speed (rad/s) near target.
+        ramp_distance: Distance (m) at which deceleration starts.
+    """
+
+    max_linear: float
+    min_linear: float
+    max_angular: float
+    min_angular: float
+    ramp_distance: float
+
+    def linear_speed(self, distance: float) -> float:
+        """Compute linear speed for a given distance to target."""
+        if self.ramp_distance <= 0:
+            return self.min_linear
+        if distance >= self.ramp_distance:
+            return self.max_linear
+        t = distance / self.ramp_distance
+        return self.min_linear + t * (self.max_linear - self.min_linear)
+
+    def angular_speed(self, distance: float) -> float:
+        """Compute angular speed for a given distance to target."""
+        if self.ramp_distance <= 0:
+            return self.min_angular
+        if distance >= self.ramp_distance:
+            return self.max_angular
+        t = distance / self.ramp_distance
+        return self.min_angular + t * (self.max_angular - self.min_angular)
+
+    @classmethod
+    def constant(cls, linear: float, angular: float) -> SpeedProfile:
+        """Create a constant-speed profile (no deceleration)."""
+        return cls(
+            max_linear=linear,
+            min_linear=linear,
+            max_angular=angular,
+            min_angular=angular,
+            ramp_distance=0.0,
+        )

--- a/src/mj_manipulator/outcome.py
+++ b/src/mj_manipulator/outcome.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Structured outcome types for manipulation behaviors.
+
+Every behavior and primitive returns an ``Outcome`` instead of a raw bool.
+Tasks branch on ``FailureKind`` (the category), never on ``failure_code``
+(the specific condition). This gives callers a fixed set of recovery
+strategies while preserving full diagnostic detail.
+
+Usage::
+
+    result = servo_to_pose(target, arm, ctx, ft_threshold=threshold)
+    if not result.success:
+        if result.failure_kind == FailureKind.SAFETY_ABORTED:
+            return result  # don't retry safety
+        if result.failure_kind == FailureKind.TIMEOUT:
+            logger.warning("Servo timed out: %s", result.failure_code)
+
+    # result.details has numeric context for logging/analysis
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class FailureKind(Enum):
+    """Category of failure. Tasks branch on these, never on failure_code.
+
+    Each kind maps to a recovery strategy:
+
+    - PRECONDITION_FAILED: missing input, check prerequisites
+    - PERCEPTION_FAILED: retry detection, use fallback
+    - PLANNING_FAILED: try different goal, relax constraints
+    - EXECUTION_FAILED: retry, recover to safe state
+    - SAFETY_ABORTED: do NOT retry, escalate to operator
+    - VERIFICATION_FAILED: action ran but outcome unconfirmed
+    - TIMEOUT: retry with longer timeout or different approach
+    """
+
+    PRECONDITION_FAILED = "precondition_failed"
+    PERCEPTION_FAILED = "perception_failed"
+    PLANNING_FAILED = "planning_failed"
+    EXECUTION_FAILED = "execution_failed"
+    SAFETY_ABORTED = "safety_aborted"
+    VERIFICATION_FAILED = "verification_failed"
+    TIMEOUT = "timeout"
+
+
+@dataclass(frozen=True)
+class Outcome:
+    """Structured result from a behavior or primitive.
+
+    Invariants:
+    - ``success=True`` implies ``failure_kind`` and ``failure_code`` are None
+    - ``success=False`` requires ``failure_kind`` to be set
+    - Tasks branch on ``failure_kind``, never on ``failure_code``
+    - ``failure_code`` format: ``"behavior_name:specific_condition"``
+    - ``details`` carries numeric context (forces, distances, durations)
+
+    Examples::
+
+        # Success
+        Outcome(success=True, details={"distance_m": 0.003})
+
+        # Planning failure
+        Outcome(
+            success=False,
+            failure_kind=FailureKind.PLANNING_FAILED,
+            failure_code="move_above:no_ik_solution",
+            details={"target_pose": pose.tolist()},
+        )
+
+        # Safety abort
+        Outcome(
+            success=False,
+            failure_kind=FailureKind.SAFETY_ABORTED,
+            failure_code="acquire_food:ft_exceeded",
+            details={"force_n": 25.3, "threshold_n": 20.0},
+        )
+    """
+
+    success: bool
+    failure_kind: FailureKind | None = None
+    failure_code: str | None = None
+    details: dict = field(default_factory=dict)
+
+    def __post_init__(self):
+        if self.success:
+            if self.failure_kind is not None:
+                raise ValueError("success=True but failure_kind is set")
+            if self.failure_code is not None:
+                raise ValueError("success=True but failure_code is set")
+        else:
+            if self.failure_kind is None:
+                raise ValueError(
+                    "success=False requires failure_kind. Use FailureKind to indicate the failure category."
+                )
+
+    def __bool__(self) -> bool:
+        """Allow ``if result:`` as shorthand for ``if result.success:``."""
+        return self.success
+
+    def __repr__(self) -> str:
+        if self.success:
+            return "Outcome(success=True)"
+        return f"Outcome(success=False, failure_kind={self.failure_kind.value!r}, failure_code={self.failure_code!r})"
+
+
+# Convenience constructors for common outcomes
+def success(**details) -> Outcome:
+    """Create a successful outcome."""
+    return Outcome(success=True, details=details)
+
+
+def failure(
+    kind: FailureKind,
+    code: str | None = None,
+    **details,
+) -> Outcome:
+    """Create a failed outcome."""
+    return Outcome(
+        success=False,
+        failure_kind=kind,
+        failure_code=code,
+        details=details,
+    )

--- a/src/mj_manipulator/servo.py
+++ b/src/mj_manipulator/servo.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Force-aware Cartesian servo primitives.
+
+General-purpose primitives for contact-rich manipulation:
+
+- ``servo_to_pose``: Move to a target pose with distance-based
+  deceleration and F/T monitoring (e.g., mouth approach, precision
+  placement near fragile objects).
+
+- ``ft_guarded_move``: Move in a fixed direction until F/T exceeds
+  a threshold or duration elapses (e.g., food stabbing, surface
+  contact detection, bite detection).
+
+Both return ``Outcome`` with structured failure information and use
+the existing ``CartesianController`` + ``ctx.step_cartesian``
+infrastructure internally.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from mj_manipulator.force_control import ForceThresholds, SpeedProfile
+from mj_manipulator.outcome import FailureKind, Outcome, failure, success
+
+if TYPE_CHECKING:
+    from mj_manipulator.arm import Arm
+    from mj_manipulator.protocols import ExecutionContext
+
+logger = logging.getLogger(__name__)
+
+
+def _rotation_error(R_target: np.ndarray, R_current: np.ndarray) -> np.ndarray:
+    """Compute rotation error as axis-angle vector."""
+    R_err = R_target @ R_current.T
+    cos_angle = np.clip((np.trace(R_err) - 1) / 2, -1, 1)
+    angle = float(np.arccos(cos_angle))
+    if angle < 1e-6:
+        return np.zeros(3)
+    axis = np.array(
+        [
+            R_err[2, 1] - R_err[1, 2],
+            R_err[0, 2] - R_err[2, 0],
+            R_err[1, 0] - R_err[0, 1],
+        ]
+    ) / (2 * np.sin(angle))
+    return axis * angle
+
+
+def _check_ft(arm: Arm, threshold: ForceThresholds | None) -> tuple[bool, float, float]:
+    """Check F/T against threshold. Returns (exceeded, force_mag, torque_mag)."""
+    if threshold is None:
+        return False, 0.0, 0.0
+    if not arm.has_ft_sensor or not arm.ft_valid:
+        return False, 0.0, 0.0
+    wrench = arm.get_ft_wrench()
+    if np.any(np.isnan(wrench)):
+        return False, 0.0, 0.0
+    return threshold.check(wrench)
+
+
+def servo_to_pose(
+    target: np.ndarray,
+    arm: Arm,
+    ctx: ExecutionContext,
+    *,
+    speed_profile: SpeedProfile | None = None,
+    ft_threshold: ForceThresholds | None = None,
+    position_tol: float = 0.005,
+    rotation_tol: float = 0.05,
+    timeout: float = 10.0,
+) -> Outcome:
+    """Cartesian servo to a target pose with deceleration and F/T monitoring.
+
+    Computes a proportional twist from current EE to target each control
+    cycle, with speed scaled by distance to target (via ``speed_profile``).
+    Aborts if F/T exceeds threshold.
+
+    This is the general primitive for any approach-to-pose motion where
+    the robot must decelerate near the target and react to contact:
+    mouth approach, precision placement, guarded insertion.
+
+    Args:
+        target: 4x4 target pose (world frame).
+        arm: Arm instance (for EE pose, F/T, joint state).
+        ctx: Execution context (for step_cartesian).
+        speed_profile: Distance-based speed ramp. If None, uses
+            constant 0.05 m/s.
+        ft_threshold: Force/torque abort threshold. If None, no F/T
+            monitoring.
+        position_tol: Stop when position error < this (meters).
+        rotation_tol: Stop when rotation error < this (radians).
+        timeout: Maximum duration (seconds).
+
+    Returns:
+        Outcome with success=True if target reached, or failure with
+        SAFETY_ABORTED (F/T exceeded) or TIMEOUT.
+    """
+    if speed_profile is None:
+        speed_profile = SpeedProfile.constant(linear=0.05, angular=0.3)
+
+    dt = ctx.control_dt
+    arm_name = arm.config.name
+    t0 = time.monotonic()
+
+    while time.monotonic() - t0 < timeout:
+        # Current EE pose
+        ee_pose = arm.get_ee_pose()
+        pos_err = target[:3, 3] - ee_pose[:3, 3]
+        rot_err = _rotation_error(target[:3, :3], ee_pose[:3, :3])
+
+        pos_err_norm = float(np.linalg.norm(pos_err))
+        rot_err_norm = float(np.linalg.norm(rot_err))
+
+        # Convergence check
+        if pos_err_norm < position_tol and rot_err_norm < rotation_tol:
+            return success(
+                position_error_m=pos_err_norm,
+                rotation_error_rad=rot_err_norm,
+            )
+
+        # F/T check
+        exceeded, force_mag, torque_mag = _check_ft(arm, ft_threshold)
+        if exceeded:
+            return failure(
+                FailureKind.SAFETY_ABORTED,
+                "servo_to_pose:ft_exceeded",
+                force_n=force_mag,
+                torque_nm=torque_mag,
+                threshold_force_n=ft_threshold.force_n,
+                threshold_torque_nm=ft_threshold.torque_nm,
+                position_error_m=pos_err_norm,
+            )
+
+        # Compute twist with speed profile
+        lin_speed = speed_profile.linear_speed(pos_err_norm)
+        ang_speed = speed_profile.angular_speed(pos_err_norm)
+
+        v = pos_err * min(1.0, lin_speed / (pos_err_norm + 1e-8))
+        w = rot_err * min(1.0, ang_speed / (rot_err_norm + 1e-8))
+
+        # Convert twist to joint targets via Jacobian
+        q_current = arm.get_joint_positions()
+        J = arm.get_ee_jacobian()
+        twist = np.concatenate([v, w])
+        qd = np.linalg.lstsq(J, twist, rcond=None)[0]
+
+        # Clamp to velocity limits
+        limits = getattr(arm.config, "kinematic_limits", None)
+        if limits is not None:
+            scale = np.max(np.abs(qd) / limits.velocity)
+            if scale > 1.0:
+                qd /= scale
+
+        q_target = q_current + qd * dt
+        ctx.step_cartesian(arm_name, q_target, qd)
+
+    return failure(
+        FailureKind.TIMEOUT,
+        "servo_to_pose:timeout",
+        timeout_s=timeout,
+        position_error_m=float(np.linalg.norm(target[:3, 3] - arm.get_ee_pose()[:3, 3])),
+    )
+
+
+def ft_guarded_move(
+    twist: np.ndarray,
+    arm: Arm,
+    ctx: ExecutionContext,
+    *,
+    ft_threshold: ForceThresholds,
+    duration: float = 2.0,
+    timeout: float | None = None,
+) -> Outcome:
+    """Move in a fixed direction until F/T exceeds threshold.
+
+    Applies a constant 6D twist each control cycle while monitoring
+    the F/T sensor. Returns success when:
+    - F/T threshold is exceeded (contact detected — ``details["contact"]=True``)
+    - Duration elapses (motion complete — ``details["contact"]=False``)
+
+    This is the general primitive for any guarded motion: food stabbing,
+    surface contact detection, bite detection, insertion.
+
+    Args:
+        twist: 6D twist [vx, vy, vz, wx, wy, wz] in world frame.
+        arm: Arm instance (for F/T, joint state).
+        ctx: Execution context (for step_cartesian).
+        ft_threshold: Force/torque threshold for contact detection.
+        duration: Maximum motion duration (seconds). Motion completes
+            successfully if this elapses without contact.
+        timeout: Hard timeout (seconds). If None, uses ``duration * 1.5``.
+
+    Returns:
+        Outcome with success=True. Check ``details["contact"]`` to
+        distinguish between contact-terminated and duration-elapsed.
+        Returns SAFETY_ABORTED only for unexpected F/T spikes beyond
+        the threshold (reserved for future graduated thresholds).
+    """
+    if timeout is None:
+        timeout = duration * 1.5
+
+    dt = ctx.control_dt
+    arm_name = arm.config.name
+    t0 = time.monotonic()
+    elapsed = 0.0
+
+    while elapsed < timeout:
+        # F/T check
+        exceeded, force_mag, torque_mag = _check_ft(arm, ft_threshold)
+        if exceeded:
+            return success(
+                contact=True,
+                force_n=force_mag,
+                torque_nm=torque_mag,
+                elapsed_s=elapsed,
+            )
+
+        # Duration check (motion complete without contact)
+        if elapsed >= duration:
+            return success(
+                contact=False,
+                elapsed_s=elapsed,
+            )
+
+        # Apply twist as joint velocities
+        q_current = arm.get_joint_positions()
+        J = arm.get_ee_jacobian()
+        qd = np.linalg.lstsq(J, twist, rcond=None)[0]
+
+        # Clamp to velocity limits
+        limits = getattr(arm.config, "kinematic_limits", None)
+        if limits is not None:
+            scale = np.max(np.abs(qd) / limits.velocity)
+            if scale > 1.0:
+                qd /= scale
+
+        q_target = q_current + qd * dt
+        ctx.step_cartesian(arm_name, q_target, qd)
+
+        elapsed = time.monotonic() - t0
+
+    return failure(
+        FailureKind.TIMEOUT,
+        "ft_guarded_move:timeout",
+        timeout_s=timeout,
+        duration_s=duration,
+    )

--- a/tests/test_force_control.py
+++ b/tests/test_force_control.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Tests for ForceThresholds and SpeedProfile."""
+
+import numpy as np
+import pytest
+
+from mj_manipulator.force_control import ForceThresholds, SpeedProfile
+
+
+class TestForceThresholds:
+    def test_below_threshold(self):
+        ft = ForceThresholds(force_n=10.0, torque_nm=2.0)
+        wrench = np.array([1.0, 2.0, 3.0, 0.1, 0.2, 0.3])
+        assert not ft.exceeded(wrench)
+
+    def test_force_exceeded(self):
+        ft = ForceThresholds(force_n=10.0, torque_nm=2.0)
+        wrench = np.array([8.0, 8.0, 0.0, 0.0, 0.0, 0.0])  # ||f|| ≈ 11.3
+        assert ft.exceeded(wrench)
+
+    def test_torque_exceeded(self):
+        ft = ForceThresholds(force_n=10.0, torque_nm=2.0)
+        wrench = np.array([0.0, 0.0, 0.0, 1.5, 1.5, 0.0])  # ||t|| ≈ 2.1
+        assert ft.exceeded(wrench)
+
+    def test_both_exceeded(self):
+        ft = ForceThresholds(force_n=1.0, torque_nm=1.0)
+        wrench = np.array([5.0, 5.0, 5.0, 5.0, 5.0, 5.0])
+        assert ft.exceeded(wrench)
+
+    def test_check_returns_magnitudes(self):
+        ft = ForceThresholds(force_n=10.0, torque_nm=2.0)
+        wrench = np.array([3.0, 4.0, 0.0, 1.0, 0.0, 0.0])
+        exceeded, force_mag, torque_mag = ft.check(wrench)
+        assert not exceeded
+        assert abs(force_mag - 5.0) < 1e-6
+        assert abs(torque_mag - 1.0) < 1e-6
+
+    def test_zero_wrench(self):
+        ft = ForceThresholds(force_n=1.0, torque_nm=1.0)
+        assert not ft.exceeded(np.zeros(6))
+
+    def test_exact_threshold_not_exceeded(self):
+        """Threshold is strict >."""
+        ft = ForceThresholds(force_n=5.0, torque_nm=2.0)
+        wrench = np.array([3.0, 4.0, 0.0, 0.0, 0.0, 0.0])  # ||f|| = 5.0 exactly
+        assert not ft.exceeded(wrench)
+
+    def test_frozen(self):
+        ft = ForceThresholds(force_n=10.0, torque_nm=2.0)
+        with pytest.raises(AttributeError):
+            ft.force_n = 20.0
+
+
+class TestSpeedProfile:
+    def test_max_speed_beyond_ramp(self):
+        sp = SpeedProfile(max_linear=0.15, min_linear=0.06, max_angular=0.15, min_angular=0.075, ramp_distance=0.3)
+        assert sp.linear_speed(0.5) == 0.15
+        assert sp.angular_speed(0.5) == 0.15
+
+    def test_min_speed_at_target(self):
+        sp = SpeedProfile(max_linear=0.15, min_linear=0.06, max_angular=0.15, min_angular=0.075, ramp_distance=0.3)
+        assert sp.linear_speed(0.0) == 0.06
+        assert sp.angular_speed(0.0) == 0.075
+
+    def test_midpoint_interpolation(self):
+        sp = SpeedProfile(max_linear=0.15, min_linear=0.06, max_angular=0.15, min_angular=0.075, ramp_distance=0.3)
+        # At ramp_distance/2 = 0.15m, t = 0.5
+        # linear: 0.06 + 0.5 * (0.15 - 0.06) = 0.105
+        assert abs(sp.linear_speed(0.15) - 0.105) < 1e-6
+        # angular: 0.075 + 0.5 * (0.15 - 0.075) = 0.1125
+        assert abs(sp.angular_speed(0.15) - 0.1125) < 1e-6
+
+    def test_at_ramp_boundary(self):
+        sp = SpeedProfile(max_linear=0.15, min_linear=0.06, max_angular=0.15, min_angular=0.075, ramp_distance=0.3)
+        assert sp.linear_speed(0.3) == 0.15
+        assert sp.angular_speed(0.3) == 0.15
+
+    def test_constant_profile(self):
+        sp = SpeedProfile.constant(linear=0.1, angular=0.2)
+        assert sp.linear_speed(0.0) == 0.1
+        assert sp.linear_speed(100.0) == 0.1
+        assert sp.angular_speed(0.0) == 0.2
+        assert sp.angular_speed(100.0) == 0.2
+
+    def test_zero_ramp_distance(self):
+        """Zero ramp → always min speed (no room to accelerate)."""
+        sp = SpeedProfile(max_linear=0.15, min_linear=0.06, max_angular=0.15, min_angular=0.075, ramp_distance=0.0)
+        assert sp.linear_speed(0.0) == 0.06
+        assert sp.linear_speed(0.5) == 0.06  # no ramp = stuck at min
+
+    def test_frozen(self):
+        sp = SpeedProfile.constant(0.1, 0.2)
+        with pytest.raises(AttributeError):
+            sp.max_linear = 0.5
+
+    def test_ada_mouth_approach_profile(self):
+        """Reproduces the original ada_feeding mouth approach parameters."""
+        sp = SpeedProfile(
+            max_linear=0.15,
+            min_linear=0.06,
+            max_angular=0.15,
+            min_angular=0.075,
+            ramp_distance=0.3,
+        )
+        # Far away: full speed
+        assert sp.linear_speed(0.4) == 0.15
+        # At 10cm: decelerating
+        speed_10cm = sp.linear_speed(0.1)
+        assert 0.06 < speed_10cm < 0.15
+        # At 1cm: nearly stopped
+        speed_1cm = sp.linear_speed(0.01)
+        assert abs(speed_1cm - 0.063) < 0.005

--- a/tests/test_outcome.py
+++ b/tests/test_outcome.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Tests for Outcome, FailureKind, and convenience constructors."""
+
+import pytest
+
+from mj_manipulator.outcome import FailureKind, Outcome, failure, success
+
+
+class TestOutcomeInvariants:
+    """Enforce the structural invariants on Outcome."""
+
+    def test_success_with_no_failure_fields(self):
+        o = Outcome(success=True)
+        assert o.success
+        assert o.failure_kind is None
+        assert o.failure_code is None
+
+    def test_success_with_details(self):
+        o = Outcome(success=True, details={"distance_m": 0.003})
+        assert o.success
+        assert o.details["distance_m"] == 0.003
+
+    def test_success_rejects_failure_kind(self):
+        with pytest.raises(ValueError, match="success=True but failure_kind"):
+            Outcome(success=True, failure_kind=FailureKind.TIMEOUT)
+
+    def test_success_rejects_failure_code(self):
+        with pytest.raises(ValueError, match="success=True but failure_code"):
+            Outcome(success=True, failure_code="test:bad")
+
+    def test_failure_requires_failure_kind(self):
+        with pytest.raises(ValueError, match="success=False requires failure_kind"):
+            Outcome(success=False)
+
+    def test_failure_with_kind_only(self):
+        o = Outcome(success=False, failure_kind=FailureKind.PLANNING_FAILED)
+        assert not o.success
+        assert o.failure_kind == FailureKind.PLANNING_FAILED
+        assert o.failure_code is None
+
+    def test_failure_with_kind_and_code(self):
+        o = Outcome(
+            success=False,
+            failure_kind=FailureKind.SAFETY_ABORTED,
+            failure_code="acquire:ft_exceeded",
+            details={"force_n": 25.3},
+        )
+        assert o.failure_kind == FailureKind.SAFETY_ABORTED
+        assert o.failure_code == "acquire:ft_exceeded"
+        assert o.details["force_n"] == 25.3
+
+    def test_frozen(self):
+        o = Outcome(success=True)
+        with pytest.raises(AttributeError):
+            o.success = False
+
+
+class TestOutcomeBool:
+    """Outcome supports if/else via __bool__."""
+
+    def test_success_is_truthy(self):
+        assert Outcome(success=True)
+        assert bool(Outcome(success=True)) is True
+
+    def test_failure_is_falsy(self):
+        o = Outcome(success=False, failure_kind=FailureKind.TIMEOUT)
+        assert not o
+        assert bool(o) is False
+
+    def test_if_pattern(self):
+        result = success()
+        if result:
+            passed = True
+        else:
+            passed = False
+        assert passed
+
+    def test_if_not_pattern(self):
+        result = failure(FailureKind.PLANNING_FAILED, "test:no_plan")
+        if not result:
+            failed = True
+        else:
+            failed = False
+        assert failed
+
+
+class TestOutcomeRepr:
+    def test_success_repr(self):
+        assert repr(Outcome(success=True)) == "Outcome(success=True)"
+
+    def test_failure_repr(self):
+        o = failure(FailureKind.TIMEOUT, "servo:timeout")
+        assert "TIMEOUT" not in repr(o)  # uses .value, not enum name
+        assert "'timeout'" in repr(o)
+        assert "'servo:timeout'" in repr(o)
+
+
+class TestConvenienceConstructors:
+    def test_success_no_details(self):
+        o = success()
+        assert o.success
+        assert o.details == {}
+
+    def test_success_with_kwargs(self):
+        o = success(distance_m=0.003, contact=True)
+        assert o.success
+        assert o.details == {"distance_m": 0.003, "contact": True}
+
+    def test_failure_minimal(self):
+        o = failure(FailureKind.EXECUTION_FAILED)
+        assert not o.success
+        assert o.failure_kind == FailureKind.EXECUTION_FAILED
+        assert o.failure_code is None
+
+    def test_failure_with_code_and_details(self):
+        o = failure(FailureKind.SAFETY_ABORTED, "test:force", force_n=25.0)
+        assert o.failure_code == "test:force"
+        assert o.details["force_n"] == 25.0
+
+
+class TestFailureKind:
+    """Every kind represents a distinct recovery strategy."""
+
+    def test_all_kinds_have_unique_values(self):
+        values = [k.value for k in FailureKind]
+        assert len(values) == len(set(values))
+
+    def test_branching_on_kind(self):
+        """Tasks branch on FailureKind, not failure_code."""
+        outcomes = [
+            failure(FailureKind.PLANNING_FAILED, "a:1"),
+            failure(FailureKind.SAFETY_ABORTED, "b:2"),
+            failure(FailureKind.TIMEOUT, "c:3"),
+        ]
+        retryable = [o for o in outcomes if o.failure_kind != FailureKind.SAFETY_ABORTED]
+        assert len(retryable) == 2

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025 Siddhartha Srinivasa
+
+"""Integration tests for servo_to_pose and ft_guarded_move.
+
+Uses the Franka arm from mujoco_menagerie with physics mode for
+realistic F/T and Jacobian behavior. Skips if menagerie is not
+available.
+"""
+
+import numpy as np
+import pytest
+
+from mj_manipulator.force_control import ForceThresholds, SpeedProfile
+from mj_manipulator.outcome import FailureKind
+from mj_manipulator.servo import ft_guarded_move, servo_to_pose
+
+
+@pytest.fixture
+def franka_ctx(franka_env_with_gravcomp, franka_arm_at_home):
+    """Franka arm in physics mode with SimContext, ready for servo tests."""
+    from mj_manipulator.config import PhysicsConfig, PhysicsExecutionConfig
+    from mj_manipulator.sim_context import SimContext
+
+    env = franka_env_with_gravcomp
+    arm = franka_arm_at_home
+    ctx = SimContext(
+        env.model,
+        env.data,
+        {"franka": arm},
+        headless=True,
+        physics_config=PhysicsConfig(
+            execution=PhysicsExecutionConfig(control_dt=0.002),
+        ),
+    )
+    with ctx as c:
+        yield arm, c
+
+
+class TestServoToPose:
+    def test_reaches_nearby_target(self, franka_ctx):
+        """Servo to a pose 5cm from current — should converge."""
+        arm, ctx = franka_ctx
+        current = arm.get_ee_pose()
+        target = current.copy()
+        target[2, 3] -= 0.05  # 5cm lower
+
+        result = servo_to_pose(
+            target,
+            arm,
+            ctx,
+            speed_profile=SpeedProfile.constant(linear=0.1, angular=0.5),
+            timeout=5.0,
+            position_tol=0.01,
+        )
+        assert result.success
+        assert result.details["position_error_m"] < 0.01
+
+    def test_timeout_on_unreachable(self, franka_ctx):
+        """Servo to a pose far out of reach — should timeout."""
+        arm, ctx = franka_ctx
+        target = np.eye(4)
+        target[:3, 3] = [2.0, 0.0, 0.0]  # way out of reach
+
+        result = servo_to_pose(
+            target,
+            arm,
+            ctx,
+            speed_profile=SpeedProfile.constant(linear=0.1, angular=0.5),
+            timeout=0.5,
+        )
+        assert not result.success
+        assert result.failure_kind == FailureKind.TIMEOUT
+
+    def test_speed_profile_decelerates(self, franka_ctx):
+        """Verify the arm moves slower near the target with a ramp profile."""
+        arm, ctx = franka_ctx
+        current = arm.get_ee_pose()
+        target = current.copy()
+        target[2, 3] -= 0.03  # 3cm lower (within ramp_distance)
+
+        result = servo_to_pose(
+            target,
+            arm,
+            ctx,
+            speed_profile=SpeedProfile(
+                max_linear=0.2,
+                min_linear=0.02,
+                max_angular=0.5,
+                min_angular=0.1,
+                ramp_distance=0.1,
+            ),
+            timeout=5.0,
+            position_tol=0.005,
+        )
+        assert result.success
+
+    def test_no_ft_threshold_means_no_abort(self, franka_ctx):
+        """Without ft_threshold, servo never aborts on force."""
+        arm, ctx = franka_ctx
+        current = arm.get_ee_pose()
+        target = current.copy()
+        target[2, 3] -= 0.02
+
+        result = servo_to_pose(
+            target,
+            arm,
+            ctx,
+            ft_threshold=None,
+            timeout=3.0,
+            position_tol=0.01,
+        )
+        assert result.success
+
+
+class TestFtGuardedMove:
+    def test_completes_without_contact(self, franka_ctx):
+        """Move in free space — should complete duration without contact."""
+        arm, ctx = franka_ctx
+        twist = np.array([0.0, 0.0, -0.02, 0.0, 0.0, 0.0])  # slow downward
+
+        result = ft_guarded_move(
+            twist,
+            arm,
+            ctx,
+            ft_threshold=ForceThresholds(force_n=50.0, torque_nm=10.0),
+            duration=0.2,
+        )
+        assert result.success
+        assert result.details["contact"] is False
+
+    def test_returns_outcome_type(self, franka_ctx):
+        """Result is always an Outcome."""
+        arm, ctx = franka_ctx
+        twist = np.zeros(6)
+
+        result = ft_guarded_move(
+            twist,
+            arm,
+            ctx,
+            ft_threshold=ForceThresholds(force_n=50.0, torque_nm=10.0),
+            duration=0.05,
+        )
+        assert hasattr(result, "success")
+        assert hasattr(result, "failure_kind")
+        assert hasattr(result, "details")


### PR DESCRIPTION
## Summary

Foundation for the ADA feeding pipeline (ada_mj#19) and general contact-rich manipulation:

- **`Outcome` + `FailureKind`** — structured return types for behaviors. Tasks branch on `FailureKind` (category), never on `failure_code` (diagnostic). Frozen dataclass with invariant validation, `__bool__` support, convenience constructors.

- **`ForceThresholds`** — F/T abort conditions with `exceeded()` and `check()` methods. Used by servo primitives and feeding behaviors.

- **`SpeedProfile`** — distance-based deceleration (linear interpolation from max to min speed). Parameters match original ada_feeding mouth approach (0.15→0.06 m/s over 0.3m).

- **`servo_to_pose()`** — Cartesian servo with deceleration + F/T monitoring. For mouth approach, precision placement, any guarded approach.

- **`ft_guarded_move()`** — fixed-direction motion until F/T threshold. For food stabbing, surface contact, bite detection.

- **`Arm.get_ee_jacobian()`** — new method wrapping the free function for clean API.

## Test plan

- [ ] 42 new tests: `uv run pytest tests/test_outcome.py tests/test_force_control.py tests/test_servo.py -v`
- [ ] Full suite: `uv run pytest tests/ -k "not test_teleop"` — 453 passed

Closes #149
Closes #150