### PR TITLE
eaik_solver: demote no-decomposition message to DEBUG

### DIFF
--- a/src/mj_manipulator/arms/eaik_solver.py
+++ b/src/mj_manipulator/arms/eaik_solver.py
@@ -205,7 +205,13 @@ class MuJoCoEAIKSolver:
             # Standard 6-DOF: create robot once
             self._robot = HPRobot(self._H, self._P)
             if not self._robot.hasKnownDecomposition():
-                logger.warning(
+                # Demoted from WARNING to DEBUG: the factory's _try_eaik
+                # also checks hasKnownDecomposition() and falls through to
+                # ssik (or mink), so the user-facing "EAIK refused; using
+                # ssik instead" message comes from the factory at INFO
+                # level — emitting a WARNING here too is duplicated noise
+                # that fires on every ADA() / Geodude() construction.
+                logger.debug(
                     "EAIK has no known decomposition for this arm: %s",
                     self._robot.getKinematicFamily(),
                 )


### PR DESCRIPTION
## Summary

The factory's `_try_eaik()` already checks `hasKnownDecomposition()` and emits an INFO-level dispatch message:

```
mj_manipulator.arms._ik_factory [INFO] EAIK has no decomposition for 'jaco2'; using ssik analytical IK.
```

Having `MuJoCoEAIKSolver.__init__` *also* log the same condition at WARNING produces a duplicated, scarier message on every `ADA()` / `Geodude()` construction:

```
mj_manipulator.arms.eaik_solver [WARNING] EAIK has no known decomposition for this arm: 6R-Unknown Kinematic Class
```

— for a condition the factory has already handled cleanly (it just switched to ssik or mink).

This PR demotes the constructor message to `logger.debug` so the factory's dispatch log remains the single source of truth.

## Test plan

- [x] `uv run pytest tests/` — 467 passed, 25 skipped (same as #159's baseline).
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean.
- [x] Manual check: `ADA()` now logs only `[INFO] EAIK has no decomposition for 'jaco2'; using ssik analytical IK.` (the WARNING is gone).