### PR TITLE
teleop: route ssik through analytical IK path (#164)

### DIFF
--- a/src/mj_manipulator/teleop.py
+++ b/src/mj_manipulator/teleop.py
@@ -106,6 +106,26 @@ class TeleopFrame:
     gripper_position: float
 
 
+def _is_analytical_ik(ik) -> bool:
+    """True iff ``ik`` returns IK solutions in O(1) and is safe to call
+    every teleop tick.
+
+    The pose dispatch in :meth:`TeleopController._step_pose` uses this
+    to choose between the fast analytical path (one ``ik.solve`` call
+    per tick) and the Jacobian-based ``_step_pose_as_twist`` fallback.
+    Numerical solvers (mink) must go through the fallback — calling
+    them per tick is both too slow and returns solutions in wrappings
+    incompatible with teleop tracking.
+
+    Lazy-imports the concrete solver classes so unrelated callers don't
+    pay for eaik/ssik import unless teleop is exercised.
+    """
+    from mj_manipulator.arms.eaik_solver import MuJoCoEAIKSolver
+    from mj_manipulator.arms.ssik_solver import MuJoCoSSIKSolver
+
+    return isinstance(ik, (MuJoCoEAIKSolver, MuJoCoSSIKSolver))
+
+
 class TeleopController:
     """Unified teleop controller with pose and twist inputs.
 
@@ -582,15 +602,13 @@ class TeleopController:
     def _step_pose(self, pose: np.ndarray) -> TeleopState:
         """Pose tracking via IK (analytical) or resolved-rate (numerical).
 
-        Analytical IK (EAIK): use IK solutions directly — fast, exact.
+        Analytical IK (EAIK or ssik): use IK solutions directly — fast, exact.
         Numerical IK (mink): convert pose error to twist and use
         CartesianController (Jacobian-based). Numerical IK is too slow
         for teleop and returns solutions in wrong wrappings.
         """
-        from mj_manipulator.arms.eaik_solver import MuJoCoEAIKSolver
-
         ik = self._arm.ik_solver
-        if ik is not None and isinstance(ik, MuJoCoEAIKSolver):
+        if ik is not None and _is_analytical_ik(ik):
             q_current = self._arm.get_joint_positions()
             solutions = ik.solve(pose, q_init=q_current)
             if not solutions:

--- a/tests/test_teleop.py
+++ b/tests/test_teleop.py
@@ -427,3 +427,38 @@ class TestSafetyModes:
         frames = ctrl.stop_recording()
 
         assert len(frames) == 1  # TRACKING_COLLISION frames are recorded
+
+
+class TestAnalyticalIKDispatch:
+    """Regression: _step_pose must route ssik through the analytical path.
+
+    Pre-fix, only MuJoCoEAIKSolver was recognized as analytical. JACO 2
+    (which uses MuJoCoSSIKSolver) silently fell through to the Jacobian
+    fallback, which can't keep up with ft_guarded_move and reports
+    "ft_guarded_move:no_progress" — see ada_mj feed_bite acquire_food.
+    """
+
+    def test_eaik_is_analytical(self):
+        from mj_manipulator.arms.eaik_solver import MuJoCoEAIKSolver
+        from mj_manipulator.teleop import _is_analytical_ik
+
+        assert _is_analytical_ik(MuJoCoEAIKSolver.__new__(MuJoCoEAIKSolver))
+
+    def test_ssik_is_analytical(self):
+        pytest.importorskip("ssik")
+        from mj_manipulator.arms.ssik_solver import MuJoCoSSIKSolver
+        from mj_manipulator.teleop import _is_analytical_ik
+
+        assert _is_analytical_ik(MuJoCoSSIKSolver.__new__(MuJoCoSSIKSolver))
+
+    def test_mink_is_not_analytical(self):
+        pytest.importorskip("mink")
+        from mj_manipulator.arms.mink_solver import MinkIKSolver
+        from mj_manipulator.teleop import _is_analytical_ik
+
+        assert not _is_analytical_ik(MinkIKSolver.__new__(MinkIKSolver))
+
+    def test_none_is_not_analytical(self):
+        from mj_manipulator.teleop import _is_analytical_ik
+
+        assert not _is_analytical_ik(None)


### PR DESCRIPTION
## Summary
- \`_step_pose\` only recognized \`MuJoCoEAIKSolver\` as analytical. \`MuJoCoSSIKSolver\` (used by JACO 2 after #159) silently fell through to the Jacobian-based fallback path designed for \`MinkIKSolver\`.
- The Jacobian path can't track \`ft_guarded_move\`'s running target fast enough — ada_mj \`feed_bite\` reported \`acquire_food failed (ft_guarded_move:no_progress)\` on every run in kinematic mode.
- Extracts \`_is_analytical_ik(ik)\` helper accepting both \`MuJoCoEAIKSolver\` and \`MuJoCoSSIKSolver\`. Both return solutions in O(1); only \`MinkIKSolver\` actually needs the Jacobian fallback.

Fixes #164

## Test plan
- [x] New \`TestAnalyticalIKDispatch\` (4 tests): eaik / ssik / mink / None classification.
- [x] Existing \`tests/test_teleop.py\` + \`tests/test_ssik_solver.py\` still pass (21 passing, 18 pre-existing skips per #160).
- [ ] After merge: run \`feed()\` in \`ada_mj --demo feeding --viser\` and confirm \`acquire_food\` reaches contact or duration instead of stalling.