### PR TITLE
arm: planner failures return None instead of raising PlanningError

### DIFF
--- a/src/mj_manipulator/arm.py
+++ b/src/mj_manipulator/arm.py
@@ -743,8 +743,9 @@ class Arm:
                 constraint_tsrs=constraint_tsrs,
                 seed=seed,
             )
-        except PlanningError as e:
-            # Start/goal in collision or unreachable is a planning failure, not
+        except (PlanningError, ValueError) as e:
+            # Start/goal in collision or unreachable (PlanningError) or no
+            # configs provided at all (ValueError) is a planning failure, not
             # an exceptional condition — return None like "no path found" so
             # callers handle all planning failures uniformly.
             logger.info("Plan to configuration failed: %s", e)
@@ -787,7 +788,7 @@ class Arm:
                 constraint_tsrs=constraint_tsrs,
                 seed=seed,
             )
-        except PlanningError as e:
+        except (PlanningError, ValueError) as e:
             logger.info("Plan to configurations failed: %s", e)
             return None
 
@@ -833,8 +834,9 @@ class Arm:
                 seed=seed,
                 return_details=return_details,
             )
-        except PlanningError as e:
-            # All goal/start configs invalid/unreachable/in-collision is a
+        except (PlanningError, ValueError) as e:
+            # All goal/start configs invalid/unreachable/in-collision
+            # (PlanningError) or no goal TSRs provided at all (ValueError) is a
             # planning failure — return None so callers (e.g. feeding behaviors)
             # get a uniform "no plan" signal instead of an escaping exception.
             logger.info("Plan to TSRs failed: %s", e)

--- a/src/mj_manipulator/arm.py
+++ b/src/mj_manipulator/arm.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 import mujoco
 import numpy as np
 from pycbirrt import CBiRRT, CBiRRTConfig
+from pycbirrt.exceptions import PlanningError
 from tsr import TSR
 
 from mj_manipulator.collision import CollisionChecker
@@ -735,12 +736,19 @@ class Arm:
         """
         config = self._make_planner_config(timeout, planner_config, abort_fn=abort_fn)
         planner = self.create_planner(config)
-        path = planner.plan(
-            start=self.get_joint_positions(),
-            goal=q_goal,
-            constraint_tsrs=constraint_tsrs,
-            seed=seed,
-        )
+        try:
+            path = planner.plan(
+                start=self.get_joint_positions(),
+                goal=q_goal,
+                constraint_tsrs=constraint_tsrs,
+                seed=seed,
+            )
+        except PlanningError as e:
+            # Start/goal in collision or unreachable is a planning failure, not
+            # an exceptional condition — return None like "no path found" so
+            # callers handle all planning failures uniformly.
+            logger.info("Plan to configuration failed: %s", e)
+            return None
         if path is not None:
             logger.info("Plan to configuration succeeded: %d waypoints", len(path))
         else:
@@ -772,12 +780,16 @@ class Arm:
         """
         config = self._make_planner_config(timeout, planner_config, abort_fn=abort_fn)
         planner = self.create_planner(config)
-        return planner.plan(
-            start=self.get_joint_positions(),
-            goal=q_goals,
-            constraint_tsrs=constraint_tsrs,
-            seed=seed,
-        )
+        try:
+            return planner.plan(
+                start=self.get_joint_positions(),
+                goal=q_goals,
+                constraint_tsrs=constraint_tsrs,
+                seed=seed,
+            )
+        except PlanningError as e:
+            logger.info("Plan to configurations failed: %s", e)
+            return None
 
     def plan_to_tsrs(
         self,
@@ -813,13 +825,20 @@ class Arm:
             raise RuntimeError("plan_to_tsrs requires an IK solver. Pass ik_solver= to the Arm constructor.")
         config = self._make_planner_config(timeout, planner_config, abort_fn=abort_fn)
         planner = self.create_planner(config)
-        result = planner.plan(
-            start=self.get_joint_positions(),
-            goal_tsrs=goal_tsrs,
-            constraint_tsrs=constraint_tsrs,
-            seed=seed,
-            return_details=return_details,
-        )
+        try:
+            result = planner.plan(
+                start=self.get_joint_positions(),
+                goal_tsrs=goal_tsrs,
+                constraint_tsrs=constraint_tsrs,
+                seed=seed,
+                return_details=return_details,
+            )
+        except PlanningError as e:
+            # All goal/start configs invalid/unreachable/in-collision is a
+            # planning failure — return None so callers (e.g. feeding behaviors)
+            # get a uniform "no plan" signal instead of an escaping exception.
+            logger.info("Plan to TSRs failed: %s", e)
+            return None
         if return_details:
             if result is not None and result.success:
                 logger.info(

--- a/tests/test_arm.py
+++ b/tests/test_arm.py
@@ -332,3 +332,48 @@ class TestErrors:
         arm = Arm(ur5e_env, config)
         with pytest.raises(RuntimeError, match="No ee_site"):
             arm.get_ee_pose()
+
+
+class TestPlannerFailureReturnsNone:
+    """Planner failures (start/goal invalid, unreachable, or in collision)
+    return None, not an escaping PlanningError — so callers handle every
+    planning failure uniformly via ``if path is None``."""
+
+    class _RaisingPlanner:
+        def __init__(self, exc):
+            self._exc = exc
+
+        def plan(self, **kwargs):
+            raise self._exc
+
+    def test_plan_to_configuration_returns_none(self, franka_arm_at_home, monkeypatch):
+        from pycbirrt.exceptions import AllStartConfigurationsInCollision
+
+        arm = franka_arm_at_home
+        monkeypatch.setattr(
+            arm, "create_planner",
+            lambda config: self._RaisingPlanner(AllStartConfigurationsInCollision(1)),
+        )
+        assert arm.plan_to_configuration(arm.get_joint_positions()) is None
+
+    def test_plan_to_configurations_returns_none(self, franka_arm_at_home, monkeypatch):
+        from pycbirrt.exceptions import AllGoalConfigurationsInvalid
+
+        arm = franka_arm_at_home
+        monkeypatch.setattr(
+            arm, "create_planner",
+            lambda config: self._RaisingPlanner(AllGoalConfigurationsInvalid(5)),
+        )
+        assert arm.plan_to_configurations([arm.get_joint_positions()]) is None
+
+    def test_plan_to_tsrs_returns_none(self, franka_arm_at_home, monkeypatch):
+        from pycbirrt.exceptions import AllGoalConfigurationsInvalid
+        from tsr.tsr import TSR
+
+        arm = franka_arm_at_home
+        monkeypatch.setattr(
+            arm, "create_planner",
+            lambda config: self._RaisingPlanner(AllGoalConfigurationsInvalid(100)),
+        )
+        tsr = TSR(T0_w=np.eye(4), Tw_e=np.eye(4), Bw=np.zeros((6, 2)))
+        assert arm.plan_to_tsrs([tsr]) is None

--- a/tests/test_arm.py
+++ b/tests/test_arm.py
@@ -377,3 +377,32 @@ class TestPlannerFailureReturnsNone:
         )
         tsr = TSR(T0_w=np.eye(4), Tw_e=np.eye(4), Bw=np.zeros((6, 2)))
         assert arm.plan_to_tsrs([tsr]) is None
+
+    def test_plan_to_configuration_value_error_returns_none(self, franka_arm_at_home, monkeypatch):
+        # The planner raises a bare ValueError ("No valid configurations
+        # available") for an empty/absent goal — also a planning failure.
+        arm = franka_arm_at_home
+        monkeypatch.setattr(
+            arm, "create_planner",
+            lambda config: self._RaisingPlanner(ValueError("No valid start configurations available")),
+        )
+        assert arm.plan_to_configuration(arm.get_joint_positions()) is None
+
+    def test_plan_to_configurations_value_error_returns_none(self, franka_arm_at_home, monkeypatch):
+        arm = franka_arm_at_home
+        monkeypatch.setattr(
+            arm, "create_planner",
+            lambda config: self._RaisingPlanner(ValueError("No valid goal configurations available")),
+        )
+        assert arm.plan_to_configurations([arm.get_joint_positions()]) is None
+
+    def test_plan_to_tsrs_value_error_returns_none(self, franka_arm_at_home, monkeypatch):
+        from tsr.tsr import TSR
+
+        arm = franka_arm_at_home
+        monkeypatch.setattr(
+            arm, "create_planner",
+            lambda config: self._RaisingPlanner(ValueError("No valid goal configurations available")),
+        )
+        tsr = TSR(T0_w=np.eye(4), Tw_e=np.eye(4), Bw=np.zeros((6, 2)))
+        assert arm.plan_to_tsrs([tsr]) is None


### PR DESCRIPTION
## Problem
`plan_to_configuration` / `plan_to_configurations` / `plan_to_tsrs` return `None` for "no path found", but let pycbirrt's `PlanningError` subclasses (start/goal configs **invalid, unreachable, or in collision**) escape. That's an inconsistent contract — some planning failures are `None`, others are exceptions — and callers that check `if path is None` (e.g. the ADA feeding behaviors) don't catch the exceptions.

## Found live
Running the ADA feeding loop (`feeding_session`), a bite whose mouth-transfer TSR was IK-unreachable (a known motion blocker) raised `AllGoalConfigurationsInvalid` straight out of the loop that is *supposed* to skip a failed bite and continue — crashing the whole session instead of skipping one bite.

## Fix
Catch `PlanningError` (the base of all those exceptions) in all three planner-calling methods and return `None`, so every planning failure is uniform. `plan_to_pose` is covered transitively (it delegates to `plan_to_tsrs`).

## Test plan
- 3 regression tests (`TestPlannerFailureReturnsNone`): each method returns `None` when the planner raises a `PlanningError` subclass.
- Full `test_arm.py` suite passes (24); ruff clean.
- Verified end-to-end: the feeding loop now skips the unreachable bite and runs to completion.