### PR TITLE
console extra: declare viser + mj-viser deps (#162)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ mj-environment = { workspace = true }
 pycbirrt = { workspace = true }
 tsr = { workspace = true }
 prl-assets = { workspace = true }
+mj-viser = { workspace = true }
 
 [project.optional-dependencies]
 bt = [
@@ -38,6 +39,8 @@ bt = [
 console = [
     "ipython>=8.0",
     "mj-manipulator[bt]",
+    "viser>=1.0",
+    "mj-viser @ git+https://github.com/personalrobotics/mj_viser.git",
 ]
 dev = [
     "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "mujoco",
     "scipy",
     "toppra>=0.6.3",
+    "py_trees>=2.2",
     "mj-environment @ git+https://github.com/personalrobotics/mj_environment.git",
     "pycbirrt @ git+https://github.com/personalrobotics/pycbirrt.git",
     "tsr @ git+https://github.com/personalrobotics/tsr.git",
@@ -33,12 +34,8 @@ prl-assets = { workspace = true }
 mj-viser = { workspace = true }
 
 [project.optional-dependencies]
-bt = [
-    "py_trees>=2.2",
-]
 console = [
     "ipython>=8.0",
-    "mj-manipulator[bt]",
     "viser>=1.0",
     "mj-viser @ git+https://github.com/personalrobotics/mj_viser.git",
 ]


### PR DESCRIPTION
## Summary
Two related fixes to make the CLI work on a fresh clone:

1. **viser + mj-viser** — `console.py` soft-imports them when `viser=True`, but neither was declared. `mj-viser` was also an orphan workspace member (nothing depended on it).
2. **py_trees promoted** — `primitives.py` top-level imports `py_trees`, and primitives is part of the public API exposed by `start_console()`. So py_trees is a hard runtime requirement, not an optional `[bt]` extra. The `[bt]` extra is removed (no external consumers reference it in this workspace).

Fixes #162

## Test plan
- [x] `uv sync --extra console --package mj-manipulator` installs viser + mj_viser (editable from workspace) and py_trees.
- [x] `uv run --package mj-manipulator python -c "import viser, mj_viser, py_trees"` works.
- [x] Verified end-to-end via the ada_mj feeding CLI: viser binds :8080, banner prints, REPL launches cleanly. See companion PRs:
  - [personalrobotics/ada_mj#38](https://github.com/personalrobotics/ada_mj/pull/38)
  - [personalrobotics/geodude#195](https://github.com/personalrobotics/geodude/pull/195)